### PR TITLE
[#33][FEAT] pr create 흐름 구현

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 
 	runtimeOnly 'com.h2database:h2'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 }
 
 kotlin {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -27,7 +27,11 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/pr")
 class PrDraftController(
-
+    private val prDraftService: PrDraftService
 ) {
+    @PostMapping
+    fun create(@RequestBody req: CreatePrReq): PrInfoRes {
+        return prDraftService.create(req)
+    }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
@@ -50,7 +50,8 @@ class PrDraft(
      *
      * 파일 변경 내역, 추가/삭제된 코드 등을 포함하며 PR 본문 생성의 입력 데이터로 사용됩니다.
      */
-    @Column(name = "diff_content", nullable = false, length = 255)
+    @Lob
+    @Column(name = "diff_content", nullable = false, columnDefinition = "TEXT")
     var diffContent: String,
 
     /**
@@ -58,8 +59,7 @@ class PrDraft(
      *
      * diff 내용을 기반으로 AI가 생성한 제목을 포함합니다.
      */
-    @Lob
-    @Column(name = "pr_title", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "pr_title", nullable = false, length = 255)
     var prTitle: String,
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/AiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/AiClient.kt
@@ -1,0 +1,28 @@
+package com.back.omos.domain.prdraft.service
+
+/**
+ * PR 초안 생성을 위한 AI 호출 기능을 추상화한 인터페이스입니다.
+ *
+ * <p>
+ * 서비스 계층은 이 인터페이스를 통해 AI 모델에 프롬프트를 전달하고,
+ * 생성된 PR 제목 및 본문 결과를 전달받습니다.
+ * </p>
+ *
+ * <p>
+ * 지금은 Mock 구현체로 테스트할 수 있고습니다.
+ * 이후 실제 OpenAI 연동 구현체로 교체할 수 있도록 확장성을 고려한 구조입니다.
+ * </p>
+ *
+ * @author 5h6vm
+ * @since 2026-04-22
+ */
+interface AiClient {
+
+    /**
+     * 전달받은 프롬프트를 기반으로 PR 초안을 생성합니다.
+     *
+     * @param prompt AI에게 전달할 PR 생성 프롬프트
+     * @return AI가 생성한 PR 제목 및 본문
+     */
+    fun generatePrDraft(prompt: String): AiPrResult
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/AiPrResult.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/AiPrResult.kt
@@ -1,0 +1,20 @@
+package com.back.omos.domain.prdraft.service
+
+/**
+ * AI가 생성한 PR 초안 결과를 담는 내부 DTO입니다.
+ *
+ * <p>
+ * PR 제목과 본문을 구조화하여 서비스 계층에서 사용할 수 있도록 표현합니다.
+ * 외부 API 응답인 {@code PrInfoRes}로 변환되기 전, AI 응답을 내부적으로 다루기 위해 사용됩니다.
+ * </p>
+ *
+ * @property title AI가 생성한 PR 제목
+ * @property body AI가 생성한 PR 본문
+ *
+ * @author 5h6vm
+ * @since 2026-04-22
+ */
+data class AiPrResult(
+    val title: String,
+    val body: String
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/MockAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/MockAiClient.kt
@@ -1,0 +1,35 @@
+package com.back.omos.domain.prdraft.service
+
+import org.springframework.stereotype.Component
+
+/**
+ * AI 연동 전 전체 PR 초안 생성 흐름을 테스트하기 위한 Mock 구현체입니다.
+ *
+ * <p>
+ * 실제 AI 호출 대신 고정된 PR 제목과 본문을 반환하여,
+ * Controller → Service → PromptBuilder → AiClient → Response 흐름이
+ * 정상적으로 동작하는지 검증하는 용도로 사용됩니다.
+ * </p>
+ *
+ * @author 5h6vm
+ * @since 2026-04-22
+ */
+@Component
+class MockAiClient : AiClient {
+
+    override fun generatePrDraft(prompt: String): AiPrResult {
+        return AiPrResult(
+            title = "fix: mock PR 제목",
+            body = """
+                ## 변경 사항
+                - diff 내용을 바탕으로 PR 초안을 생성했습니다.
+
+                ## 테스트 방법
+                - 관련 기능을 직접 확인했습니다.
+
+                ## 관련 이슈
+                - close #123
+            """.trimIndent()
+        )
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -1,0 +1,54 @@
+package com.back.omos.domain.prdraft.service
+
+import com.back.omos.domain.prdraft.dto.CreatePrReq
+import org.springframework.stereotype.Component
+
+/**
+ * PR 초안 생성을 위한 AI 프롬프트를 구성하는 클래스입니다.
+ *
+ * <p>
+ * 사용자가 전달한 diff 정보를 기반으로,
+ * AI에게 PR 제목과 본문 생성을 요청하기 위한 입력 문자열(prompt)을 생성합니다.
+ * </p>
+ *
+ * <p>
+ * 생성된 프롬프트는 다음과 같은 역할을 수행합니다:
+ * <ul>
+ *   <li>AI의 역할을 "PR 작성 도우미"로 명확히 지정</li>
+ *   <li>코드 변경 내용(diff)을 전달하여 변경 의도를 이해하도록 유도</li>
+ *   <li>응답 형식을 JSON으로 강제하여 파싱 가능하도록 제한</li>
+ * </ul>
+ * </p>
+ *
+ * <p><b>동작 방식:</b><br>
+ * {@link CreatePrReq}로부터 diff 내용을 추출하여,
+ * PR 제목과 본문 생성을 위한 프롬프트 문자열을 구성합니다.
+ * </p>
+ *
+ * <p><b>빈 관리:</b><br>
+ * {@link org.springframework.stereotype.Component}로 등록되어
+ * 서비스 계층에서 주입받아 사용됩니다.
+ * </p>
+ *
+ * @author 5h6vm
+ * @since 2026-04-22
+ */
+@Component
+class PrDraftPromptBuilder {
+
+    fun build(req: CreatePrReq): String {
+        return """
+            당신은 오픈소스 프로젝트의 PR 초안 작성 도우미입니다.
+            아래 diff를 바탕으로 PR 제목과 본문을 작성하세요.
+
+            [Diff]
+            ${req.diffContent}
+
+            반드시 아래 JSON 형식으로만 응답하세요.
+            {
+              "title": "PR 제목",
+              "body": "PR 본문"
+            }
+        """.trimIndent()
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -26,7 +26,8 @@ import org.springframework.stereotype.Service
 @Service
 class PrDraftServiceImpl(
     private val prDraftRepository: PrDraftRepository,
-    private val prDraftPromptBuilder: PrDraftPromptBuilder
+    private val prDraftPromptBuilder: PrDraftPromptBuilder,
+    private val aiClient: AiClient
 ) : PrDraftService {
 
     @Transactional
@@ -40,11 +41,13 @@ class PrDraftServiceImpl(
         val prompt = prDraftPromptBuilder.build(request)
 
         // TODO: AI 호출하기
+        val aiResult = aiClient.generatePrDraft(prompt)
+
         // TODO: 응답 반환하기
 
         return PrInfoRes(
-            title = "feat: 임시 제목",
-            body = prompt
+            title = aiResult.title,
+            body = aiResult.body
         )
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -3,6 +3,7 @@ package com.back.omos.domain.prdraft.service
 import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.repository.PrDraftRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 /**
@@ -24,15 +25,26 @@ import org.springframework.stereotype.Service
  */
 @Service
 class PrDraftServiceImpl(
-    private val prDraftRepository: PrDraftRepository
+    private val prDraftRepository: PrDraftRepository,
+    private val prDraftPromptBuilder: PrDraftPromptBuilder
 ) : PrDraftService {
 
+    @Transactional
     override fun create(request: CreatePrReq): PrInfoRes {
-        // TODO:
+        // TODO: val issue = issueRepository.findById
+        // TODO: val repo = repoRepository.findById
+        // TODO: issue의 레포와 repo가 동일한지 확인
+
+        // TODO: 규칙 정리하기
+        // TODO: 프롬프트 만들기
+        val prompt = prDraftPromptBuilder.build(request)
+
+        // TODO: AI 호출하기
+        // TODO: 응답 반환하기
 
         return PrInfoRes(
             title = "feat: 임시 제목",
-            body = "임시 PR 본문."
+            body = prompt
         )
     }
 }

--- a/omos/src/main/resources/application.yaml
+++ b/omos/src/main/resources/application.yaml
@@ -18,6 +18,5 @@ spring:
 
   # Jackson 직렬화 설정
   jackson:
-    property-naming-strategy: SNAKE_CASE
     serialization:
       fail-on-empty-beans: false


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
변경 사항에 대한 간단한 설명을 작성해주세요.
pr create의 전체적인 흐름 설계
``` kotlin
@Transactional
override fun create(request: CreatePrReq): PrInfoRes {
    // TODO: val issue = issueRepository.findById
    // TODO: val repo = repoRepository.findById
    // TODO: issue의 레포와 repo가 동일한지 확인 (여긴 x)

    // TODO: 규칙 정리하기

    // TODO: 프롬프트 만들기
    val prompt = prDraftPromptBuilder.build(request)

    // TODO: AI 호출하기
    val aiResult = aiClient.generatePrDraft(prompt)

    // TODO: 응답 반환하기
    return PrInfoRes(
        title = aiResult.title,
        body = aiResult.body
    )
}
```
## 🔗 관련 이슈
- Close #33 

## 🛠️ 주요 변경 사항
- [ ] serviceimpl create Todo 흐름 설정
- [ ] prompt builder 틀만 구현 (기능 x)
- [ ] AiClinet 인터페이스 구현 (현재 AI는 Mock으로 구현 실제 연동 x)
- [ ] AiPrResult(AI 결과 전해줄 내부 Dto) 구현

## 🧪 테스트 결과
테스트 통과 여부나 결과를 적어주세요. (스크린샷 가능)

## 🧐 리뷰어에게
- 특별한 기능이 추가된 것은 없습니다. 흐름 위주로 봐주시면 좋을 것 같습니다.
- `main`이 아니라 `feat/pr-create`로 병합됩니다. 
- 기능들이 지금은 service에 모두 들어가 있지만 추후 구조 변경을 통해 개선할 예정입니다.
- yaml파일에 snake case제거와 build.gradle에 추가된 의존성을 신경쓰지 않으셔도 됩니다.