### PR TITLE
[FEAT] Context Analyzer 서비스 및 예외 처리 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/dto/GuideResponseDto.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/dto/GuideResponseDto.kt
@@ -1,0 +1,24 @@
+package com.back.omos.domain.analysis.dto
+
+/**
+ * AI가 생성한 코드 수정 가이드를 응답하는 DTO입니다.
+ * <p>
+ * 사용자가 이슈를 선택하면 Context Analyzer가 분석한 결과 중
+ * 수정 파일 위치, 가이드라인, 부작용 정보를 프론트엔드에 전달합니다.
+ * AnalysisResult 엔티티에서 pseudoCode를 제외한 가이드 정보만 담습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code GuideResponseDto(List<String>, String, String)} <br>
+ * filePaths: 수정 대상 파일 경로 목록 <br>
+ * guideline: AI가 생성한 수정 방향 안내 <br>
+ * sideEffects: 수정 시 발생 가능한 부작용 <br>
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-22
+ * @see com.back.omos.domain.analysis.entity.AnalysisResult
+ */
+data class GuideResponseDto(
+    val filePaths: List<String>,
+    val guideline: String,
+    val sideEffects: String
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/dto/PseudoCodeResponseDto.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/dto/PseudoCodeResponseDto.kt
@@ -1,0 +1,22 @@
+package com.back.omos.domain.analysis.dto
+
+/**
+ * AI가 생성한 의사 코드를 응답하는 DTO입니다.
+ * <p>
+ * 사용자가 "코드도 보여줘" 버튼을 눌렀을 때,
+ * AnalysisResult 엔티티에서 수정 대상 파일 경로와 의사 코드를
+ * 추출하여 프론트엔드에 전달합니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code PseudoCodeResponseDto(List<String>, String)} <br>
+ * filePaths: 수정 대상 파일 경로 목록 <br>
+ * pseudoCode: AI가 생성한 구체적인 코드 수정 제안 <br>
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-22
+ * @see com.back.omos.domain.analysis.entity.AnalysisResult
+ */
+data class PseudoCodeResponseDto(
+    val filePaths: List<String>,
+    val pseudoCode: String
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/AnalysisResultRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/AnalysisResultRepository.kt
@@ -2,6 +2,7 @@ package com.back.omos.domain.analysis.repository
 
 import com.back.omos.domain.analysis.entity.AnalysisResult
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 /**
  * [AnalysisResult] 엔티티에 대한 데이터 액세스 인터페이스입니다.
@@ -23,5 +24,6 @@ interface AnalysisResultRepository : JpaRepository<AnalysisResult, Long> {
      * @param issueId 조회할 이슈의 ID
      * @return 해당 이슈의 분석 결과, 없으면 null
      */
+    @Query("SELECT a FROM AnalysisResult a WHERE a.issue.id = :issueId")
     fun findByIssueId(issueId: Long): AnalysisResult?
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerService.kt
@@ -1,0 +1,41 @@
+package com.back.omos.domain.analysis.service
+
+import com.back.omos.domain.analysis.dto.GuideResponseDto
+import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
+
+/**
+ * 코드에 대한 전체적인 역할을 적습니다.
+ * <p>
+ * 코드에 대한 작동 원리 등을 적습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 상속 정보를 적습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code ContextAnalyzerService(String example)} <br>
+ * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
+ *
+ * <p><b>빈 관리:</b><br>
+ * 필요 시 빈 관리에 대한 내용을 적습니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-22
+ * @see
+ */
+interface ContextAnalyzerService {
+
+    /**
+     * 이슈에 대한 코드 수정 가이드를 조회합니다.
+     * 캐시된 결과가 있고 이슈가 수정되지 않았으면 캐시를 반환하고,
+     * 이슈가 수정됐거나 캐시가 없으면 새로 분석합니다.
+     */
+    fun getGuide(issueId: Long): GuideResponseDto
+
+    /**
+     * 이슈에 대한 의사 코드를 조회합니다.
+     */
+    fun getPseudoCode(issueId: Long): PseudoCodeResponseDto
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -9,6 +9,7 @@ import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.global.exception.errorCode.AnalysisErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.core.type.TypeReference
 
@@ -40,6 +41,7 @@ class ContextAnalyzerServiceImpl(
     private val objectMapper: ObjectMapper
 ) : ContextAnalyzerService {
 
+    @Transactional
     override fun getGuide(issueId: Long): GuideResponseDto {
         val issue = issueRepository.findById(issueId)
             .orElseThrow {
@@ -61,6 +63,7 @@ class ContextAnalyzerServiceImpl(
         return toGuideDto(analysisResult)
     }
 
+    @Transactional
     override fun getPseudoCode(issueId: Long): PseudoCodeResponseDto {
         val issue = issueRepository.findById(issueId)
             .orElseThrow {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -1,0 +1,150 @@
+package com.back.omos.domain.analysis.service
+
+import com.back.omos.domain.analysis.dto.GuideResponseDto
+import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
+import com.back.omos.domain.analysis.entity.AnalysisResult
+import com.back.omos.domain.analysis.repository.AnalysisResultRepository
+import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.global.exception.errorCode.AnalysisErrorCode
+import com.back.omos.global.exception.exceptions.AnalysisException
+import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.core.type.TypeReference
+
+/**
+ * Context Analyzer의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
+ * <p>
+ * 이슈에 대한 코드 수정 가이드 조회 요청을 처리하며,
+ * 캐시된 분석 결과가 유효하면 즉시 반환하고,
+ * 이슈가 수정되었거나 캐시가 없으면 GLM API를 호출하여 새로운 분석 결과를 생성합니다.
+ *
+ * <p><b>캐시 갱신 정책:</b><br>
+ * 이슈의 updatedAt과 분석 결과의 createdAt을 비교하여,
+ * 이슈가 분석 이후 수정된 경우에만 가이드를 재생성합니다.
+ * 기존 결과가 있으면 동일 row를 업데이트하고, 없으면 새로 생성합니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * GitHub API — 관련 소스코드 수집 (TODO) <br>
+ * GLM API — 코드 수정 가이드 생성 (TODO)
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-22
+ * @see ContextAnalyzerService
+ * @see AnalysisResult
+ */
+@Service
+class ContextAnalyzerServiceImpl(
+    private val analysisResultRepository: AnalysisResultRepository,
+    private val issueRepository: IssueRepository,
+    private val objectMapper: ObjectMapper
+) : ContextAnalyzerService {
+
+    override fun getGuide(issueId: Long): GuideResponseDto {
+        val issue = issueRepository.findById(issueId)
+            .orElseThrow {
+                AnalysisException(
+                    AnalysisErrorCode.ISSUE_NOT_FOUND,
+                    "[ContextAnalyzerServiceImpl#getGuide] 이슈를 찾을 수 없습니다: issueId=$issueId",
+                    "해당 이슈를 찾을 수 없습니다."
+                )
+            }
+
+        // 캐시 있으면 바로 반환
+        val cached = analysisResultRepository.findByIssueId(issueId)
+        if (cached != null) {
+            return toGuideDto(cached)
+        }
+
+        // 없으면 새로 생성
+        val analysisResult = generateAnalysis(issue)
+        return toGuideDto(analysisResult)
+    }
+
+    override fun getPseudoCode(issueId: Long): PseudoCodeResponseDto {
+        val issue = issueRepository.findById(issueId)
+            .orElseThrow {
+                AnalysisException(
+                    AnalysisErrorCode.ISSUE_NOT_FOUND,
+                    "[ContextAnalyzerServiceImpl#getPseudoCode] 이슈를 찾을 수 없습니다: issueId=$issueId",
+                    "해당 이슈를 찾을 수 없습니다."
+                )
+            }
+
+        val cached = analysisResultRepository.findByIssueId(issueId)
+        if (cached != null) {
+            return toPseudoCodeDto(cached)
+        }
+
+        val analysisResult = generateAnalysis(issue)
+        return toPseudoCodeDto(analysisResult)
+    }
+    /**
+     * 이슈가 분석 이후 수정되었는지 판단합니다.
+     *
+     * issue.updatedAt이 analysisResult.createdAt보다 이후이면
+     * 이슈 내용이 변경된 것이므로 가이드를 재생성해야 합니다.
+     */
+    private fun isIssueModifiedAfterAnalysis(issue: Issue, result: AnalysisResult): Boolean {
+        return issue.updatedAt.isAfter(result.createdAt)
+    }
+
+    /**
+     * GLM API를 호출하여 새로운 분석 결과를 생성합니다.
+     *
+     * 기존 캐시가 있으면 업데이트하고, 없으면 새로 생성하여 저장합니다.
+     */
+    private fun generateAnalysis(issue: Issue): AnalysisResult {
+        // TODO: GitHub API로 관련 소스코드 가져오기
+        // TODO: GLM API로 가이드 생성 요청
+
+        val filePaths = """["src/main/java/Example.java"]"""
+        val guideline = "TODO: GLM 연동 후 실제 가이드 생성"
+        val pseudoCode = "TODO: GLM 연동 후 실제 의사 코드 생성"
+        val sideEffects = "TODO: GLM 연동 후 실제 부작용 분석"
+
+        val newResult = AnalysisResult(
+            issue = issue,
+            filePaths = filePaths,
+            guideline = guideline,
+            pseudoCode = pseudoCode,
+            sideEffects = sideEffects
+        )
+        return analysisResultRepository.save(newResult)
+    }
+
+    /**
+     * AnalysisResult를 GuideResponseDto로 변환합니다.
+     * filePaths는 JSON 문자열을 List<String>으로 파싱합니다.
+     */
+    private fun toGuideDto(result: AnalysisResult): GuideResponseDto {
+        return GuideResponseDto(
+            filePaths = parseFilePaths(result.filePaths),
+            guideline = result.guideline,
+            sideEffects = result.sideEffects
+        )
+    }
+
+    /**
+     * AnalysisResult를 PseudoCodeResponseDto로 변환합니다.
+     */
+    private fun toPseudoCodeDto(result: AnalysisResult): PseudoCodeResponseDto {
+        return PseudoCodeResponseDto(
+            filePaths = parseFilePaths(result.filePaths),
+            pseudoCode = result.pseudoCode
+        )
+    }
+
+    /**
+     * JSON 배열 문자열을 List<String>으로 파싱합니다.
+     * <p>
+     * ObjectMapper를 사용하여 안전하게 역직렬화합니다.
+     * 예: '["a.java", "b.java"]' → listOf("a.java", "b.java")
+     *
+     * @param filePaths JSON 배열 형태의 파일 경로 문자열
+     * @return 파싱된 파일 경로 목록
+     */
+    private fun parseFilePaths(filePaths: String): List<String> {
+        return objectMapper.readValue(filePaths, object : TypeReference<List<String>>() {})
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AnalysisErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AnalysisErrorCode.kt
@@ -1,0 +1,30 @@
+package com.back.omos.global.exception.errorCode
+
+import com.plog.global.exception.errorCode.ErrorCode
+import org.springframework.http.HttpStatus
+
+/**
+ * Context Analyzer 도메인에서 발생하는 예외에 대한 상수 값을 정의합니다.
+ *
+ * <p>{@code AnalysisErrorCode}는 {@link
+ * com.back.omos.global.exception.exceptions.AnalysisException AnalysisException}에서 사용되며,
+ * {@code NAME(HttpStatus.STATUS, "some message")}로 저장됩니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link ErrorCode}의 구현체입니다.
+ *
+ * @author Jaewon Ryu
+ * @see ErrorCode
+ * @see com.back.omos.global.exception.exceptions.AnalysisException AnalysisException
+ * @since 2026-04-22
+ */
+enum class AnalysisErrorCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+) : ErrorCode {
+    ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈를 찾을 수 없습니다."),
+    ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈에 대한 분석 결과가 존재하지 않습니다."),
+    ANALYSIS_GENERATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "코드 분석 가이드 생성에 실패하였습니다."),
+    GITHUB_API_FAIL(HttpStatus.BAD_GATEWAY, "GitHub API 호출에 실패하였습니다."),
+    GLM_API_FAIL(HttpStatus.BAD_GATEWAY, "GLM API 호출에 실패하였습니다.");
+}

--- a/omos/src/main/kotlin/com/back/omos/global/exception/exceptions/AnalysisException.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/exceptions/AnalysisException.kt
@@ -1,0 +1,31 @@
+package com.back.omos.global.exception.exceptions
+
+import com.back.omos.global.exception.errorCode.AnalysisErrorCode
+import com.plog.global.exception.exceptions.BaseException
+
+/**
+ * Context Analyzer 도메인에서 발생하는 예외입니다.
+ *
+ * <p>{@link AnalysisErrorCode}의 값과 (optional) 내부 로그 메시지를 담습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link BaseException}의 구현 클래스입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code AnalysisException(AnalysisErrorCode errorCode)} <br>
+ * 내부 로그 메시지를 담지 않는 예외를 생성합니다. <br>
+ * {@code AnalysisException(AnalysisErrorCode errorCode, String logMessage)} <br>
+ * 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ * {@code AnalysisException(AnalysisErrorCode errorCode, String logMessage, String clientMessage)} <br>
+ * 클라이언트 메시지 및 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ *
+ * @author Jaewon Ryu
+ * @see AnalysisErrorCode
+ * @see BaseException
+ * @since 2026-04-22
+ */
+class AnalysisException : BaseException {
+    constructor(errorCode: AnalysisErrorCode) : super(errorCode)
+    constructor(errorCode: AnalysisErrorCode, logMessage: String) : super(errorCode, logMessage)
+    constructor(errorCode: AnalysisErrorCode, logMessage: String, clientMessage: String) : super(errorCode, logMessage, clientMessage)
+}

--- a/omos/src/main/resources/application.yaml
+++ b/omos/src/main/resources/application.yaml
@@ -5,6 +5,9 @@ spring:
       dev: "dev"
       prod: "prod"
       test: "test"
+  output:
+    ansi:
+      enabled: always
 
   application:
     name: omos


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
Context Analyzer 도메인의 서비스 레이어, DTO, 예외 처리를 구현했습니다.
GLM/GitHub API 연동은 TODO로 두고 캐시 조회 → 생성 → 반환 흐름을 먼저 잡았습니다.

## 🔗 관련 이슈
- Close #43

## 🛠️ 주요 변경 사항
- [x] AnalysisErrorCode, AnalysisException 추가
- [x] GuideResponseDto, PseudoCodeResponseDto 추가
- [x] ContextAnalyzerService 인터페이스 및 구현체 추가
- [x] application.yml ANSI 로그 컬러 설정

## 🧪 테스트 결과
-  GLM/GitHub API 연동 전이라 테스트는 연동 완료 후 추가 예정
## 🧐 리뷰어에게
-  feat/be/context-analyzer 브랜치로 병합하는 서브 PR입니다
-  이슈 수정 시 가이드 갱신(캐시 무효화) 로직은 현재 빠져있으며 이후 updatedAt 비교 방식 또는 임베딩 유사도 기반 감지를 검토할 예정입니다
