### PR TITLE
[#37][Feat] Github OAuth 로그인

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -21,7 +21,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 	implementation 'tools.jackson.module:jackson-module-kotlin'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/omos/src/main/kotlin/com/back/omos/domain/user/controller/UserController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/user/controller/UserController.kt
@@ -1,9 +1,10 @@
 package com.back.omos.domain.user.controller
 
-import com.back.omos.domain.user.dto.UserCreateReq
 import com.back.omos.domain.user.dto.UserInfoRes
 import com.back.omos.domain.user.service.UserService
+import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.plog.global.response.CommonResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 /**
@@ -23,22 +24,6 @@ import org.springframework.web.bind.annotation.*
 class UserController(
     private val userService: UserService
 ) {
-
-    /**
-     * 새로운 사용자를 등록(가입)합니다.
-     *
-     * <p>
-     * GitHub 로그인 성공 후 전달받은 고유 ID와 정보를 기반으로 계정을 생성합니다.
-     *
-     * @param request 신규 사용자 생성 요청 데이터
-     * @return 생성된 사용자 정보와 함께 성공 응답 반환
-     */
-    @PostMapping("/")
-    fun createUser(@RequestBody request: UserCreateReq): CommonResponse<UserInfoRes> {
-        val userInfo = userService.createUser(request)
-        return CommonResponse.success(userInfo, "사용자 등록에 성공하였습니다.")
-    }
-
     /**
      * 현재 로그인한 사용자의 정보를 조회합니다.
      *
@@ -49,11 +34,8 @@ class UserController(
      * @return 현재 로그인한 사용자 정보와 함께 성공 응답 반환
      */
     @GetMapping("/me")
-    fun getMyInfo(): CommonResponse<UserInfoRes> {
-        // TODO: SecurityContext에서 현재 사용자의 githubId를 가져오는 로직 추가 필요
-        // 예: val githubId = authentication.name
-        val tempGithubId = "temp-id" 
-        val userInfo = userService.getUserByGithubId(tempGithubId)
+    fun getMyInfo(@AuthenticationPrincipal principal: OAuthPrincipal): CommonResponse<UserInfoRes> {
+        val userInfo = userService.getUserByGithubId(principal.githubId)
         return CommonResponse.success(userInfo)
     }
 
@@ -80,12 +62,11 @@ class UserController(
      */
     @PatchMapping("/me")
     fun updateMyProfile(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
         @RequestParam(required = false) name: String?,
         @RequestParam(required = false) email: String?
     ): CommonResponse<UserInfoRes> {
-        // TODO: SecurityContext에서 현재 사용자의 githubId를 가져오는 로직 추가 필요
-        val tempGithubId = "temp-id"
-        val updatedInfo = userService.updateProfile(tempGithubId, name, email)
+        val updatedInfo = userService.updateProfile(principal.githubId, name, email)
         return CommonResponse.success(updatedInfo, "프로필이 성공적으로 수정되었습니다.")
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/global/auth/controller/OAuthCallbackController.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/controller/OAuthCallbackController.kt
@@ -1,0 +1,45 @@
+package com.back.omos.global.auth.controller
+
+import com.plog.global.response.CommonResponse
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 개발 환경에서 OAuth2 로그인 흐름을 프론트엔드 없이 테스트하기 위한 임시 콜백 컨트롤러입니다.
+ *
+ * <p>
+ * {@code dev} 프로파일에서만 활성화되며, [OAuth2SuccessHandler]가 리다이렉트하는
+ * {@code /oauth/callback} 경로를 처리하여 발급된 JWT를 응답 본문에 그대로 반환합니다.
+ *
+ * <p>
+ * 사용 방법:
+ * <ol>
+ *   <li>브라우저에서 {@code GET /oauth2/authorization/github}로 접근합니다.</li>
+ *   <li>GitHub 로그인을 완료합니다.</li>
+ *   <li>이 엔드포인트가 JWT를 JSON으로 반환합니다.</li>
+ *   <li>반환된 토큰을 Swagger UI 또는 curl의 {@code Authorization: Bearer} 헤더에 사용합니다.</li>
+ * </ol>
+ *
+ * <p><b>주의:</b> 이 컨트롤러는 {@code dev} 프로파일에서만 동작합니다. 운영 환경에서는 비활성화됩니다.
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see com.back.omos.global.auth.handler.OAuth2SuccessHandler
+ */
+@RestController
+@Profile("dev")
+class OAuthCallbackController {
+
+    /**
+     * OAuth2 로그인 성공 후 리다이렉트된 요청에서 JWT를 추출하여 반환합니다.
+     *
+     * @param token [OAuth2SuccessHandler]가 쿼리 파라미터로 전달한 JWT 문자열
+     * @return 발급된 JWT를 담은 성공 응답
+     */
+    @GetMapping("/oauth/callback")
+    fun callback(@RequestParam token: String): CommonResponse<Map<String, String>> {
+        return CommonResponse.success(mapOf("token" to token), "로그인 성공. 아래 토큰을 Authorization 헤더에 사용하세요.")
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/auth/handler/OAuth2FailureHandler.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/handler/OAuth2FailureHandler.kt
@@ -1,0 +1,46 @@
+package com.back.omos.global.auth.handler
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.stereotype.Component
+
+/**
+ * GitHub OAuth2 로그인 실패 시 프론트엔드로 에러를 전달하는 핸들러입니다.
+ *
+ * <p>
+ * [com.back.omos.global.auth.service.CustomOAuth2UserService]에서 예외가 발생하거나,
+ * GitHub 인증 자체가 실패한 경우 Spring Security에 의해 호출됩니다.
+ *
+ * <p>
+ * 실패 시 설정된 프론트엔드 URI에 {@code ?error=oauth_failed} 쿼리 파라미터를 붙여 리다이렉트합니다.
+ * 프론트엔드는 이 파라미터를 감지하여 사용자에게 로그인 실패 안내를 표시해야 합니다.
+ *
+ * @property redirectUri OAuth2 로그인 실패 후 이동할 프론트엔드 URI
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see OAuth2SuccessHandler
+ */
+@Component
+class OAuth2FailureHandler(
+    @Value("\${app.oauth2.redirect-uri}") private val redirectUri: String
+) : AuthenticationFailureHandler {
+
+    /**
+     * 로그인 실패 시 에러 파라미터를 포함하여 프론트엔드 URI로 리다이렉트합니다.
+     *
+     * @param request 현재 HTTP 요청
+     * @param response 현재 HTTP 응답
+     * @param exception 인증 실패 원인 예외
+     */
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException
+    ) {
+        response.sendRedirect("$redirectUri?error=oauth_failed")
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/auth/handler/OAuth2SuccessHandler.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/handler/OAuth2SuccessHandler.kt
@@ -1,0 +1,62 @@
+package com.back.omos.global.auth.handler
+
+import com.back.omos.global.auth.jwt.JwtProvider
+import com.back.omos.global.auth.principal.OAuthPrincipal
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+/**
+ * GitHub OAuth2 로그인 성공 시 JWT를 발급하고 프론트엔드로 리다이렉트하는 핸들러입니다.
+ *
+ * <p>
+ * [com.back.omos.global.auth.service.CustomOAuth2UserService]가 사용자 정보를 정상적으로
+ * 로드한 뒤 Spring Security에 의해 호출됩니다.
+ *
+ * <p>
+ * 처리 흐름:
+ * <ol>
+ *   <li>[Authentication]에서 [OAuthPrincipal]을 꺼내 {@code githubId}를 추출합니다.</li>
+ *   <li>[JwtProvider.generateToken]으로 JWT를 발급합니다.</li>
+ *   <li>설정된 프론트엔드 URI에 {@code ?token=<JWT>} 쿼리 파라미터를 붙여 리다이렉트합니다.</li>
+ * </ol>
+ *
+ * <p>
+ * 리다이렉트 대상 URI는 {@code app.oauth2.redirect-uri} 프로퍼티 또는
+ * {@code OAUTH2_REDIRECT_URI} 환경변수로 설정합니다.
+ *
+ * @property jwtProvider JWT 생성 및 검증을 담당하는 컴포넌트
+ * @property redirectUri OAuth2 로그인 성공 후 이동할 프론트엔드 URI
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see JwtProvider
+ * @see OAuthPrincipal
+ * @see OAuth2FailureHandler
+ */
+@Component
+class OAuth2SuccessHandler(
+    private val jwtProvider: JwtProvider,
+    @Value("\${app.oauth2.redirect-uri}") private val redirectUri: String
+) : AuthenticationSuccessHandler {
+
+    /**
+     * 로그인 성공 시 JWT를 발급하고 프론트엔드 URI로 리다이렉트합니다.
+     *
+     * @param request 현재 HTTP 요청
+     * @param response 현재 HTTP 응답
+     * @param authentication 인증된 사용자 정보 ([OAuthPrincipal]을 포함)
+     */
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        val principal = authentication.principal as OAuthPrincipal
+        val token = jwtProvider.generateToken(principal.githubId)
+        response.sendRedirect("$redirectUri?token=$token")
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/auth/jwt/JwtAuthenticationFilter.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,82 @@
+package com.back.omos.global.auth.jwt
+
+import com.back.omos.global.auth.principal.OAuthPrincipal
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * HTTP 요청의 {@code Authorization} 헤더에서 JWT를 추출하여 인증을 처리하는 필터입니다.
+ *
+ * <p>
+ * 요청당 한 번만 실행되도록 [OncePerRequestFilter]를 상속받으며,
+ * [com.back.omos.global.config.SecurityConfig]에서 [org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter]
+ * 앞에 등록됩니다.
+ *
+ * <p>
+ * 처리 흐름:
+ * <ol>
+ *   <li>{@code Authorization: Bearer <token>} 헤더에서 토큰을 추출합니다.</li>
+ *   <li>[JwtProvider.isValid]로 유효성을 검증합니다.</li>
+ *   <li>유효한 경우 [JwtProvider.getGithubId]로 사용자 ID를 추출하고
+ *       [OAuthPrincipal]을 생성하여 [SecurityContextHolder]에 등록합니다.</li>
+ *   <li>유효하지 않은 경우 인증 정보를 등록하지 않고 다음 필터로 넘깁니다.</li>
+ * </ol>
+ *
+ * <p><b>상속 정보:</b><br>
+ * [OncePerRequestFilter]의 구현 클래스입니다.
+ *
+ * @property jwtProvider JWT 생성 및 검증을 담당하는 컴포넌트
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see JwtProvider
+ * @see OAuthPrincipal
+ * @see com.back.omos.global.config.SecurityConfig
+ */
+class JwtAuthenticationFilter(
+    private val jwtProvider: JwtProvider
+) : OncePerRequestFilter() {
+
+    /**
+     * 요청 헤더에서 JWT를 추출하고 유효성을 검증하여 [SecurityContextHolder]에 인증 정보를 설정합니다.
+     *
+     * @param request 현재 HTTP 요청
+     * @param response 현재 HTTP 응답
+     * @param filterChain 다음 필터 체인
+     */
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = extractToken(request)
+        if (token != null && jwtProvider.isValid(token)) {
+            val githubId = jwtProvider.getGithubId(token)
+            val principal = OAuthPrincipal(githubId, emptyMap())
+            val auth = UsernamePasswordAuthenticationToken(
+                principal, null, listOf(SimpleGrantedAuthority("ROLE_USER"))
+            )
+            SecurityContextHolder.getContext().authentication = auth
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    /**
+     * HTTP 요청 헤더에서 Bearer 토큰을 추출합니다.
+     *
+     * <p>
+     * {@code Authorization} 헤더가 없거나 {@code Bearer }로 시작하지 않는 경우 {@code null}을 반환합니다.
+     *
+     * @param request Bearer 토큰을 추출할 HTTP 요청
+     * @return 추출된 JWT 문자열, 헤더가 없거나 형식이 올바르지 않으면 {@code null}
+     */
+    private fun extractToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization") ?: return null
+        return if (header.startsWith("Bearer ")) header.substring(7) else null
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/auth/jwt/JwtProvider.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/jwt/JwtProvider.kt
@@ -1,0 +1,92 @@
+package com.back.omos.global.auth.jwt
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.Date
+import javax.crypto.SecretKey
+
+/**
+ * JWT(JSON Web Token)의 생성, 파싱, 유효성 검증을 담당하는 컴포넌트입니다.
+ *
+ * <p>
+ * JJWT 0.12.x 라이브러리를 사용하며, HMAC-SHA 알고리즘으로 서명합니다.
+ * 서명 키와 만료 시간은 애플리케이션 설정 파일의 {@code jwt.secret}, {@code jwt.expiration}
+ * 프로퍼티에서 주입받습니다.
+ *
+ * <p>
+ * 발급된 토큰은 사용자의 {@code githubId}를 subject 클레임에 담으며,
+ * [JwtAuthenticationFilter]에서 요청마다 검증됩니다.
+ *
+ * @property expiration 토큰 만료 시간 (밀리초 단위, 기본값 86400000ms = 24시간)
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see JwtAuthenticationFilter
+ * @see com.back.omos.global.auth.handler.OAuth2SuccessHandler
+ */
+@Component
+class JwtProvider(
+    @Value("\${jwt.secret}") secret: String,
+    @Value("\${jwt.expiration}") private val expiration: Long
+) {
+
+    /**
+     * 설정에서 주입받은 시크릿 문자열로 초기화된 HMAC-SHA 서명 키입니다.
+     *
+     * <p>
+     * 키 길이는 최소 32바이트(256비트) 이상이어야 하며, {@code JWT_SECRET} 환경변수로 관리합니다.
+     */
+    private val key: SecretKey = Keys.hmacShaKeyFor(secret.toByteArray(Charsets.UTF_8))
+
+    /**
+     * 주어진 GitHub ID를 subject로 담은 JWT를 생성합니다.
+     *
+     * <p>
+     * 발급 시각은 현재 시각이며, 만료 시각은 현재 시각에 {@link #expiration}을 더한 값입니다.
+     *
+     * @param githubId JWT subject에 담을 GitHub 사용자 고유 ID
+     * @return 서명된 JWT 문자열
+     */
+    fun generateToken(githubId: String): String =
+        Jwts.builder()
+            .subject(githubId)
+            .issuedAt(Date())
+            .expiration(Date(System.currentTimeMillis() + expiration))
+            .signWith(key)
+            .compact()
+
+    /**
+     * JWT에서 GitHub ID(subject 클레임)를 추출합니다.
+     *
+     * <p>
+     * 서명 검증에 실패하거나 토큰이 만료된 경우 JJWT 예외가 발생합니다.
+     * 외부에서 호출 전 [isValid]로 유효성을 먼저 확인하는 것을 권장합니다.
+     *
+     * @param token 파싱할 JWT 문자열
+     * @return 토큰의 subject에 저장된 GitHub 사용자 고유 ID
+     */
+    fun getGithubId(token: String): String =
+        Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .payload
+            .subject
+
+    /**
+     * JWT의 서명과 만료 여부를 검증합니다.
+     *
+     * <p>
+     * 서명 불일치, 만료, 형식 오류 등 JJWT 예외가 발생하는 모든 경우에 {@code false}를 반환하며,
+     * 예외를 외부로 전파하지 않습니다.
+     *
+     * @param token 검증할 JWT 문자열
+     * @return 유효한 토큰이면 {@code true}, 그렇지 않으면 {@code false}
+     */
+    fun isValid(token: String): Boolean = runCatching {
+        Jwts.parser().verifyWith(key).build().parseSignedClaims(token)
+        true
+    }.getOrDefault(false)
+}

--- a/omos/src/main/kotlin/com/back/omos/global/auth/principal/OAuthPrincipal.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/principal/OAuthPrincipal.kt
@@ -1,0 +1,62 @@
+package com.back.omos.global.auth.principal
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+/**
+ * GitHub OAuth2 인증을 통해 로그인한 사용자의 인증 주체(Principal)를 나타내는 클래스입니다.
+ *
+ * <p>
+ * Spring Security의 [OAuth2User]를 구현하여 [org.springframework.security.core.context.SecurityContext]에
+ * 등록되며, [org.springframework.security.core.annotation.AuthenticationPrincipal] 어노테이션을 통해
+ * 컨트롤러 메서드 파라미터로 주입받을 수 있습니다.
+ *
+ * <p>
+ * 이 클래스는 GitHub OAuth2 인증 완료 후 [com.back.omos.global.auth.service.CustomOAuth2UserService]에서
+ * 생성되며, JWT 재발급 시에는 [githubId]만 담긴 빈 attributes로도 생성됩니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * [OAuth2User]의 구현 클래스입니다.
+ *
+ * @property githubId GitHub에서 제공하는 사용자의 고유 숫자 ID (문자열로 저장)
+ * @property attributes GitHub OAuth2 응답에서 받은 사용자 속성 맵 (login, email, avatar_url 등 포함)
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see com.back.omos.global.auth.service.CustomOAuth2UserService
+ * @see com.back.omos.global.auth.jwt.JwtAuthenticationFilter
+ */
+class OAuthPrincipal(
+    val githubId: String,
+    private val attributes: Map<String, Any>
+) : OAuth2User {
+
+    /**
+     * Spring Security가 이 Principal을 식별하는 데 사용하는 이름을 반환합니다.
+     *
+     * @return GitHub 사용자 고유 ID ([githubId])
+     */
+    override fun getName(): String = githubId
+
+    /**
+     * GitHub OAuth2 응답에서 받은 사용자 속성 맵을 반환합니다.
+     *
+     * <p>
+     * JWT 인증 경로에서 생성된 경우 빈 맵이 반환될 수 있습니다.
+     *
+     * @return 사용자 속성 맵 (login, name, email, avatar_url 등)
+     */
+    override fun getAttributes(): Map<String, Any> = attributes
+
+    /**
+     * 이 사용자에게 부여된 권한 목록을 반환합니다.
+     *
+     * <p>
+     * 현재는 모든 인증된 사용자에게 `ROLE_USER` 권한을 단일하게 부여합니다.
+     *
+     * @return [SimpleGrantedAuthority]("ROLE_USER")를 포함한 권한 목록
+     */
+    override fun getAuthorities(): Collection<GrantedAuthority> =
+        listOf(SimpleGrantedAuthority("ROLE_USER"))
+}

--- a/omos/src/main/kotlin/com/back/omos/global/auth/service/CustomOAuth2UserService.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/auth/service/CustomOAuth2UserService.kt
@@ -1,0 +1,77 @@
+package com.back.omos.global.auth.service
+
+import com.back.omos.domain.user.entity.User
+import com.back.omos.domain.user.repository.UserRepository
+import com.back.omos.global.auth.principal.OAuthPrincipal
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * GitHub OAuth2 인증 과정에서 사용자 정보를 로드하고 DB와 동기화하는 서비스입니다.
+ *
+ * <p>
+ * Spring Security OAuth2 Client가 GitHub로부터 액세스 토큰을 발급받은 후,
+ * GitHub User API({@code /user})를 호출하여 사용자 정보를 가져오는 과정에서 이 클래스가 사용됩니다.
+ *
+ * <p>
+ * 처리 흐름:
+ * <ol>
+ *   <li>부모 클래스 [DefaultOAuth2UserService.loadUser]를 통해 GitHub로부터 사용자 정보를 수신합니다.</li>
+ *   <li>응답 속성({@code id}, {@code login}, {@code email})에서 필요한 정보를 추출합니다.</li>
+ *   <li>DB에 해당 {@code githubId}를 가진 사용자가 없으면 신규 생성하고, 있으면 프로필을 최신 상태로 업데이트합니다.</li>
+ *   <li>[OAuthPrincipal]을 반환하여 이후 [com.back.omos.global.auth.handler.OAuth2SuccessHandler]에서 JWT 발급에 활용됩니다.</li>
+ * </ol>
+ *
+ * <p><b>상속 정보:</b><br>
+ * [DefaultOAuth2UserService]의 구현 클래스입니다.
+ *
+ * @property userRepository 사용자 데이터 액세스를 위한 Repository
+ *
+ * @author MintyU
+ * @since 2026-04-23
+ * @see OAuthPrincipal
+ * @see com.back.omos.global.auth.handler.OAuth2SuccessHandler
+ */
+@Service
+class CustomOAuth2UserService(
+    private val userRepository: UserRepository
+) : DefaultOAuth2UserService() {
+
+    /**
+     * GitHub OAuth2 인증 완료 후 사용자 정보를 로드하고 DB와 동기화합니다.
+     *
+     * <p>
+     * GitHub 응답 속성 중 {@code id}(숫자 형태의 고유 ID), {@code login}(GitHub 사용자명),
+     * {@code email}(공개 이메일)을 사용합니다. {@code id}가 없는 경우 [OAuth2AuthenticationException]을 발생시킵니다.
+     *
+     * @param userRequest OAuth2 클라이언트 등록 정보와 액세스 토큰을 포함한 요청 객체
+     * @return GitHub ID와 속성 정보를 담은 [OAuthPrincipal]
+     * @throws OAuth2AuthenticationException GitHub 응답에서 사용자 ID를 가져오지 못한 경우
+     */
+    @Transactional
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val oAuth2User = super.loadUser(userRequest)
+        val attributes = oAuth2User.attributes
+
+        val githubId = attributes["id"]?.toString()
+            ?: throw OAuth2AuthenticationException(
+                OAuth2Error("invalid_user_info", "GitHub ID를 가져올 수 없습니다.", null)
+            )
+        val name = attributes["login"] as? String
+        val email = attributes["email"] as? String
+
+        val user = userRepository.findByGithubId(githubId).orElse(null)
+            ?: userRepository.save(User(githubId = githubId, name = name, email = email))
+
+        if (user.name != name || user.email != email) {
+            user.updateProfile(name, email)
+        }
+
+        return OAuthPrincipal(githubId, attributes)
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/config/SecurityConfig.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/config/SecurityConfig.kt
@@ -1,36 +1,104 @@
 package com.back.omos.global.config
 
+import com.back.omos.global.auth.handler.OAuth2FailureHandler
+import com.back.omos.global.auth.handler.OAuth2SuccessHandler
+import com.back.omos.global.auth.jwt.JwtAuthenticationFilter
+import com.back.omos.global.auth.jwt.JwtProvider
+import com.back.omos.global.auth.service.CustomOAuth2UserService
+import com.plog.global.exception.errorCode.AuthErrorCode
+import com.plog.global.response.CommonResponse
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import tools.jackson.databind.ObjectMapper
 
 /**
  * 프로젝트의 보안 설정을 담당하는 클래스입니다.
- * 
+ *
  * <p>
- * 개발 초기 단계에서는 테스트 편의를 위해 모든 API 경로([/api/~])에 대한
- * 인증을 해제하고 CSRF 보호를 비활성화합니다.
- * 
+ * GitHub OAuth2 로그인과 JWT 기반의 Stateless 인증을 함께 구성합니다.
+ * OAuth2 인증 흐름은 세션을 통해 상태(state 파라미터)를 유지하며,
+ * 로그인 성공 후 발급된 JWT를 클라이언트가 이후 요청의 {@code Authorization} 헤더에 포함합니다.
+ *
+ * <p>
+ * 주요 설정:
+ * <ul>
+ *   <li>CSRF: REST API이므로 비활성화</li>
+ *   <li>OAuth2 로그인: [CustomOAuth2UserService], [OAuth2SuccessHandler], [OAuth2FailureHandler] 연동</li>
+ *   <li>JWT 필터: [JwtAuthenticationFilter]를 [org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter] 앞에 등록</li>
+ *   <li>인증 실패 응답: 표준 [CommonResponse] 형식의 JSON 반환</li>
+ * </ul>
+ *
+ * <p>
+ * 인증 없이 접근 가능한 경로: {@code /oauth2/~}, {@code /login/~}, {@code /swagger-ui/~}, {@code /v3/api-docs/~}
+ *
+ * @property customOAuth2UserService GitHub 사용자 정보 로드 및 DB 동기화 서비스
+ * @property oauth2SuccessHandler OAuth2 로그인 성공 시 JWT 발급 핸들러
+ * @property oauth2FailureHandler OAuth2 로그인 실패 시 에러 리다이렉트 핸들러
+ * @property jwtProvider JWT 생성 및 검증 컴포넌트
+ * @property objectMapper JSON 직렬화를 위한 ObjectMapper
+ *
  * @author MintyU
- * @since 2026-04-22
- **/
+ * @since 2026-04-23
+ * @see CustomOAuth2UserService
+ * @see OAuth2SuccessHandler
+ * @see OAuth2FailureHandler
+ * @see JwtAuthenticationFilter
+ */
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val customOAuth2UserService: CustomOAuth2UserService,
+    private val oauth2SuccessHandler: OAuth2SuccessHandler,
+    private val oauth2FailureHandler: OAuth2FailureHandler,
+    private val jwtProvider: JwtProvider,
+    private val objectMapper: ObjectMapper
+) {
 
+    /**
+     * Spring Security 필터 체인을 구성하여 빈으로 등록합니다.
+     *
+     * @param http [HttpSecurity] 빌더
+     * @return 구성이 완료된 [SecurityFilterChain]
+     */
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
-            .csrf { it.disable() } // REST API이므로 CSRF 비활성화
-            .headers { headers -> 
-                headers.frameOptions { it.disable() } // H2 Console 등을 사용할 경우 대비
-            }
+            .csrf { it.disable() }
             .authorizeHttpRequests { auth ->
-                auth.anyRequest().permitAll() // 모든 요청 임시 허용
+                auth
+                    .requestMatchers(
+                        "/oauth2/**",
+                        "/login/**",
+                        "/oauth/callback",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**"
+                    ).permitAll()
+                    .anyRequest().authenticated()
             }
-        
+            .oauth2Login { oauth2 ->
+                oauth2
+                    .userInfoEndpoint { it.userService(customOAuth2UserService) }
+                    .successHandler(oauth2SuccessHandler)
+                    .failureHandler(oauth2FailureHandler)
+            }
+            .exceptionHandling { exceptions ->
+                exceptions.authenticationEntryPoint { _, response, _ ->
+                    response.status = HttpServletResponse.SC_UNAUTHORIZED
+                    response.contentType = "application/json;charset=UTF-8"
+                    val body = CommonResponse.fail<Any>(AuthErrorCode.LOGIN_REQUIRED.message)
+                    response.writer.write(objectMapper.writeValueAsString(body))
+                }
+            }
+            .addFilterBefore(
+                JwtAuthenticationFilter(jwtProvider),
+                UsernamePasswordAuthenticationFilter::class.java
+            )
+
         return http.build()
     }
 }

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -3,6 +3,18 @@ spring:
     activate:
       on-profile: dev
 
+  # GitHub OAuth2 설정
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+            scope:
+              - user:email
+              - read:user
+
   # 데이터베이스 설정 (Docker Compose 호환)
   datasource:
     url: jdbc:postgresql://localhost:5432/oh_my_opensource?stringtype=unspecified
@@ -19,6 +31,16 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+# JWT 설정
+jwt:
+  secret: ${JWT_SECRET}
+  expiration: 86400000  # 24시간 (ms)
+
+# OAuth2 로그인 성공 후 리다이렉트할 프론트엔드 URI
+app:
+  oauth2:
+    redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth/callback}
 
 # 로깅 레벨
 logging:


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
Spring Security 설정 및 Github OAuth 로그인이 구현되었습니다.

## 🔗 관련 이슈
- Close #37 

## 🛠️ 주요 변경 사항
- [x] `.env`에 관련 키가 추가되었으며, Slack으로 변경 사항을 보내 드렸습니다.
- [x] `build.gradle`에 `spring-boot-starter-oauth2-client`, `jjwt` 의존성이 추가되었습니다.
- [x] `application-dev.yaml`에 GitHub OAuth2 클라이언트 설정 및 JWT 설정(`jwt.secret`, `jwt.expiration`)이 추가되었습니다.

## 🔐 인증 흐름

  GET /oauth2/authorization/github
    → GitHub 로그인
    → CustomOAuth2UserService: 사용자 DB 저장/업데이트
    → OAuth2SuccessHandler: JWT 발급 → {REDIRECT_URI}?token=JWT

  이후 API 요청:
    Authorization: Bearer {JWT}
    → JwtAuthenticationFilter → SecurityContext 등록
    → `@AuthenticationPrincipal OAuthPrincipal`
