### PR TITLE
[#52][FEAT] PrDraft/contributing file 읽어오기

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
 	runtimeOnly 'com.h2database:h2'
 
+	implementation 'io.github.microutils:kotlin-logging-jvm:3.0.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiClient.kt
@@ -1,4 +1,4 @@
-package com.back.omos.domain.prdraft.service
+package com.back.omos.domain.prdraft.ai
 
 /**
  * PR 초안 생성을 위한 AI 호출 기능을 추상화한 인터페이스입니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiPrResult.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiPrResult.kt
@@ -1,4 +1,4 @@
-package com.back.omos.domain.prdraft.service
+package com.back.omos.domain.prdraft.ai
 
 /**
  * AI가 생성한 PR 초안 결과를 담는 내부 DTO입니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/MockAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/MockAiClient.kt
@@ -1,4 +1,4 @@
-package com.back.omos.domain.prdraft.service
+package com.back.omos.domain.prdraft.ai
 
 import org.springframework.stereotype.Component
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
@@ -1,0 +1,28 @@
+package com.back.omos.domain.prdraft.github
+
+/**
+ * GitHub API 호출 기능을 추상화한 인터페이스입니다.
+ *
+ * <p>
+ * 서비스 계층은 이 인터페이스를 통해 GitHub API를 호출하여
+ * 레포지토리의 파일 내용을 가져옵니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 별도의 상속 없이 GitHub API 호출 역할을 정의하는 인터페이스입니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-23
+ */
+interface GitHubClient {
+
+    /**
+     * 레포지토리의 CONTRIBUTING.md 내용을 가져옵니다.
+     *
+     * <p>
+     * CONTRIBUTING.md가 존재하지 않는 레포지토리의 경우 null을 반환합니다.
+     *
+     * @param fullName owner/repo 형식의 레포지토리 이름
+     * @return CONTRIBUTING.md 내용, 없으면 null
+     */
+    fun fetchContributing(fullName: String): String?
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -1,11 +1,13 @@
 package com.back.omos.domain.prdraft.github
 
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestClientResponseException
 import java.time.Duration
 import java.util.Base64
 
@@ -41,6 +43,12 @@ import java.util.Base64
 class GitHubClientImpl(
     @Value("\${github.token}") private val token: String
 ) : GitHubClient {
+
+    private val logger = KotlinLogging.logger {}
+
+    init {
+        require(token.isNotBlank()) { "github.token이 설정되지 않았습니다." }
+    }
 
     private val restClient = RestClient.builder()
         .baseUrl("https://api.github.com")
@@ -100,7 +108,15 @@ class GitHubClientImpl(
             response?.content
                 ?.replace("\n", "")
                 ?.let { Base64.getDecoder().decode(it).toString(Charsets.UTF_8) }
+        } catch (e: RestClientResponseException) {
+            if (e.statusCode.value() == 404) {
+                null
+            } else {
+                logger.warn { "GitHub API 오류: $fullName/$path - ${e.statusCode}" }
+                null
+            }
         } catch (e: RestClientException) {
+            logger.warn { "GitHub API 네트워크 오류: $fullName/$path - ${e.message}" }
             null
         }
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -42,9 +42,18 @@ class GitHubClientImpl(
      * @return CONTRIBUTING.md 내용, 없으면 null
      */
     override fun fetchContributing(fullName: String): String? {
+        val paths = listOf("CONTRIBUTING.md", ".github/CONTRIBUTING.md")
+        for (path in paths) {
+            val result = fetchFile(fullName, path)
+            if (result != null) return result
+        }
+        return null
+    }
+
+    private fun fetchFile(fullName: String, path: String): String? {
         return try {
             val response = restClient.get()
-                .uri("/repos/$fullName/contents/CONTRIBUTING.md")
+                .uri("/repos/$fullName/contents/$path")
                 .retrieve()
                 .body(GitHubContentsRes::class.java)
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.client.RestClientException
 import java.util.Base64
 
 /**
@@ -42,7 +42,7 @@ class GitHubClientImpl(
      * @return CONTRIBUTING.md 내용, 없으면 null
      */
     override fun fetchContributing(fullName: String): String? {
-        val paths = listOf("CONTRIBUTING.md", ".github/CONTRIBUTING.md")
+        val paths = listOf("CONTRIBUTING.md", ".github/CONTRIBUTING.md", "CONTRIBUTING.adoc", ".github/CONTRIBUTING.adoc")
         for (path in paths) {
             val result = fetchFile(fullName, path)
             if (result != null) return result
@@ -60,7 +60,7 @@ class GitHubClientImpl(
             response?.content
                 ?.replace("\n", "")
                 ?.let { Base64.getDecoder().decode(it).toString(Charsets.UTF_8) }
-        } catch (e: RestClientResponseException) {
+        } catch (e: RestClientException) {
             null
         }
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -1,0 +1,58 @@
+package com.back.omos.domain.prdraft.github
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
+import java.util.Base64
+
+/**
+ * GitHub Contents API를 호출하여 파일 내용을 가져오는 구현체입니다.
+ *
+ * <p>
+ * RestClient를 사용하여 GitHub API를 호출하며,
+ * 응답으로 받은 base64 인코딩된 파일 내용을 디코딩하여 반환합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link GitHubClient}를 구현합니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-23
+ * @see GitHubClient
+ */
+@Component
+class GitHubClientImpl(
+    @Value("\${github.token}") private val token: String
+) : GitHubClient {
+
+    private val restClient = RestClient.builder()
+        .baseUrl("https://api.github.com")
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $token")
+        .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+        .build()
+
+    /**
+     * GitHub Contents API를 통해 CONTRIBUTING.md 내용을 가져옵니다.
+     *
+     * <p>
+     * 파일이 존재하지 않거나 API 호출에 실패한 경우 null을 반환합니다.
+     *
+     * @param fullName owner/repo 형식의 레포지토리 이름
+     * @return CONTRIBUTING.md 내용, 없으면 null
+     */
+    override fun fetchContributing(fullName: String): String? {
+        return try {
+            val response = restClient.get()
+                .uri("/repos/$fullName/contents/CONTRIBUTING.md")
+                .retrieve()
+                .body(GitHubContentsRes::class.java)
+
+            response?.content
+                ?.replace("\n", "")
+                ?.let { Base64.getDecoder().decode(it).toString(Charsets.UTF_8) }
+        } catch (e: RestClientResponseException) {
+            null
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -2,9 +2,11 @@ package com.back.omos.domain.prdraft.github
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
+import java.time.Duration
 import java.util.Base64
 
 /**
@@ -13,6 +15,20 @@ import java.util.Base64
  * <p>
  * RestClient를 사용하여 GitHub API를 호출하며,
  * 응답으로 받은 base64 인코딩된 파일 내용을 디코딩하여 반환합니다.
+ *
+ * <p><b>탐색 순서:</b><br>
+ * CONTRIBUTING 파일은 레포지토리마다 위치와 확장자가 다를 수 있어,
+ * 아래 순서로 순차 탐색하며 가장 먼저 발견된 파일을 반환합니다.
+ * <ol>
+ *   <li>CONTRIBUTING.md (루트)</li>
+ *   <li>.github/CONTRIBUTING.md</li>
+ *   <li>CONTRIBUTING.adoc (루트)</li>
+ *   <li>.github/CONTRIBUTING.adoc</li>
+ * </ol>
+ *
+ * <p><b>타임아웃:</b><br>
+ * 연결 타임아웃 3초, 읽기 타임아웃 5초로 설정되어 있습니다.
+ * 타임아웃 초과 시 예외를 잡아 null을 반환하며, 서비스 장애로 이어지지 않습니다.
  *
  * <p><b>상속 정보:</b><br>
  * {@link GitHubClient}를 구현합니다.
@@ -30,16 +46,25 @@ class GitHubClientImpl(
         .baseUrl("https://api.github.com")
         .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $token")
         .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+        .requestFactory(SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(Duration.ofSeconds(3))
+            setReadTimeout(Duration.ofSeconds(5))
+        })
         .build()
 
     /**
-     * GitHub Contents API를 통해 CONTRIBUTING.md 내용을 가져옵니다.
+     * CONTRIBUTING 파일 내용을 가져옵니다.
      *
      * <p>
+     * 루트 및 .github 폴더 하위에서 .md, .adoc 확장자 순으로 탐색합니다.
      * 파일이 존재하지 않거나 API 호출에 실패한 경우 null을 반환합니다.
      *
+     * <p>
+     * CONTRIBUTING은 AI 프롬프트의 선택적 컨텍스트이므로,
+     * 파일이 없거나 GitHub API 장애가 발생해도 null을 반환하여 PR 생성은 계속 진행됩니다.
+     *
      * @param fullName owner/repo 형식의 레포지토리 이름
-     * @return CONTRIBUTING.md 내용, 없으면 null
+     * @return CONTRIBUTING 파일 내용, 없으면 null
      */
     override fun fetchContributing(fullName: String): String? {
         val paths = listOf("CONTRIBUTING.md", ".github/CONTRIBUTING.md", "CONTRIBUTING.adoc", ".github/CONTRIBUTING.adoc")
@@ -50,6 +75,21 @@ class GitHubClientImpl(
         return null
     }
 
+    /**
+     * GitHub Contents API로 단일 파일의 내용을 가져옵니다.
+     *
+     * <p>
+     * GitHub Contents API는 파일 내용을 base64로 인코딩하여 반환합니다.
+     * 줄바꿈 문자(\n)를 제거한 뒤 디코딩하여 원본 텍스트로 복원합니다.
+     *
+     * <p>
+     * HTTP 오류(4xx/5xx), 네트워크 오류, 타임아웃 등 모든 API 호출 실패는
+     * {@link RestClientException}으로 잡아 null을 반환합니다.
+     *
+     * @param fullName owner/repo 형식의 레포지토리 이름
+     * @param path 조회할 파일 경로 (예: CONTRIBUTING.md, .github/CONTRIBUTING.md)
+     * @return 디코딩된 파일 내용, 실패 시 null
+     */
     private fun fetchFile(fullName: String, path: String): String? {
         return try {
             val response = restClient.get()

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubContentsRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubContentsRes.kt
@@ -1,0 +1,23 @@
+package com.back.omos.domain.prdraft.github
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GitHub Contents API 응답을 담는 DTO입니다.
+ *
+ * <p>
+ * GitHub API의 파일 내용은 base64로 인코딩되어 전달됩니다.
+ * {@link GitHubClientImpl}에서 디코딩하여 사용합니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-23
+ * @see GitHubClientImpl
+ */
+data class GitHubContentsRes(
+
+    /**
+     * base64로 인코딩된 파일 내용입니다.
+     */
+    @JsonProperty("content")
+    val content: String?
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -36,11 +36,17 @@ import org.springframework.stereotype.Component
 @Component
 class PrDraftPromptBuilder {
 
-    fun build(req: CreatePrReq): String {
+    fun build(req: CreatePrReq, contributing: String?): String {
+        val contributingSection = if (contributing != null) {
+            "\n[CONTRIBUTING.md]\n$contributing\n"
+        } else {
+            ""
+        }
+
         return """
             당신은 오픈소스 프로젝트의 PR 초안 작성 도우미입니다.
             아래 diff를 바탕으로 PR 제목과 본문을 작성하세요.
-
+            $contributingSection
             [Diff]
             ${req.diffContent}
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -3,6 +3,7 @@ package com.back.omos.domain.prdraft.service
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.github.GitHubClient
 import com.back.omos.domain.prdraft.repository.PrDraftRepository
 import com.back.omos.domain.repo.repository.RepoRepository
 import com.back.omos.global.exception.errorCode.IssueErrorCode
@@ -35,7 +36,8 @@ class PrDraftServiceImpl(
     private val issueRepository: IssueRepository,
     private val repoRepository: RepoRepository,
     private val prDraftPromptBuilder: PrDraftPromptBuilder,
-    private val aiClient: AiClient
+    private val aiClient: AiClient,
+    private val gitHubClient: GitHubClient
 ) : PrDraftService {
 
     @Transactional
@@ -45,13 +47,13 @@ class PrDraftServiceImpl(
         val repo = repoRepository.findById(request.repositoryId)
             .orElseThrow { RepoException(RepoErrorCode.REPO_NOT_FOUND) }
 
-        // TODO: 프롬프트 만들기
-        val prompt = prDraftPromptBuilder.build(request)
+        val contributing = gitHubClient.fetchContributing(repo.fullName)
+
+        val prompt = prDraftPromptBuilder.build(request, contributing)
 
         // TODO: AI 호출하기
         val aiResult = aiClient.generatePrDraft(prompt)
 
-        // TODO: 응답 반환하기
         return PrInfoRes(
             title = aiResult.title,
             body = aiResult.body

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -3,6 +3,7 @@ package com.back.omos.domain.prdraft.service
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.ai.AiClient
 import com.back.omos.domain.prdraft.github.GitHubClient
 import com.back.omos.domain.prdraft.repository.PrDraftRepository
 import com.back.omos.domain.repo.repository.RepoRepository

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -32,6 +32,10 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+# GitHub API 설정
+github:
+  token: ${GITHUB_TOKEN}
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET}

--- a/omos/src/main/resources/application-test.yaml
+++ b/omos/src/main/resources/application-test.yaml
@@ -18,3 +18,10 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+github:
+  token: ${GITHUB_TOKEN}
+
+jwt:
+  secret: test-secret-key-for-jwt-testing-only
+  expiration: 86400000

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
@@ -34,6 +34,15 @@ class GitHubClientImplTest {
     }
 
     @Test
+    fun `CONTRIBUTING_adoc인 레포에서도 내용을 가져온다`() {
+        val result = gitHubClient.fetchContributing("spring-projects/spring-framework")
+
+        assertThat(result).isNotNull()
+        println("=== CONTRIBUTING.adoc 내용 ===")
+        println(result)
+    }
+
+    @Test
     fun `CONTRIBUTING_md가 없는 레포에서 null을 반환한다`() {
         val result = gitHubClient.fetchContributing("torvalds/linux")
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
@@ -25,6 +25,15 @@ class GitHubClientImplTest {
     }
 
     @Test
+    fun `github_폴더에 있는 CONTRIBUTING_md도 가져온다`() {
+        val result = gitHubClient.fetchContributing("kubernetes/kubernetes")
+
+        assertThat(result).isNotNull()
+        println("=== .github/CONTRIBUTING.md 내용 ===")
+        println(result)
+    }
+
+    @Test
     fun `CONTRIBUTING_md가 없는 레포에서 null을 반환한다`() {
         val result = gitHubClient.fetchContributing("torvalds/linux")
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
@@ -1,0 +1,25 @@
+package com.back.omos.domain.prdraft.github
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GitHubClientImplTest {
+
+    private val gitHubClient = GitHubClientImpl(System.getenv("GITHUB_TOKEN") ?: "")
+
+    @Test
+    fun `CONTRIBUTING_md가 있는 레포에서 내용을 가져온다`() {
+        val result = gitHubClient.fetchContributing("angular/angular")
+
+        assertThat(result).isNotNull()
+        println("=== CONTRIBUTING.md 내용 ===")
+        println(result)
+    }
+
+    @Test
+    fun `CONTRIBUTING_md가 없는 레포에서 null을 반환한다`() {
+        val result = gitHubClient.fetchContributing("torvalds/linux")
+
+        assertThat(result).isNull()
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
@@ -2,14 +2,22 @@ package com.back.omos.domain.prdraft.github
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.io.File
 
 class GitHubClientImplTest {
 
-    private val gitHubClient = GitHubClientImpl(System.getenv("GITHUB_TOKEN") ?: "")
+    private val token = File(".env").readLines()
+        .firstOrNull { it.startsWith("GITHUB_TOKEN=") }
+        ?.removePrefix("GITHUB_TOKEN=")
+        ?.trim()
+        ?: System.getenv("GITHUB_TOKEN")
+        ?: ""
+
+    private val gitHubClient = GitHubClientImpl(token)
 
     @Test
     fun `CONTRIBUTING_md가 있는 레포에서 내용을 가져온다`() {
-        val result = gitHubClient.fetchContributing("angular/angular")
+        val result = gitHubClient.fetchContributing("facebook/react")
 
         assertThat(result).isNotNull()
         println("=== CONTRIBUTING.md 내용 ===")


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
 PR 초안 생성 시 AI 프롬프트에 활용할 CONTRIBUTING 파일을 GitHub API로 조회하는 기능

## 🔗 관련 이슈
- Close #52 

## 🛠️ 주요 변경 사항
- [ ] 루트 및 `.github/` 폴더 하위에서 `.md`, `.adoc` 순으로 순차 탐색(CONTRIBUTING.md -> .github/CONTRIBUTING.md -> CONTRIBUTING.adoc -> .github/CONTRIBUTING.adoc 순서)
- [ ] CONTRIBUTING은 선택적 컨텍스트이므로 파일이 없거나 API 호출 실패 시 null 반환하여 PR 생성 계속 진행
- [ ] RestClientException으로 HTTP 오류 및 네트워크 오류 통합 처리
- [ ] 연결 타임아웃 3초, 읽기 타임아웃 5초 설정

## 🧪 테스트 결과
<img width="373" height="146" alt="image" src="https://github.com/user-attachments/assets/c8dc1c99-6220-41f8-bd9d-72c469908f24" />

## 🧐 리뷰어에게
1. ai에 대한 내용은 파일 위치만 변경한 것이니 넘어가셔도 됩니다.
2. test내용은 실제 파일과 동일한지 확인 하는 것이 아니고 안의 내용이 있는 정도만 판단합니다. 결과에 보시면 실제 파일 내용이 출력되는 걸 확인하실 수 있습니다.
<img width="249" height="126" alt="image" src="https://github.com/user-attachments/assets/ed008bea-ae8c-4add-8114-3c9a0858b7ff" />

3. .env파일에 `GITHUB_TOKEN=ghp_~~~~` 추가하셔야 정상 실행됩니다.
4. contributing이 없는 경우에는 null을 반환하며 pr 톤앤매너를 맞추거나 default contributing을 쓰는 경우에 대해서는 추후에 구현될 예정입니다.
5. `main`이 아닌 `feat/pr-create`로 merge됩니다.
