### PR TITLE
[#56][FEAT] 이슈 크롤링 기능 추가

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+
+    // WebClient 사용
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 kotlin {

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -1,0 +1,52 @@
+package com.back.omos.domain.issue.controller
+
+import com.back.omos.domain.issue.service.IssueService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 이슈 관련 외부 요청을 처리하는 REST 컨트롤러입니다.
+ * <p>
+ * 깃허브 오픈소스 이슈의 수집, 조회 및 추천 시스템과의 상호작용을 위한
+ * 진입점 역할을 수행하며, HTTP 요청을 서비스 계층으로 전달합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 해당 사항 없음
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code IssueController(IssueService issueService)} <br>
+ * 이슈 관련 비즈니스 로직을 처리하는 [IssueService]를 주입받아 초기화합니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * Spring Container에 의해 Singleton 빈으로 관리됩니다. (@RestController)
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Spring Web MVC를 사용하여 RESTful API 엔드포인트를 노출합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-23
+ * @see com.back.omos.domain.issue.service.IssueService
+ */
+@RestController
+@RequestMapping("/api/v1/issues")
+class IssueController(
+    private val issueService: IssueService
+) {
+
+    /**
+     * 특정 레포지토리 ID를 입력받아 깃허브 이슈를 크롤링하고 저장합니다.
+     */
+    @PostMapping("/crawl/{repoId}")
+    fun crawlIssues(@PathVariable repoId: Long): ResponseEntity<String> {
+        return try {
+            issueService.crawlAndSave(repoId)
+            ResponseEntity.ok("성공적으로 레포지토리($repoId)의 이슈를 수집했습니다.")
+        } catch (e: Exception) {
+            // 에러 발생 시 400 또는 500 에러와 함께 메시지 반환
+            ResponseEntity.badRequest().body("크롤링 실패: ${e.message}")
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/GithubIssueResponse.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/GithubIssueResponse.kt
@@ -1,0 +1,58 @@
+package com.back.omos.domain.issue.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GitHub API로부터 수집한 이슈 상세 정보를 담는 데이터 전송 객체(DTO)입니다.
+ * <p>
+ * GitHub REST API의 응답 JSON 데이터를 코틀린 객체로 역직렬화하며,
+ * 분석에 필요한 핵심 필드(제목, 본문, 라벨 등)만을 선택적으로 유지합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 해당 사항 없음 (Data Class)
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code GithubIssueResponse(id, number, title, body, htmlUrl, labels)} <br>
+ * GitHub 이슈의 식별자, 번호, 텍스트 데이터 및 메타데이터를 초기화합니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * 해당 객체는 빈으로 관리되지 않으며, 외부 API 호출 시 동적으로 생성됩니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Jackson 라이브러리를 사용하여 JSON 필드 매핑 및 무시 설정을 처리합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-24
+ * @see <a href="https://docs.github.com/en/rest/issues/issues">GitHub Issues API</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GithubIssueResponse(
+    // 깃허브 시스템 내부 고유 ID
+    val id: Long,
+
+    // 우리가 흔히 보는 이슈 번호 (예: #102)
+    val number: Long,
+
+    // 이슈 제목
+    val title: String,
+
+    // 이슈 본문 (마크다운 형식, 내용이 없을 수 있어 Nullable 처리)
+    val body: String?,
+
+    // 해당 이슈의 실제 깃허브 웹 주소
+    @JsonProperty("html_url")
+    val htmlUrl: String,
+
+    // 이슈에 달린 라벨 목록
+    val labels: List<LabelResponse> = emptyList()
+) {
+    /**
+     * 라벨 정보를 담는 내부 데이터 클래스
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class LabelResponse(
+        val name: String, // 라벨 이름 (예: "bug", "good first issue")
+        val color: String // 라벨 색상 코드
+    )
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/GithubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/GithubClient.kt
@@ -1,0 +1,52 @@
+package com.back.omos.domain.issue.service
+
+import com.back.omos.domain.issue.dto.GithubIssueResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import kotlin.jvm.java
+
+/**
+ * GitHub REST API와 직접 통신하여 리포지토리 데이터를 수집하는 클라이언트 클래스입니다.
+ * <p>
+ * 비차단(Non-blocking) I/O 모델인 [WebClient]를 사용하여 GitHub 서버에 HTTP 요청을 전송하며,
+ * 전달받은 JSON 응답을 [GithubIssueResponse] DTO 리스트로 변환하는 역할을 수행합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 해당 사항 없음
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code GithubClient(webClient, token)} <br>
+ * HTTP 요청을 위한 [WebClient]와 GitHub API 호출 시 인증에 필요한 Personal Access Token을 주입받습니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * Spring Container에 의해 Singleton 빈으로 관리됩니다. (@Component)
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Spring WebFlux의 WebClient를 사용하여 비동기 통신 아키텍처를 구성합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-24
+ * @see <a href="https://docs.github.com/en/rest">GitHub REST API Documentation</a>
+ */
+@Component
+class GithubClient(
+    private val webClient: WebClient,
+    @Value("\${github.token}") private val token: String
+) {
+    fun fetchIssues(owner: String, repo: String): List<GithubIssueResponse> {
+        return webClient.get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/repos/$owner/$repo/issues")
+                    .queryParam("state", "open")
+                    .queryParam("per_page", 1) // 현재 테스트용으로 1개 설정
+                    .build()
+            }
+            .header("Authorization", "Bearer $token")
+            .retrieve()
+            .bodyToFlux(GithubIssueResponse::class.java)
+            .collectList()
+            .block() ?: emptyList()
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
@@ -56,4 +56,19 @@ interface IssueService {
      * @return 추천된 이슈 목록
      */
     fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes>
+
+    /**
+     * 지정된 레포지토리의 GitHub 이슈를 수집하고 벡터 임베딩을 생성하여 저장합니다.
+     *
+     * GitHub REST API를 호출하여 최신 이슈 데이터를 가져오며,
+     * 수집된 텍스트 데이터(제목, 본문)는 AI 모델을 통해 고차원 벡터로 변환됩니다.
+     * * [설계 특징]
+     * 1. 도메인 간 결합도를 낮추기 위해 객체 참조 대신 [repoId]를 직접 저장합니다.
+     * 2. 중복 수집 방지를 위해 기존에 저장된 이슈 번호([issueNumber])와 비교 로직이 포함될 수 있습니다.
+     * 3. 저장된 벡터 데이터는 추후 [recommendIssues]에서 유사도 기반 추천에 활용됩니다.
+     *
+     * @param repoId 이슈를 수집할 대상 레포지토리의 고유 식별자(ID)
+     * @throws IllegalArgumentException 존재하지 않는 [repoId]이거나 API 호출에 실패한 경우 발생
+     */
+    fun crawlAndSave(repoId: Long)
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
@@ -6,8 +6,11 @@ import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.dto.UpdateIssueReq
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.repo.repository.RepoRepository
 import com.back.omos.global.exception.errorCode.IssueErrorCode
+import com.back.omos.global.exception.errorCode.RepoErrorCode
 import com.back.omos.global.exception.exceptions.IssueException
+import com.back.omos.global.exception.exceptions.RepoException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -20,7 +23,9 @@ import org.springframework.transaction.annotation.Transactional
  */
 @Service
 class IssueServiceImpl(
-    private val issueRepository: IssueRepository
+    private val issueRepository: IssueRepository,
+    private val githubClient: GithubClient,
+    private val repoRepository: RepoRepository,
 ) : IssueService {
 
     @Transactional
@@ -62,6 +67,36 @@ class IssueServiceImpl(
 
     override fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes> {
         TODO("추천 로직 구현 필요")
+    }
+
+    @Transactional
+    override fun crawlAndSave(repoId: Long) {
+        // 1. 레포지토리 이름(fullName)을 알아내기 위해 DB 조회
+        val repo = repoRepository.findByIdOrNull(repoId)
+            ?: throw RepoException(RepoErrorCode.REPO_NOT_FOUND, "해당 레포지토리가 존재하지 않습니다. ID: $repoId")
+
+        // "owner/repo" 문자열 분리
+        val (owner, repoName) = repo.fullName.split("/").let {
+            if (it.size < 2) throw RepoException(RepoErrorCode.REPO_NOT_FOUND, "해당 레포지토리의 이름이 잘못되었습니다. ID: $repoId")
+            it[0] to it[1]
+        }
+
+        // 2. GitHub API를 통해 이슈 목록 가져오기
+        val githubIssues = githubClient.fetchIssues(owner, repoName)
+
+        // 3. DTO를 엔티티로 변환하여 저장
+        githubIssues.forEach { dto ->
+            val issue = Issue(
+                repositoryId = repoId,
+                issueNumber = dto.number,
+                title = dto.title,
+                content = dto.body,
+                labels = dto.labels.map { it.name },
+                status = Issue.IssueStatus.OPEN,
+                issueVector = null // TODO : 임베딩은 추후에 구현 아직 Spring AI 도입 안됐음
+            )
+            issueRepository.save(issue)
+        }
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/global/config/WebClientConfig.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/config/WebClientConfig.kt
@@ -1,0 +1,26 @@
+package com.back.omos.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * WebClient 설정을 담당하는 클래스입니다.
+ *  @author 유재원
+ *  @since 2026-04-24
+ *  @see
+ */
+@Configuration
+class WebClientConfig {
+
+    /**
+     * 공통으로 사용할 WebClient 빈을 등록합니다.
+     */
+    @Bean
+    fun webClient(): WebClient {
+        return WebClient.builder()
+            .baseUrl("https://api.github.com") // 기본 주소 설정
+            .defaultHeader("Accept", "application/vnd.github.v3+json") // 깃허브 권장 헤더
+            .build()
+    }
+}

--- a/omos/src/main/resources/application.yaml
+++ b/omos/src/main/resources/application.yaml
@@ -15,3 +15,7 @@ spring:
       charset: UTF-8
       enabled: true
       force: true
+
+#깃허브 토큰
+github:
+  token: ${GITHUB_TOKEN}


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
깃허브 API를 활용하여 Repo에 해당하는 이슈들을 크롤링 해옵니다.

## 🔗 관련 이슈
- Close #56 

## 🛠️ 주요 변경 사항
- [x] `IssueController` 생성
- [x] Github 전용 `CreateIssueReq` DTO추가


## 🧐 리뷰어에게
특별히 확인을 요청하거나 고민되는 지점이 있다면 적어주세요.
아직 Repo가 구현이 안되어서 일단 DB에 저장된 Repo를 확인하고 그 Repo에 이름을 활용하여
깃허브 API로 이슈를 다 가져오는거로 해놨습니다 나중에는 태그로 Good first Issue 만 가져온다던지
로직을 바꾸겠습니다.