### PR TITLE
[#56][FEAT] 이슈 크롤링 추가

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+
+    // WebClient 사용
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 kotlin {

--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -46,10 +46,9 @@ dependencies {
 
 	runtimeOnly 'com.h2database:h2'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+    // WebClient 사용
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 
-  // WebClient 사용
-  implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
 	// Spring AI: GLM (OpenAI 호환 Chat)

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -1,0 +1,52 @@
+package com.back.omos.domain.issue.controller
+
+import com.back.omos.domain.issue.service.IssueService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 이슈 관련 외부 요청을 처리하는 REST 컨트롤러입니다.
+ * <p>
+ * 깃허브 오픈소스 이슈의 수집, 조회 및 추천 시스템과의 상호작용을 위한
+ * 진입점 역할을 수행하며, HTTP 요청을 서비스 계층으로 전달합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 해당 사항 없음
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code IssueController(IssueService issueService)} <br>
+ * 이슈 관련 비즈니스 로직을 처리하는 [IssueService]를 주입받아 초기화합니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * Spring Container에 의해 Singleton 빈으로 관리됩니다. (@RestController)
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Spring Web MVC를 사용하여 RESTful API 엔드포인트를 노출합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-23
+ * @see com.back.omos.domain.issue.service.IssueService
+ */
+@RestController
+@RequestMapping("/api/v1/issues")
+class IssueController(
+    private val issueService: IssueService
+) {
+
+    /**
+     * 특정 레포지토리 ID를 입력받아 깃허브 이슈를 크롤링하고 저장합니다.
+     */
+    @PostMapping("/crawl/{repoId}")
+    fun crawlIssues(@PathVariable repoId: Long): ResponseEntity<String> {
+        return try {
+            issueService.crawlAndSave(repoId)
+            ResponseEntity.ok("성공적으로 레포지토리($repoId)의 이슈를 수집했습니다.")
+        } catch (e: Exception) {
+            // 에러 발생 시 400 또는 500 에러와 함께 메시지 반환
+            ResponseEntity.badRequest().body("크롤링 실패: ${e.message}")
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -1,10 +1,15 @@
 package com.back.omos.domain.issue.controller
 
+import com.back.omos.domain.issue.dto.RecommendIssueRes
+import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.issue.service.IssueService
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -33,20 +38,39 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/issues")
 class IssueController(
-    private val issueService: IssueService
+    private val issueService: IssueService,
+    private val issueRepository: IssueRepository
 ) {
+    /**
+     * 현재 수집한 모든 이슈를 보여줍니다.
+     * 깃허브 API 동작 확인용으로 넣었습니다.
+     */
+    @GetMapping
+    fun getAllIssues(): ResponseEntity<List<Issue>> {
+        return ResponseEntity.ok(issueRepository.findAll())
+    }
 
     /**
-     * 특정 레포지토리 ID를 입력받아 깃허브 이슈를 크롤링하고 저장합니다.
+     * 특정 언어나 라벨 조건에 맞는 깃허브 이슈를 수집하고 수집된 목록을 반환합니다.
+     * <p>
+     * 수집된 데이터는 [RecommendIssueRes] 형태로 변환되어 클라이언트에 즉시 전달됩니다.
+     *
+     * @param q 깃허브 검색 쿼리 (예: language:kotlin state:open)
+     * @return 수집된 이슈 정보 리스트
+     * @author 유재원
      */
-    @PostMapping("/crawl/{repoId}")
-    fun crawlIssues(@PathVariable repoId: Long): ResponseEntity<String> {
+    @PostMapping("/crawl/search")
+    fun crawlBySearch(@RequestParam q: String): ResponseEntity<List<RecommendIssueRes>> {
         return try {
-            issueService.crawlAndSave(repoId)
-            ResponseEntity.ok("성공적으로 레포지토리($repoId)의 이슈를 수집했습니다.")
+            val savedIssues = issueService.crawlAndSaveByQuery(q)
+
+            // 엔티티 리스트를 DTO 리스트로 변환
+            val response = savedIssues.map { RecommendIssueRes.from(it) }
+
+            ResponseEntity.ok(response)
         } catch (e: Exception) {
-            // 에러 발생 시 400 또는 500 에러와 함께 메시지 반환
-            ResponseEntity.badRequest().body("크롤링 실패: ${e.message}")
+            //ToDO 에러처리 로직 추가
+            ResponseEntity.internalServerError().build()
         }
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/CreateIssueReq.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/CreateIssueReq.kt
@@ -18,7 +18,7 @@ import com.back.omos.domain.issue.entity.Issue
  * @since 2026-04-22
  */
 data class CreateIssueReq(
-    val repositoryId: Long,
+    val repoFullName: String,
     val issueNumber: Long,
     val title: String,
     val content: String? = null,
@@ -32,7 +32,7 @@ data class CreateIssueReq(
      */
     fun toEntity(): Issue {
         return Issue(
-            repositoryId = repositoryId,
+            repoFullName = repoFullName,
             issueNumber = issueNumber,
             title = title,
             content = content,

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/GithubIssueResponse.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/GithubIssueResponse.kt
@@ -28,31 +28,26 @@ import com.fasterxml.jackson.annotation.JsonProperty
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GithubIssueResponse(
-    // 깃허브 시스템 내부 고유 ID
     val id: Long,
-
-    // 우리가 흔히 보는 이슈 번호 (예: #102)
     val number: Long,
-
-    // 이슈 제목
     val title: String,
-
-    // 이슈 본문 (마크다운 형식, 내용이 없을 수 있어 Nullable 처리)
     val body: String?,
 
-    // 해당 이슈의 실제 깃허브 웹 주소
     @JsonProperty("html_url")
     val htmlUrl: String,
 
-    // 이슈에 달린 라벨 목록
+    /** * 이슈가 속한 레포지토리의 API URL입니다.
+     * 예: "https://api.github.com/repos/naver/fixture-monkey"
+     * 여기서 "naver/fixture-monkey"를 파싱하여 repoFullName으로 사용합니다.
+     */
+    @JsonProperty("repository_url")
+    val repositoryUrl: String,
+
     val labels: List<LabelResponse> = emptyList()
 ) {
-    /**
-     * 라벨 정보를 담는 내부 데이터 클래스
-     */
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class LabelResponse(
-        val name: String, // 라벨 이름 (예: "bug", "good first issue")
-        val color: String // 라벨 색상 코드
+        val name: String,
+        val color: String
     )
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/GithubIssueResponse.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/GithubIssueResponse.kt
@@ -1,0 +1,58 @@
+package com.back.omos.domain.issue.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GitHub API로부터 수집한 이슈 상세 정보를 담는 데이터 전송 객체(DTO)입니다.
+ * <p>
+ * GitHub REST API의 응답 JSON 데이터를 코틀린 객체로 역직렬화하며,
+ * 분석에 필요한 핵심 필드(제목, 본문, 라벨 등)만을 선택적으로 유지합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 해당 사항 없음 (Data Class)
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code GithubIssueResponse(id, number, title, body, htmlUrl, labels)} <br>
+ * GitHub 이슈의 식별자, 번호, 텍스트 데이터 및 메타데이터를 초기화합니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * 해당 객체는 빈으로 관리되지 않으며, 외부 API 호출 시 동적으로 생성됩니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Jackson 라이브러리를 사용하여 JSON 필드 매핑 및 무시 설정을 처리합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-24
+ * @see <a href="https://docs.github.com/en/rest/issues/issues">GitHub Issues API</a>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GithubIssueResponse(
+    // 깃허브 시스템 내부 고유 ID
+    val id: Long,
+
+    // 우리가 흔히 보는 이슈 번호 (예: #102)
+    val number: Long,
+
+    // 이슈 제목
+    val title: String,
+
+    // 이슈 본문 (마크다운 형식, 내용이 없을 수 있어 Nullable 처리)
+    val body: String?,
+
+    // 해당 이슈의 실제 깃허브 웹 주소
+    @JsonProperty("html_url")
+    val htmlUrl: String,
+
+    // 이슈에 달린 라벨 목록
+    val labels: List<LabelResponse> = emptyList()
+) {
+    /**
+     * 라벨 정보를 담는 내부 데이터 클래스
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class LabelResponse(
+        val name: String, // 라벨 이름 (예: "bug", "good first issue")
+        val color: String // 라벨 색상 코드
+    )
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/IssueInfoRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/IssueInfoRes.kt
@@ -21,7 +21,7 @@ import com.back.omos.domain.issue.entity.Issue
  */
 data class IssueInfoRes(
     val id: Long,
-    val repositoryId: Long,
+    val repoFullName: String,
     val issueNumber: Long,
     val title: String,
     val content: String?,
@@ -38,7 +38,7 @@ data class IssueInfoRes(
         fun from(issue: Issue): IssueInfoRes {
             return IssueInfoRes(
                 id = issue.id!!,
-                repositoryId = issue.repositoryId,
+                repoFullName = issue.repoFullName,
                 issueNumber = issue.issueNumber,
                 title = issue.title,
                 content = issue.content,

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/RecommendIssueReq.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/RecommendIssueReq.kt
@@ -15,6 +15,6 @@ package com.back.omos.domain.issue.dto
  */
 data class RecommendIssueReq(
     val userId: Long,
-    val repositoryId: Long,
+    val repoFullName: String,
     val limit: Int = 5
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/RecommendIssueRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/RecommendIssueRes.kt
@@ -1,5 +1,7 @@
 package com.back.omos.domain.issue.dto
 
+import com.back.omos.domain.issue.entity.Issue
+
 /**
  * 추천된 이슈 정보를 응답으로 전달하는 DTO입니다.
  *
@@ -20,11 +22,26 @@ package com.back.omos.domain.issue.dto
  */
 data class RecommendIssueRes(
     val id: Long,
-    val repositoryId : Long,
+    val repoFullName: String,
     val issueNumber: Long,
     val title: String,
     val summary: String,
     val score: Float,
     val labels: List<String>?,
-    val status: String  // "OPEN" or "CLOSED"
-)
+    val status: String
+) {
+    companion object {
+        fun from(issue: Issue): RecommendIssueRes {
+            return RecommendIssueRes(
+                id = issue.id ?: 0L,
+                repoFullName = issue.repoFullName,
+                issueNumber = issue.issueNumber,
+                title = issue.title,
+                summary = issue.content?.take(100) ?: "요약 정보 없음", // 임시 요약
+                score = 0.0f, // 수집 단계이므로 기본값
+                labels = issue.labels,
+                status = issue.status.name
+            )
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/entity/Issue.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/entity/Issue.kt
@@ -26,13 +26,10 @@ import org.hibernate.type.SqlTypes
 class Issue(
 
     /**
-     * 이 이슈가 속한 레포지토리의 고유 식별자(ID)입니다.
-     *
-     * 데이터베이스 상에서 외래 키(FK) 역할을 하며, 객체 참조 대신 ID 값만 유지하여
-     * 도메인 간의 결합도를 낮추는 구조로 설계되었습니다.
+     * 이 이슈가 속한 레포지토리의 full name
      */
-    @Column(name = "repository_id", nullable = false)
-    var repositoryId: Long,
+    @Column(name = "repo_full_name", nullable = false)
+    var repoFullName: String,
 
     /**
      * 레포지토리 내에서 해당 이슈를 식별하는 고유 번호입니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/github/GithubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/github/GithubClient.kt
@@ -1,24 +1,23 @@
-package com.back.omos.domain.issue.service
+package com.back.omos.domain.issue.github
 
 import com.back.omos.domain.issue.dto.GithubIssueResponse
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
-import kotlin.jvm.java
 
 /**
  * GitHub REST API와 직접 통신하여 리포지토리 데이터를 수집하는 클라이언트 클래스입니다.
  * <p>
- * 비차단(Non-blocking) I/O 모델인 [WebClient]를 사용하여 GitHub 서버에 HTTP 요청을 전송하며,
- * 전달받은 JSON 응답을 [GithubIssueResponse] DTO 리스트로 변환하는 역할을 수행합니다.
+ * 비차단(Non-blocking) I/O 모델인 [org.springframework.web.reactive.function.client.WebClient]를 사용하여 GitHub 서버에 HTTP 요청을 전송하며,
+ * 전달받은 JSON 응답을 [com.back.omos.domain.issue.dto.GithubIssueResponse] DTO 리스트로 변환하는 역할을 수행합니다.
  *
  * <p><b>상속 정보:</b><br>
  * 해당 사항 없음
  *
  * <p><b>주요 생성자:</b><br>
  * {@code GithubClient(webClient, token)} <br>
- * HTTP 요청을 위한 [WebClient]와 GitHub API 호출 시 인증에 필요한 Personal Access Token을 주입받습니다.
+ * HTTP 요청을 위한 [org.springframework.web.reactive.function.client.WebClient]와 GitHub API 호출 시 인증에 필요한 Personal Access Token을 주입받습니다.
  *
  * <p><b>빈 관리:</b><br>
  * Spring Container에 의해 Singleton 빈으로 관리됩니다. (@Component)
@@ -42,11 +41,14 @@ class GithubClient(
 
     // GithubClient 내부
     fun searchIssues(query: String): List<GithubIssueResponse> {
+        // 쿼리에 is:issue is:open추가 , pr오는걸 방지 + open된 이슈만 가져오게
+        val normalizedQuery = "$query is:issue is:open"
+
         return webClient.get()
             .uri { uriBuilder ->
                 uriBuilder
                     .path("/search/issues")
-                    .queryParam("q", query)
+                    .queryParam("q", normalizedQuery)
                     .queryParam("per_page", 10)
                     .build()
             }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/repository/IssueRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/repository/IssueRepository.kt
@@ -15,7 +15,13 @@ import org.springframework.data.jpa.repository.JpaRepository
  */
 interface IssueRepository : JpaRepository<Issue, Long> {
     /**
-     * repositoryId와 issueNumber로 존재하는지 확인
+     * 특정 레포지토리와 이슈 번호로 존재 여부 확인
      */
-    fun existsByRepositoryIdAndIssueNumber(repositoryId : Long, issueNumber: Long) : Boolean
+    fun existsByRepoFullNameAndIssueNumber(repoFullName: String, issueNumber: Long): Boolean
+
+    /**
+     * 특정 레포지토리와 이슈 번호로 단일 이슈 조회
+     * 결과가 없을 수 있으므로 반환 타입을 Issue? (Nullable)로 설정합니다.
+     */
+    fun findByRepoFullNameAndIssueNumber(repoFullName: String, issueNumber: Long): Issue?
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/GithubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/GithubClient.kt
@@ -1,6 +1,7 @@
 package com.back.omos.domain.issue.service
 
 import com.back.omos.domain.issue.dto.GithubIssueResponse
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -34,19 +35,25 @@ class GithubClient(
     private val webClient: WebClient,
     @Value("\${github.token}") private val token: String
 ) {
-    fun fetchIssues(owner: String, repo: String): List<GithubIssueResponse> {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class GithubSearchResponse(
+        val items: List<GithubIssueResponse>
+    )
+
+    // GithubClient 내부
+    fun searchIssues(query: String): List<GithubIssueResponse> {
         return webClient.get()
             .uri { uriBuilder ->
                 uriBuilder
-                    .path("/repos/$owner/$repo/issues")
-                    .queryParam("state", "open")
-                    .queryParam("per_page", 1) // 현재 테스트용으로 1개 설정
+                    .path("/search/issues")
+                    .queryParam("q", query)
+                    .queryParam("per_page", 10)
                     .build()
             }
             .header("Authorization", "Bearer $token")
             .retrieve()
-            .bodyToFlux(GithubIssueResponse::class.java)
-            .collectList()
+            .bodyToMono(GithubSearchResponse::class.java) // 래퍼 클래스로 한 번에 받기
+            .map { it.items }
             .block() ?: emptyList()
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/GithubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/GithubClient.kt
@@ -1,0 +1,52 @@
+package com.back.omos.domain.issue.service
+
+import com.back.omos.domain.issue.dto.GithubIssueResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import kotlin.jvm.java
+
+/**
+ * GitHub REST API와 직접 통신하여 리포지토리 데이터를 수집하는 클라이언트 클래스입니다.
+ * <p>
+ * 비차단(Non-blocking) I/O 모델인 [WebClient]를 사용하여 GitHub 서버에 HTTP 요청을 전송하며,
+ * 전달받은 JSON 응답을 [GithubIssueResponse] DTO 리스트로 변환하는 역할을 수행합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 해당 사항 없음
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code GithubClient(webClient, token)} <br>
+ * HTTP 요청을 위한 [WebClient]와 GitHub API 호출 시 인증에 필요한 Personal Access Token을 주입받습니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * Spring Container에 의해 Singleton 빈으로 관리됩니다. (@Component)
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Spring WebFlux의 WebClient를 사용하여 비동기 통신 아키텍처를 구성합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-24
+ * @see <a href="https://docs.github.com/en/rest">GitHub REST API Documentation</a>
+ */
+@Component
+class GithubClient(
+    private val webClient: WebClient,
+    @Value("\${github.token}") private val token: String
+) {
+    fun fetchIssues(owner: String, repo: String): List<GithubIssueResponse> {
+        return webClient.get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/repos/$owner/$repo/issues")
+                    .queryParam("state", "open")
+                    .queryParam("per_page", 1) // 현재 테스트용으로 1개 설정
+                    .build()
+            }
+            .header("Authorization", "Bearer $token")
+            .retrieve()
+            .bodyToFlux(GithubIssueResponse::class.java)
+            .collectList()
+            .block() ?: emptyList()
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
@@ -56,4 +56,19 @@ interface IssueService {
      * @return 추천된 이슈 목록
      */
     fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes>
+
+    /**
+     * 지정된 레포지토리의 GitHub 이슈를 수집하고 벡터 임베딩을 생성하여 저장합니다.
+     *
+     * GitHub REST API를 호출하여 최신 이슈 데이터를 가져오며,
+     * 수집된 텍스트 데이터(제목, 본문)는 AI 모델을 통해 고차원 벡터로 변환됩니다.
+     * * [설계 특징]
+     * 1. 도메인 간 결합도를 낮추기 위해 객체 참조 대신 [repoId]를 직접 저장합니다.
+     * 2. 중복 수집 방지를 위해 기존에 저장된 이슈 번호([issueNumber])와 비교 로직이 포함될 수 있습니다.
+     * 3. 저장된 벡터 데이터는 추후 [recommendIssues]에서 유사도 기반 추천에 활용됩니다.
+     *
+     * @param repoId 이슈를 수집할 대상 레포지토리의 고유 식별자(ID)
+     * @throws IllegalArgumentException 존재하지 않는 [repoId]이거나 API 호출에 실패한 경우 발생
+     */
+    fun crawlAndSave(repoId: Long)
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
@@ -4,6 +4,7 @@ import com.back.omos.domain.issue.dto.CreateIssueReq
 import com.back.omos.domain.issue.dto.IssueInfoRes
 import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.dto.UpdateIssueReq
+import com.back.omos.domain.issue.entity.Issue
 
 /**
  * 이슈 관련 비즈니스 로직을 처리하는 서비스 인터페이스입니다.
@@ -58,17 +59,8 @@ interface IssueService {
     fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes>
 
     /**
-     * 지정된 레포지토리의 GitHub 이슈를 수집하고 벡터 임베딩을 생성하여 저장합니다.
-     *
-     * GitHub REST API를 호출하여 최신 이슈 데이터를 가져오며,
-     * 수집된 텍스트 데이터(제목, 본문)는 AI 모델을 통해 고차원 벡터로 변환됩니다.
-     * * [설계 특징]
-     * 1. 도메인 간 결합도를 낮추기 위해 객체 참조 대신 [repoId]를 직접 저장합니다.
-     * 2. 중복 수집 방지를 위해 기존에 저장된 이슈 번호([issueNumber])와 비교 로직이 포함될 수 있습니다.
-     * 3. 저장된 벡터 데이터는 추후 [recommendIssues]에서 유사도 기반 추천에 활용됩니다.
-     *
-     * @param repoId 이슈를 수집할 대상 레포지토리의 고유 식별자(ID)
-     * @throws IllegalArgumentException 존재하지 않는 [repoId]이거나 API 호출에 실패한 경우 발생
+     * 검색 쿼리를 기반으로 이슈를 전역적으로 수집하고 저장합니다.
+     * @param query 예: "language:kotlin state:open label:\"good first issue\""
      */
-    fun crawlAndSave(repoId: Long)
+    fun crawlAndSaveByQuery(query: String): List<Issue>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
@@ -6,8 +6,11 @@ import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.dto.UpdateIssueReq
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.repo.repository.RepoRepository
 import com.back.omos.global.exception.errorCode.IssueErrorCode
+import com.back.omos.global.exception.errorCode.RepoErrorCode
 import com.back.omos.global.exception.exceptions.IssueException
+import com.back.omos.global.exception.exceptions.RepoException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -20,7 +23,9 @@ import org.springframework.transaction.annotation.Transactional
  */
 @Service
 class IssueServiceImpl(
-    private val issueRepository: IssueRepository
+    private val issueRepository: IssueRepository,
+    private val githubClient: GithubClient,
+    private val repoRepository: RepoRepository,
 ) : IssueService {
 
     @Transactional
@@ -62,6 +67,36 @@ class IssueServiceImpl(
 
     override fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes> {
         TODO("추천 로직 구현 필요")
+    }
+
+    @Transactional
+    override fun crawlAndSave(repoId: Long) {
+        // 1. 레포지토리 이름(fullName)을 알아내기 위해 DB 조회
+        val repo = repoRepository.findByIdOrNull(repoId)
+            ?: throw RepoException(RepoErrorCode.REPO_NOT_FOUND, "해당 레포지토리가 존재하지 않습니다. ID: $repoId")
+
+        // "owner/repo" 문자열 분리
+        val (owner, repoName) = repo.fullName.split("/").let {
+            if (it.size < 2) throw RepoException(RepoErrorCode.REPO_NOT_FOUND, "해당 레포지토리의 이름이 잘못되었습니다. ID: $repoId")
+            it[0] to it[1]
+        }
+
+        // 2. GitHub API를 통해 이슈 목록 가져오기
+        val githubIssues = githubClient.fetchIssues(owner, repoName)
+
+        // 3. DTO를 엔티티로 변환하여 저장
+        githubIssues.forEach { dto ->
+            val issue = Issue(
+                repositoryId = repoId,
+                issueNumber = dto.number,
+                title = dto.title,
+                content = dto.body,
+                labels = dto.labels.map { it.name },
+                status = Issue.IssueStatus.OPEN,
+                issueVector = null // TODO : 임베딩은 추후에 구현 아직 Spring AI 도입 안됐음
+            )
+            issueRepository.save(issue)
+        }
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
@@ -30,7 +30,7 @@ class IssueServiceImpl(
 
     @Transactional
     override fun createIssue(request: CreateIssueReq): IssueInfoRes {
-        if(issueRepository.existsByRepositoryIdAndIssueNumber(request.repositoryId, request.issueNumber)){
+        if(issueRepository.existsByRepoFullNameAndIssueNumber(request.repoFullName, request.issueNumber)){
             throw IssueException(IssueErrorCode.ISSUE_ALREADY_EXIST)
         }
 
@@ -69,33 +69,26 @@ class IssueServiceImpl(
         TODO("추천 로직 구현 필요")
     }
 
+
     @Transactional
-    override fun crawlAndSave(repoId: Long) {
-        // 1. 레포지토리 이름(fullName)을 알아내기 위해 DB 조회
-        val repo = repoRepository.findByIdOrNull(repoId)
-            ?: throw RepoException(RepoErrorCode.REPO_NOT_FOUND, "해당 레포지토리가 존재하지 않습니다. ID: $repoId")
+    override fun crawlAndSaveByQuery(query: String): List<Issue> {
+        val githubIssues = githubClient.searchIssues(query)
 
-        // "owner/repo" 문자열 분리
-        val (owner, repoName) = repo.fullName.split("/").let {
-            if (it.size < 2) throw RepoException(RepoErrorCode.REPO_NOT_FOUND, "해당 레포지토리의 이름이 잘못되었습니다. ID: $repoId")
-            it[0] to it[1]
-        }
+        return githubIssues.map { dto ->
+            val fullName = dto.repositoryUrl.substringAfter("repos/")
 
-        // 2. GitHub API를 통해 이슈 목록 가져오기
-        val githubIssues = githubClient.fetchIssues(owner, repoName)
-
-        // 3. DTO를 엔티티로 변환하여 저장
-        githubIssues.forEach { dto ->
-            val issue = Issue(
-                repositoryId = repoId,
-                issueNumber = dto.number,
-                title = dto.title,
-                content = dto.body,
-                labels = dto.labels.map { it.name },
-                status = Issue.IssueStatus.OPEN,
-                issueVector = null // TODO : 임베딩은 추후에 구현 아직 Spring AI 도입 안됐음
-            )
-            issueRepository.save(issue)
+            // 1. 이미 있으면 가져오고, 없으면 새로 생성해서 저장
+            issueRepository.findByRepoFullNameAndIssueNumber(fullName, dto.number)
+                ?: issueRepository.save(
+                    Issue(
+                        repoFullName = fullName,
+                        issueNumber = dto.number,
+                        title = dto.title,
+                        content = dto.body,
+                        labels = dto.labels.map { it.name },
+                        status = Issue.IssueStatus.OPEN
+                    )
+                )
         }
     }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
@@ -5,12 +5,11 @@ import com.back.omos.domain.issue.dto.IssueInfoRes
 import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.dto.UpdateIssueReq
 import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.github.GithubClient
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.repo.repository.RepoRepository
 import com.back.omos.global.exception.errorCode.IssueErrorCode
-import com.back.omos.global.exception.errorCode.RepoErrorCode
 import com.back.omos.global.exception.exceptions.IssueException
-import com.back.omos.global.exception.exceptions.RepoException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/omos/src/main/kotlin/com/back/omos/global/config/WebClientConfig.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/config/WebClientConfig.kt
@@ -1,0 +1,26 @@
+package com.back.omos.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * WebClient 설정을 담당하는 클래스입니다.
+ *  @author 유재원
+ *  @since 2026-04-24
+ *  @see
+ */
+@Configuration
+class WebClientConfig {
+
+    /**
+     * 공통으로 사용할 WebClient 빈을 등록합니다.
+     */
+    @Bean
+    fun webClient(): WebClient {
+        return WebClient.builder()
+            .baseUrl("https://api.github.com") // 기본 주소 설정
+            .defaultHeader("Accept", "application/vnd.github.v3+json") // 깃허브 권장 헤더
+            .build()
+    }
+}

--- a/omos/src/main/resources/application.yaml
+++ b/omos/src/main/resources/application.yaml
@@ -15,3 +15,7 @@ spring:
       charset: UTF-8
       enabled: true
       force: true
+
+#깃허브 토큰
+github:
+  token: ${GITHUB_TOKEN}


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
좀 바뀐 내용이 많습니다. 이슈 엔티티에 Repository_id를 저장하지 않고 repoFullName으로 레포지토리 이름을 저장합니다.
그거에 맞춰서 DTO와Repository 를 변경하고 `IssueService`에서는 `GithubClient`의 깃허브API 기능을 사용하여
특정 쿼리에 맞는 이슈들을 크롤링 해서 받아와서 저장합니다.
AI를 활용한 벡터계산후 유사도 판단은 나중에 추가될 예정입니다.


## 🔗 관련 이슈
- Close #56 

## 🛠️ 주요 변경 사항
- [x] `domain/issue` 의 코드들

