### PR TITLE
[#66][Feat] Pr draft AI 연동, DB에 저장

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -46,13 +46,11 @@ dependencies {
 
 	runtimeOnly 'com.h2database:h2'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
-
 	// Spring AI: GLM (OpenAI 호환 Chat)
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'io.github.microutils:kotlin-logging-jvm:3.0.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 kotlin {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiClient.kt
@@ -9,7 +9,7 @@ package com.back.omos.domain.prdraft.ai
  * </p>
  *
  * <p>
- * 지금은 Mock 구현체로 테스트할 수 있고습니다.
+ * 지금은 Mock 구현체로 테스트할 수 있습니다.
  * 이후 실제 OpenAI 연동 구현체로 교체할 수 있도록 확장성을 고려한 구조입니다.
  * </p>
  *

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/MockAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/MockAiClient.kt
@@ -1,5 +1,7 @@
 package com.back.omos.domain.prdraft.ai
 
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 /**
@@ -15,6 +17,8 @@ import org.springframework.stereotype.Component
  * @since 2026-04-22
  */
 @Component
+@Profile("test")
+@Primary
 class MockAiClient : AiClient {
 
     override fun generatePrDraft(prompt: String): AiPrResult {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -67,6 +67,7 @@ class SpringAiClient(
     private fun extractJson(response: String): String? {
         val fenceMatch = Regex("""```(?:json)?\s*([\s\S]*?)```""").find(response)
         if (fenceMatch != null) return fenceMatch.groupValues[1].trim()
-        return Regex("""\{[\s\S]*\}""").find(response)?.value
+        val candidate = Regex("""\{[\s\S]*?\}""").find(response)?.value ?: return null
+        return runCatching { objectMapper.readTree(candidate); candidate }.getOrNull()
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KotlinLogging
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.stereotype.Component
+import java.security.MessageDigest
 
 /**
  * Spring AI를 사용하여 GLM 모델을 호출하는 실제 AI 구현체입니다.
@@ -41,16 +42,26 @@ class SpringAiClient(
     private fun parseResponse(response: String): AiPrResult {
         val json = extractJson(response)
             ?: run {
-                logger.warn { "AI 응답에서 JSON을 찾을 수 없습니다: $response" }
-                throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED, response)
+                val safe = safeLog(response)
+                logger.warn { "AI 응답에서 JSON을 찾을 수 없습니다 ($safe)" }
+                throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED, safe)
             }
 
         return try {
             objectMapper.readValue(json, AiPrResult::class.java)
         } catch (e: Exception) {
-            logger.warn { "AI 응답 JSON 파싱 실패: $json" }
-            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED, json)
+            val safe = safeLog(json)
+            logger.warn { "AI 응답 JSON 파싱 실패 ($safe)" }
+            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED, safe)
         }
+    }
+
+    private fun safeLog(value: String): String {
+        val hash = MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+            .take(16)
+        return "len=${value.length}, sha256=$hash"
     }
 
     private fun extractJson(response: String): String? {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -1,0 +1,60 @@
+package com.back.omos.domain.prdraft.ai
+
+import com.back.omos.global.exception.errorCode.AiErrorCode
+import com.back.omos.global.exception.exceptions.AiException
+import com.fasterxml.jackson.databind.ObjectMapper
+import mu.KotlinLogging
+import org.springframework.ai.chat.model.ChatModel
+import org.springframework.stereotype.Component
+
+/**
+ * Spring AI를 사용하여 GLM 모델을 호출하는 실제 AI 구현체입니다.
+ *
+ * <p>
+ * 프롬프트를 GLM에 전달하고, JSON 형식으로 반환된 응답을 파싱하여
+ * PR 제목과 본문을 추출합니다.
+ *
+ * <p><b>응답 파싱:</b><br>
+ * AI 응답에 마크다운 코드 블록이 포함될 수 있어,
+ * 정규식으로 JSON 객체를 추출한 뒤 역직렬화합니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-24
+ * @see AiClient
+ */
+@Component
+class SpringAiClient(
+    private val chatModel: ChatModel,
+    private val objectMapper: ObjectMapper
+) : AiClient {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun generatePrDraft(prompt: String): AiPrResult {
+        val response = chatModel.call(prompt)
+            .takeIf { it.isNotBlank() }
+            ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+
+        return parseResponse(response)
+    }
+
+    private fun parseResponse(response: String): AiPrResult {
+        val json = extractJson(response)
+            ?: run {
+                logger.warn { "AI 응답에서 JSON을 찾을 수 없습니다: $response" }
+                throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED, response)
+            }
+
+        return try {
+            objectMapper.readValue(json, AiPrResult::class.java)
+        } catch (e: Exception) {
+            logger.warn { "AI 응답 JSON 파싱 실패: $json" }
+            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED, json)
+        }
+    }
+
+    // AI 응답에서 JSON 객체 부분만 추출 (마크다운 코드블록 등 감싸진 경우 대응)
+    private fun extractJson(response: String): String? {
+        return Regex("""\{[\s\S]*\}""").find(response)?.value
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -53,8 +53,9 @@ class SpringAiClient(
         }
     }
 
-    // AI 응답에서 JSON 객체 부분만 추출 (마크다운 코드블록 등 감싸진 경우 대응)
     private fun extractJson(response: String): String? {
+        val fenceMatch = Regex("""```(?:json)?\s*([\s\S]*?)```""").find(response)
+        if (fenceMatch != null) return fenceMatch.groupValues[1].trim()
         return Regex("""\{[\s\S]*\}""").find(response)?.value
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -3,8 +3,10 @@ package com.back.omos.domain.prdraft.controller
 import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.service.PrDraftService
+import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
 import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,8 +33,11 @@ class PrDraftController(
     private val prDraftService: PrDraftService
 ) {
     @PostMapping
-    fun create(@Valid @RequestBody req: CreatePrReq): CommonResponse<PrInfoRes> {
-        return CommonResponse.success(prDraftService.create(req))
+    fun create(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
+        @Valid @RequestBody req: CreatePrReq
+    ): CommonResponse<PrInfoRes> {
+        return CommonResponse.success(prDraftService.create(principal.githubId, req))
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -3,8 +3,8 @@ package com.back.omos.domain.prdraft.controller
 import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.service.PrDraftService
+import com.back.omos.global.response.CommonResponse
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,8 +31,8 @@ class PrDraftController(
     private val prDraftService: PrDraftService
 ) {
     @PostMapping
-    fun create(@Valid @RequestBody req: CreatePrReq): PrInfoRes {
-        return prDraftService.create(req)
+    fun create(@Valid @RequestBody req: CreatePrReq): CommonResponse<PrInfoRes> {
+        return CommonResponse.success(prDraftService.create(req))
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrInfoRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrInfoRes.kt
@@ -4,12 +4,18 @@ package com.back.omos.domain.prdraft.dto
  * 생성된 PR 정보를 응답으로 전달하는 DTO입니다.
  *
  * <p>
- * AI를 통해 생성된 PR 제목과 본문을 포함합니다.
+ * AI를 통해 생성된 PR 제목과 본문, 그리고 GitHub PR 생성 페이지 URL을 포함합니다.
+ * githubUrl을 통해 제목과 본문이 미리 채워진 GitHub PR 작성 창으로 바로 이동할 수 있습니다.
+ *
+ * @property title AI가 생성한 PR 제목
+ * @property body AI가 생성한 PR 본문
+ * @property githubUrl 제목과 본문이 pre-fill된 GitHub PR 생성 URL
  *
  * @author 5h6vm
  * @since 2026-04-22
  */
 data class PrInfoRes(
     val title: String,
-    val body: String
+    val body: String,
+    val githubUrl: String
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.Lob
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
@@ -50,7 +49,6 @@ class PrDraft(
      *
      * 파일 변경 내역, 추가/삭제된 코드 등을 포함하며 PR 본문 생성의 입력 데이터로 사용됩니다.
      */
-    @Lob
     @Column(name = "diff_content", nullable = false, columnDefinition = "TEXT")
     var diffContent: String,
 
@@ -67,7 +65,6 @@ class PrDraft(
      *
      * diff 내용을 기반으로 AI가 생성한 설명(변경 사항, 테스트 방법 등)을 포함합니다.
      */
-    @Lob
     @Column(name = "pr_body", nullable = false, columnDefinition = "TEXT")
     var prBody: String
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -16,5 +16,5 @@ import com.back.omos.domain.prdraft.dto.PrInfoRes
  * @since 2026-04-22
  */
 interface PrDraftService {
-    fun create(request: CreatePrReq): PrInfoRes
+    fun create(githubId: String, request: CreatePrReq): PrInfoRes
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -4,11 +4,15 @@ import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.ai.AiClient
+import com.back.omos.domain.prdraft.entity.PrDraft
 import com.back.omos.domain.prdraft.github.GitHubClient
 import com.back.omos.domain.prdraft.repository.PrDraftRepository
 import com.back.omos.domain.repo.repository.RepoRepository
+import com.back.omos.domain.user.repository.UserRepository
+import com.back.omos.global.exception.errorCode.AuthErrorCode
 import com.back.omos.global.exception.errorCode.IssueErrorCode
 import com.back.omos.global.exception.errorCode.RepoErrorCode
+import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.RepoException
 import org.springframework.stereotype.Service
@@ -35,6 +39,7 @@ import java.nio.charset.StandardCharsets
 @Service
 class PrDraftServiceImpl(
     private val prDraftRepository: PrDraftRepository,
+    private val userRepository: UserRepository,
     private val issueRepository: IssueRepository,
     private val repoRepository: RepoRepository,
     private val prDraftPromptBuilder: PrDraftPromptBuilder,
@@ -42,8 +47,10 @@ class PrDraftServiceImpl(
     private val gitHubClient: GitHubClient
 ) : PrDraftService {
 
-    override fun create(request: CreatePrReq): PrInfoRes {
-        // 이슈, 레포 조회
+    override fun create(githubId: String, request: CreatePrReq): PrInfoRes {
+        // 정보 조회
+        val user = userRepository.findByGithubId(githubId)
+            .orElseThrow { AuthException(AuthErrorCode.USER_NOT_FOUND) }
         val issue = issueRepository.findById(request.issueId)
             .orElseThrow { IssueException(IssueErrorCode.ISSUE_NOT_FOUND) }
         val repo = repoRepository.findById(request.repositoryId)
@@ -60,6 +67,14 @@ class PrDraftServiceImpl(
         val aiResult = aiClient.generatePrDraft(prompt)
 
         val githubUrl = buildGithubUrl(repo.fullName, aiResult.title, aiResult.body)
+
+        prDraftRepository.save(PrDraft(
+            user = user,
+            issue = issue,
+            diffContent = request.diffContent,
+            prTitle = aiResult.title,
+            prBody = aiResult.body
+        ))
 
         return PrInfoRes(
             title = aiResult.title,

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -13,6 +13,8 @@ import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.RepoException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.stereotype.Service
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 /**
  * PR 생성 기능의 구현체입니다.
@@ -59,9 +61,18 @@ class PrDraftServiceImpl(
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)
 
+        val githubUrl = buildGithubUrl(repo.fullName, aiResult.title, aiResult.body)
+
         return PrInfoRes(
             title = aiResult.title,
-            body = aiResult.body
+            body = aiResult.body,
+            githubUrl = githubUrl
         )
+    }
+
+    private fun buildGithubUrl(fullName: String, title: String, body: String): String {
+        val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8)
+        val encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8)
+        return "https://github.com/$fullName/compare?quick_pull=1&title=$encodedTitle&body=$encodedBody"
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -11,7 +11,6 @@ import com.back.omos.global.exception.errorCode.IssueErrorCode
 import com.back.omos.global.exception.errorCode.RepoErrorCode
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.RepoException
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.stereotype.Service
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -43,7 +42,6 @@ class PrDraftServiceImpl(
     private val gitHubClient: GitHubClient
 ) : PrDraftService {
 
-    @Transactional
     override fun create(request: CreatePrReq): PrInfoRes {
         // 이슈, 레포 조회
         val issue = issueRepository.findById(request.issueId)
@@ -71,8 +69,8 @@ class PrDraftServiceImpl(
     }
 
     private fun buildGithubUrl(fullName: String, title: String, body: String): String {
-        val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8)
-        val encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8)
+        val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8).replace("+", "%20")
+        val encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8).replace("+", "%20")
         return "https://github.com/$fullName/compare?quick_pull=1&title=$encodedTitle&body=$encodedBody"
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/global/config/SwaggerConfig.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/config/SwaggerConfig.kt
@@ -1,0 +1,29 @@
+package com.back.omos.global.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        val securitySchemeName = "Bearer Authentication"
+        return OpenAPI()
+            .addSecurityItem(SecurityRequirement().addList(securitySchemeName))
+            .components(
+                Components().addSecuritySchemes(
+                    securitySchemeName,
+                    SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                )
+            )
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AiErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AiErrorCode.kt
@@ -1,0 +1,17 @@
+package com.back.omos.global.exception.errorCode
+
+import org.springframework.http.HttpStatus
+
+/**
+ * AI 호출 및 응답 처리 과정에서 발생하는 에러 코드입니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-24
+ */
+enum class AiErrorCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+) : ErrorCode {
+    AI_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답이 비어 있습니다."),
+    AI_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답을 파싱하는 데 실패했습니다."),
+}

--- a/omos/src/main/kotlin/com/back/omos/global/exception/exceptions/AiException.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/exceptions/AiException.kt
@@ -1,0 +1,21 @@
+package com.back.omos.global.exception.exceptions
+
+import com.back.omos.global.exception.errorCode.AiErrorCode
+
+/**
+ * AI 호출 및 응답 처리 과정에서 발생하는 예외입니다.
+ *
+ * <p>{@link AiErrorCode} 의 값과 (optional) 내부 로그 메시지를 담습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link BaseException} 의 구현 클래스입니다.
+ *
+ * @author 5h6vm
+ * @see AiErrorCode
+ * @see BaseException
+ * @since 2026-04-24
+ */
+class AiException : BaseException {
+    constructor(errorCode: AiErrorCode) : super(errorCode)
+    constructor(errorCode: AiErrorCode, logMessage: String) : super(errorCode, logMessage)
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
@@ -7,8 +7,8 @@ import java.io.File
 
 class GitHubClientImplTest {
 
-    private val token = File(".env").readLines()
-        .firstOrNull { it.startsWith("GITHUB_TOKEN=") }
+    private val token = File(".env").takeIf { it.exists() }?.readLines()
+        ?.firstOrNull { it.startsWith("GITHUB_TOKEN=") }
         ?.removePrefix("GITHUB_TOKEN=")
         ?.trim()
         ?: System.getenv("GITHUB_TOKEN")


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
MockAi에서 실제 GLM을 사용하여 AI 연동
생성된 내용 db에 save

## 🔗 관련 이슈
- Close #66 

## 🛠️ 주요 변경 사항
- [ ] SpringAiClient 구현 — GLM 모델 호출 및 JSON 응답 파싱 (마크다운 코드펜스 대응 포함) 
- [ ] MockAI -> test 사용 SpringAI -> 실제 사용
- [ ] github url필드 추가 (PR 생성 페이지 pre-fill)
- [ ] Swagger config -> 인증 설정 추가

## 🧪 테스트 결과
<img width="798" height="381" alt="스크린샷 2026-04-27 103220" src="https://github.com/user-attachments/assets/2518ea99-600d-4521-92fc-f821d43406c1" />


## 🧐 리뷰어에게
`feat/pr-create`로 merge 됩니다.
자잘한 수정도 조금 있어서 `ai error 구현` , `SpringAiClient구현` `db에 저장` 정도만 봐주셔도 됩니다.