### PR TITLE
[Feat] GLM API 연동 (코드 수정 가이드 생성)

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'com.pgvector:pgvector:0.1.6'

--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.jetbrains.kotlin.jvm' version '2.2.21'
 	id 'org.jetbrains.kotlin.plugin.spring' version '2.2.21'
 	id 'org.jetbrains.kotlin.plugin.jpa' version '2.2.21'
-	id 'org.springframework.boot' version '4.0.5'
+	id 'org.springframework.boot' version '3.5.14'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -19,18 +19,23 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:1.1.4"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'tools.jackson.module:jackson-module-kotlin'
+	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
@@ -41,7 +46,13 @@ dependencies {
 
 	runtimeOnly 'com.h2database:h2'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+	// WebClient 사용
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+	// Spring AI: GLM (OpenAI 호환 Chat)
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 }
 
 kotlin {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmAnalysisRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmAnalysisRes.kt
@@ -1,0 +1,13 @@
+package com.back.omos.domain.analysis.ai
+
+/**
+ * GLM API 분석 결과를 담는 DTO입니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-25
+ */
+data class GlmAnalysisRes(
+    val guideline: String,
+    val pseudoCode: String,
+    val sideEffects: String
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClient.kt
@@ -1,0 +1,30 @@
+package com.back.omos.domain.analysis.ai
+
+/**
+ * GLM API 호출 기능을 추상화한 인터페이스입니다.
+ *
+ * <p>
+ * 서비스 계층은 이 인터페이스를 통해 GLM API를 호출하여
+ * 이슈에 대한 코드 수정 가이드를 생성합니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-25
+ */
+interface GlmClient {
+
+    /**
+     * 이슈 정보와 관련 소스코드를 기반으로 코드 수정 가이드를 생성합니다.
+     *
+     * @param issueTitle 이슈 제목
+     * @param issueBody 이슈 본문
+     * @param labels 이슈 라벨 목록
+     * @param fileContents 관련 파일 경로 → 파일 내용 Map
+     * @return GLM이 생성한 분석 결과
+     */
+    fun analyze(
+        issueTitle: String,
+        issueBody: String?,
+        labels: List<String>,
+        fileContents: Map<String, String>
+    ): GlmAnalysisRes
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
@@ -1,0 +1,130 @@
+package com.back.omos.domain.analysis.ai
+
+import com.back.omos.global.exception.errorCode.AnalysisErrorCode
+import com.back.omos.global.exception.exceptions.AnalysisException
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+
+/**
+ * Spring AI ChatClient를 통해 GLM API를 호출하는 구현체입니다.
+ *
+ * <p>
+ * 이슈 정보와 관련 소스코드를 프롬프트로 구성하여 GLM API에 전달하고,
+ * JSON 형태의 응답을 파싱하여 GlmAnalysisRes로 반환합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link GlmClient}를 구현합니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-25
+ * @see GlmClient
+ */
+@Component
+class GlmClientImpl(
+    chatClientBuilder: ChatClient.Builder,
+    private val objectMapper: ObjectMapper
+) : GlmClient {
+    private val chatClient = chatClientBuilder.build()
+
+
+    private val log = LoggerFactory.getLogger(GlmClientImpl::class.java)
+
+    /**
+     * 이슈 정보와 소스코드를 기반으로 GLM API에 분석을 요청합니다.
+     *
+     * @throws AnalysisException GLM_API_FAIL - API 호출 실패 시
+     */
+    override fun analyze(
+        issueTitle: String,
+        issueBody: String?,
+        labels: List<String>,
+        fileContents: Map<String, String>
+    ): GlmAnalysisRes {
+        val prompt = buildPrompt(issueTitle, issueBody, labels, fileContents)
+
+        return try {
+            val response = chatClient.prompt()
+                .user(prompt)
+                .call()
+                .content()
+                ?: throw AnalysisException(
+                    AnalysisErrorCode.GLM_API_FAIL,
+                    "[GlmClientImpl#analyze] GLM 응답이 null입니다.",
+                    "코드 분석에 실패했습니다."
+                )
+
+            parseResponse(response)
+
+        } catch (e: Exception) {
+            log.error("[GlmClientImpl#analyze] GLM API 호출 실패: ${e.message}")
+            throw AnalysisException(
+                AnalysisErrorCode.GLM_API_FAIL,
+                "[GlmClientImpl#analyze] GLM API 호출 실패: ${e.message}",
+                "코드 분석에 실패했습니다."
+            )
+        }
+    }
+
+    /**
+     * GLM API에 전달할 프롬프트를 구성합니다.
+     *
+     * 이슈 제목, 본문, 라벨, 관련 소스코드를 포함하며
+     * JSON 형태로만 응답하도록 지시합니다.
+     */
+    private fun buildPrompt(
+        issueTitle: String,
+        issueBody: String?,
+        labels: List<String>,
+        fileContents: Map<String, String>
+    ): String {
+        val filesSection = fileContents.entries.joinToString("\n\n") { (path, content) ->
+            "### $path\n```\n$content\n```"
+        }
+
+        return """
+        이 이슈를 해결하려면 어떤 파일을 수정해야 하는지 알려주고, 수정 방향을 설명해줘.
+        반드시 아래 JSON 형식으로만 응답해줘. 설명이나 마크다운 없이 JSON만 출력해.
+        
+        [이슈 내용]
+        제목: $issueTitle
+        라벨: ${labels.joinToString(", ")}
+        본문: ${issueBody ?: "내용 없음"}
+        
+        [관련 코드]
+        $filesSection
+        
+        [출력 형식]
+        {
+            "guideline": "수정 방향 설명 (한국어)",
+            "pseudoCode": "수정 방법을 보여주는 의사 코드 (한국어)",
+            "sideEffects": "수정 시 발생할 수 있는 부작용 (한국어)"
+        }
+        """.trimIndent()
+    }
+
+    /**
+     * GLM API 응답 JSON을 GlmAnalysisRes로 파싱합니다.
+     *
+     * @throws AnalysisException GLM_API_FAIL - JSON 파싱 실패 시
+     */
+    private fun parseResponse(response: String): GlmAnalysisRes {
+        return try {
+            // ```json ... ``` 형태로 올 경우 제거
+            val cleaned = response
+                .replace(Regex("```json\\s*"), "")
+                .replace(Regex("```\\s*"), "")
+                .trim()
+
+            objectMapper.readValue(cleaned, GlmAnalysisRes::class.java)
+        } catch (e: Exception) {
+            log.error("[GlmClientImpl#parseResponse] JSON 파싱 실패: $response")
+            throw AnalysisException(
+                AnalysisErrorCode.GLM_API_FAIL,
+                "[GlmClientImpl#parseResponse] JSON 파싱 실패: ${e.message}",
+                "코드 분석 결과를 처리하는 데 실패했습니다."
+            )
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -12,8 +12,8 @@ import com.back.omos.global.exception.errorCode.AnalysisErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import tools.jackson.databind.ObjectMapper
-import tools.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.core.type.TypeReference
 
 /**
  * Context Analyzer의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
@@ -44,7 +44,7 @@ class ContextAnalyzerServiceImpl(
     private val gitHubClient: GitHubClient,
     private val objectMapper: ObjectMapper
 ) : ContextAnalyzerService {
-
+    @Transactional
     override fun getGuide(issueId: Long): GuideResponseDto {
         val issue = issueRepository.findById(issueId)
             .orElseThrow {
@@ -65,7 +65,7 @@ class ContextAnalyzerServiceImpl(
         val analysisResult = generateAnalysis(issue)
         return toGuideDto(analysisResult)
     }
-
+    @Transactional
     override fun getPseudoCode(issueId: Long): PseudoCodeResponseDto {
         val issue = issueRepository.findById(issueId)
             .orElseThrow {
@@ -99,7 +99,7 @@ class ContextAnalyzerServiceImpl(
      *
      * 기존 캐시가 있으면 업데이트하고, 없으면 새로 생성하여 저장합니다.
      */
-    @Transactional
+
     private fun generateAnalysis(issue: Issue): AnalysisResult {
 
         // 1. repositoryId로 Repo 조회 → owner/repo 파싱

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.analysis.service
 
+import com.back.omos.domain.analysis.ai.GlmClient
 import com.back.omos.domain.analysis.dto.GuideResponseDto
 import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
 import com.back.omos.domain.analysis.entity.AnalysisResult
@@ -10,10 +11,10 @@ import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.repo.repository.RepoRepository
 import com.back.omos.global.exception.errorCode.AnalysisErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.core.type.TypeReference
 
 /**
  * Context Analyzer의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
@@ -28,8 +29,8 @@ import com.fasterxml.jackson.core.type.TypeReference
  * 기존 결과가 있으면 동일 row를 업데이트하고, 없으면 새로 생성합니다.
  *
  * <p><b>외부 모듈:</b><br>
- * GitHub API — 관련 소스코드 수집 (TODO) <br>
- * GLM API — 코드 수정 가이드 생성 (TODO)
+ * GitHub API — 관련 소스코드 수집 <br>
+ * GLM API — 코드 수정 가이드 생성
  *
  * @author Jaewon Ryu
  * @since 2026-04-22
@@ -42,8 +43,10 @@ class ContextAnalyzerServiceImpl(
     private val issueRepository: IssueRepository,
     private val repoRepository: RepoRepository,
     private val gitHubClient: GitHubClient,
+    private val glmClient: GlmClient,
     private val objectMapper: ObjectMapper
 ) : ContextAnalyzerService {
+
     @Transactional
     override fun getGuide(issueId: Long): GuideResponseDto {
         val issue = issueRepository.findById(issueId)
@@ -55,16 +58,15 @@ class ContextAnalyzerServiceImpl(
                 )
             }
 
-        // 캐시 있으면 바로 반환
         val cached = analysisResultRepository.findByIssueId(issueId)
         if (cached != null) {
             return toGuideDto(cached)
         }
 
-        // 없으면 새로 생성
         val analysisResult = generateAnalysis(issue)
         return toGuideDto(analysisResult)
     }
+
     @Transactional
     override fun getPseudoCode(issueId: Long): PseudoCodeResponseDto {
         val issue = issueRepository.findById(issueId)
@@ -84,22 +86,17 @@ class ContextAnalyzerServiceImpl(
         val analysisResult = generateAnalysis(issue)
         return toPseudoCodeDto(analysisResult)
     }
+
     /**
      * 이슈가 분석 이후 수정되었는지 판단합니다.
-     *
-     * issue.updatedAt이 analysisResult.createdAt보다 이후이면
-     * 이슈 내용이 변경된 것이므로 가이드를 재생성해야 합니다.
      */
     private fun isIssueModifiedAfterAnalysis(issue: Issue, result: AnalysisResult): Boolean {
         return issue.updatedAt.isAfter(result.createdAt)
     }
 
     /**
-     * GLM API를 호출하여 새로운 분석 결과를 생성합니다.
-     *
-     * 기존 캐시가 있으면 업데이트하고, 없으면 새로 생성하여 저장합니다.
+     * GitHub API로 소스코드를 수집하고 GLM API로 분석 결과를 생성합니다.
      */
-
     private fun generateAnalysis(issue: Issue): AnalysisResult {
 
         // 1. repositoryId로 Repo 조회 → owner/repo 파싱
@@ -131,25 +128,25 @@ class ContextAnalyzerServiceImpl(
         // 5. filePaths JSON 직렬화
         val filePaths = objectMapper.writeValueAsString(fileContents.keys.toList())
 
-        // TODO: GLM API로 가이드 생성 요청
-        val guideline = "TODO: GLM 연동 후 실제 가이드 생성"
-        val pseudoCode = "TODO: GLM 연동 후 실제 의사 코드 생성"
-        val sideEffects = "TODO: GLM 연동 후 실제 부작용 분석"
+        // 6. GLM API로 가이드 생성
+        val labels = issueInfo.labels.map { it.name }
+        val glmResult = glmClient.analyze(
+            issueTitle = issueInfo.title,
+            issueBody = issueInfo.body,
+            labels = labels,
+            fileContents = fileContents
+        )
 
         val newResult = AnalysisResult(
             issue = issue,
             filePaths = filePaths,
-            guideline = guideline,
-            pseudoCode = pseudoCode,
-            sideEffects = sideEffects
+            guideline = glmResult.guideline,
+            pseudoCode = glmResult.pseudoCode,
+            sideEffects = glmResult.sideEffects
         )
         return analysisResultRepository.save(newResult)
     }
 
-    /**
-     * AnalysisResult를 GuideResponseDto로 변환합니다.
-     * filePaths는 JSON 문자열을 List<String>으로 파싱합니다.
-     */
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {
         return GuideResponseDto(
             filePaths = parseFilePaths(result.filePaths),
@@ -158,9 +155,6 @@ class ContextAnalyzerServiceImpl(
         )
     }
 
-    /**
-     * AnalysisResult를 PseudoCodeResponseDto로 변환합니다.
-     */
     private fun toPseudoCodeDto(result: AnalysisResult): PseudoCodeResponseDto {
         return PseudoCodeResponseDto(
             filePaths = parseFilePaths(result.filePaths),
@@ -170,9 +164,6 @@ class ContextAnalyzerServiceImpl(
 
     /**
      * JSON 배열 문자열을 List<String>으로 파싱합니다.
-     * <p>
-     * ObjectMapper를 사용하여 안전하게 역직렬화합니다.
-     * 예: '["a.java", "b.java"]' → listOf("a.java", "b.java")
      *
      * @param filePaths JSON 배열 형태의 파일 경로 문자열
      * @return 파싱된 파일 경로 목록

--- a/omos/src/main/kotlin/com/back/omos/global/config/SecurityConfig.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/config/SecurityConfig.kt
@@ -14,7 +14,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 
 /**
  * 프로젝트의 보안 설정을 담당하는 클래스입니다.

--- a/omos/src/main/kotlin/com/back/omos/global/exception/exceptionHandler/GlobalExceptionHandler.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/exceptionHandler/GlobalExceptionHandler.kt
@@ -206,6 +206,6 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     override fun handleMaxUploadSizeExceededException(
         ex: MaxUploadSizeExceededException, headers: HttpHeaders, status: HttpStatusCode, request: WebRequest
     ): ResponseEntity<Any>? {
-        return fail("File size exceeds limit", HttpStatus.CONTENT_TOO_LARGE)
+        return fail("File size exceeds limit", HttpStatus.PAYLOAD_TOO_LARGE)
     }
 }

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -2,6 +2,16 @@ spring:
   config:
     activate:
       on-profile: dev
+  ai:
+    openai:
+      api-key: ${GLM_API_KEY}
+      base-url: https://aigw.alpha.grepp.co/v1
+      chat:
+        completions-path: /chat/completions
+        options:
+          model: glm-4.5
+      embedding:
+        enabled: false  # 임베딩은 Gemini가 담당
 
   # GitHub OAuth2 설정
   security:
@@ -31,6 +41,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+gemini:
+  api-key: ${GEMINI_API_KEY}
+  embedding:
+    model: gemini-embedding-2
 
 # JWT 설정
 jwt:

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -1,5 +1,7 @@
 package com.back.omos.domain.analysis.service
 
+import com.back.omos.domain.analysis.ai.GlmClient
+import com.back.omos.domain.analysis.ai.GlmAnalysisRes
 import com.back.omos.domain.analysis.dto.GuideResponseDto
 import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
 import com.back.omos.domain.analysis.entity.AnalysisResult
@@ -19,10 +21,14 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.BDDMockito.*
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.test.context.ActiveProfiles
 import java.util.Optional
 
 /**
@@ -35,6 +41,7 @@ import java.util.Optional
  * @since 2026-04-24
  */
 @ExtendWith(MockitoExtension::class)
+@ActiveProfiles("test")
 class ContextAnalyzerServiceImplTest {
 
     @Mock
@@ -49,6 +56,9 @@ class ContextAnalyzerServiceImplTest {
     @Mock
     private lateinit var gitHubClient: GitHubClient
 
+    @Mock
+    private lateinit var glmClient: GlmClient
+
     private lateinit var contextAnalyzerService: ContextAnalyzerServiceImpl
 
     @BeforeEach
@@ -58,7 +68,8 @@ class ContextAnalyzerServiceImplTest {
             issueRepository = issueRepository,
             repoRepository = repoRepository,
             gitHubClient = gitHubClient,
-            objectMapper = ObjectMapper()  // 실제 인스턴스 직접 넘김
+            glmClient = glmClient,
+            objectMapper = ObjectMapper()
         )
     }
 
@@ -146,6 +157,12 @@ class ContextAnalyzerServiceImplTest {
             given(gitHubClient.fetchFileContent("spring-projects", "spring-boot", "src/main/kotlin/com/example/UserService.kt"))
                 .willReturn("fun userService() { ... }")
             given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
+            given(glmClient.analyze(any(), anyOrNull(), any(), any()))
+                .willReturn(GlmAnalysisRes(
+                    guideline = "가이드라인",
+                    pseudoCode = "의사코드",
+                    sideEffects = "부작용"
+                ))
 
             // when
             val result = contextAnalyzerService.getGuide(1L)
@@ -184,7 +201,7 @@ class ContextAnalyzerServiceImplTest {
         fun `캐시 HIT시 즉시 반환`() {
             // given
             given(issueRepository.findById(1L)).willReturn(Optional.of(mockIssue))
-            given(analysisResultRepository.findByIssueId(1L)).willReturn(mockAnalysisResult)
+            given(analysisResultRepository.findByIssueId(1L)).willReturn(mockAnalysisResult)  // 추가!
 
             // when
             val result = contextAnalyzerService.getPseudoCode(1L)


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
GLM API를 연동하고, GitHub API로 수집한 소스코드를 기반으로 실제 코드 수정 가이드(guideline, pseudoCode, sideEffects)를 생성하도록 구현했습니다.

## 🔗 관련 이슈
- Close #67

## 🛠️ 주요 변경 사항
- [x] GlmClient 인터페이스 및 GlmClientImpl 구현체 구현 (Spring AI ChatClient 기반)
- [x] GlmAnalysisRes DTO 구현
- [x] 이슈 정보 + 소스코드 기반 프롬프트 설계 (v1)
- [x] GLM API 호출하여 guideline, pseudoCode, sideEffects 생성
- [x] ContextAnalyzerServiceImpl에 GlmClient 연동 (generateAnalysis() 완성)
- [x] ContextAnalyzerServiceImplTest GlmClient Mock 추가 및 테스트 보완
- [x] mockito-kotlin 의존성 추가

## 🧪 테스트 결과
**단위 테스트 5개 전체 통과 (692ms)**
<img width="547" height="246" alt="image" src="https://github.com/user-attachments/assets/ad7d80ff-1d0b-4b78-943c-4e6bf7e2d234" />

**실제 API 호출 테스트 (Postman)**

https://github.com/microsoft/vscode/issues/256854

GET /api/v1/issues/{issueId}/guide (27.91s)
- microsoft/vscode 레포의 실제 이슈(#256854) 기반 테스트
- GLM이 이슈 내용을 분석하여 실제 guideline, sideEffects 생성 확인
<img width="1205" height="393" alt="image" src="https://github.com/user-attachments/assets/f074684b-6762-4ba4-9873-c0b636b907aa" />

GET /api/v1/issues/{issueId}/pseudo (67ms)
- 두 번째 호출 시 캐시 HIT 확인 (GitHub/GLM API 재호출 없음)
- pseudoCode 정상 반환 확인
<img width="1216" height="404" alt="image" src="https://github.com/user-attachments/assets/d5adea84-e90c-49ee-bccb-c85691bfabd4" />

## 🧐 리뷰어에게

-  feat/be/context-analyzer 브랜치로 병합하는 서브 PR입니다

-  현재 기초 프롬프트를 사용하고 있으며, 이후 단계적으로 개선할 예정입니다.

**filePaths가 비어있는 문제**
-  현재 GitHub Code Search API로 이슈 제목을 키워드로 파일을 검색하는데, 이슈 제목이 길거나 특수문자가 포함된 경우 검색 결과가 0개로 나오는 문제가 있습니다.
-  이로 인해 filePaths가 비어있어도 GLM이 이슈 내용만으로 가이드를 생성하고 있습니다.

**개선 계획 (별도 이슈로 분리)**
-  현재 (v1): GitHub Code Search API → 이슈 제목 키워드 검색 → 부정확
↓
-  개선 (v2): GitHub Tree API → 전체 디렉토리 구조 fetch
→ GLM에게 "이 이슈랑 관련있는 파일 골라줘" 프롬프트
→ GLM이 뽑은 파일 경로로 fetchFileContent 호출
→ 파일 내용 + 이슈 내용으로 GLM 가이드 생성
이 방식으로 개선하면 Code Search의 키워드 한계를 극복하고 보다 정확한 파일 탐색이 가능해집니다.
(개선 후에 main으로 병합할 예정입니다.)

**응답 시간**
-  현재 GLM API 응답 시간이 약 28초로 다소 깁니다.
프롬프트 최적화 및 파일 수 조정(현재 최대 5개)을 통해 개선할 예정입니다.