### PR TITLE
[#76][FEAT] PrDraft 조회, 삭제 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -1,12 +1,14 @@
 package com.back.omos.domain.prdraft.controller
 
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -40,6 +42,13 @@ class PrDraftController(
         @Valid @RequestBody req: CreatePrReq
     ): CommonResponse<PrInfoRes> {
         return CommonResponse.success(prDraftService.create(principal.githubId, req))
+    }
+
+    @GetMapping("/history")
+    fun getHistory(
+        @AuthenticationPrincipal principal: OAuthPrincipal
+    ): CommonResponse<List<PrHistoryRes>> {
+        return CommonResponse.success(prDraftService.getHistory(principal.githubId))
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -17,10 +17,11 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * PR 생성 요청을 처리하는 Controller입니다.
+ * PR 초안 생성, 목록 조회, 삭제 요청을 처리하는 Controller입니다.
  *
  * <p>
- * diff 내용과 이슈 정보를 받아 AI 기반 PR 초안을 생성하는 엔드포인트를 제공합니다.
+ * diff 내용과 이슈 정보를 받아 AI 기반 PR 초안을 생성하고,
+ * 생성된 초안의 목록 조회 및 삭제 기능을 제공합니다.
  * </p>
  *
  * <p><b>상속 정보:</b><br>
@@ -57,9 +58,9 @@ class PrDraftController(
     fun delete(
         @AuthenticationPrincipal principal: OAuthPrincipal,
         @PathVariable id: Long
-    ): CommonResponse<Unit> {
+    ): CommonResponse<Void?> {
         prDraftService.delete(principal.githubId, id)
-        return CommonResponse.success(Unit)
+        return CommonResponse.success(null)
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -8,7 +8,9 @@ import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -49,6 +51,15 @@ class PrDraftController(
         @AuthenticationPrincipal principal: OAuthPrincipal
     ): CommonResponse<List<PrHistoryRes>> {
         return CommonResponse.success(prDraftService.getHistory(principal.githubId))
+    }
+
+    @DeleteMapping("/{id}")
+    fun delete(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
+        @PathVariable id: Long
+    ): CommonResponse<Unit> {
+        prDraftService.delete(principal.githubId, id)
+        return CommonResponse.success(Unit)
     }
 
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrHistoryRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrHistoryRes.kt
@@ -10,6 +10,8 @@ import java.time.LocalDateTime
  * 사용자가 생성한 PR 초안의 제목, 본문 및 생성 시각을 포함합니다.
  *
  * @property id PR 초안 ID
+ * @property repoFullName 이슈가 속한 레포지토리 전체 이름 (예: owner/repo)
+ * @property issueTitle 연결된 이슈 제목
  * @property title AI가 생성한 PR 제목
  * @property body AI가 생성한 PR 본문
  * @property createdAt PR 초안 생성 시각
@@ -19,6 +21,8 @@ import java.time.LocalDateTime
  */
 data class PrHistoryRes(
     val id: Long,
+    val repoFullName: String,
+    val issueTitle: String,
     val title: String,
     val body: String,
     val createdAt: LocalDateTime
@@ -26,6 +30,8 @@ data class PrHistoryRes(
     companion object {
         fun from(prDraft: PrDraft) = PrHistoryRes(
             id = prDraft.id!!,
+            repoFullName = prDraft.issue.repoFullName,
+            issueTitle = prDraft.issue.title,
             title = prDraft.prTitle,
             body = prDraft.prBody,
             createdAt = prDraft.createdAt

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrHistoryRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrHistoryRes.kt
@@ -1,0 +1,34 @@
+package com.back.omos.domain.prdraft.dto
+
+import com.back.omos.domain.prdraft.entity.PrDraft
+import java.time.LocalDateTime
+
+/**
+ * PR 초안 목록 조회 결과를 응답으로 전달하는 DTO입니다.
+ *
+ * <p>
+ * 사용자가 생성한 PR 초안의 제목, 본문 및 생성 시각을 포함합니다.
+ *
+ * @property id PR 초안 ID
+ * @property title AI가 생성한 PR 제목
+ * @property body AI가 생성한 PR 본문
+ * @property createdAt PR 초안 생성 시각
+ *
+ * @author 5h6vm
+ * @since 2026-04-27
+ */
+data class PrHistoryRes(
+    val id: Long,
+    val title: String,
+    val body: String,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(prDraft: PrDraft) = PrHistoryRes(
+            id = prDraft.id!!,
+            title = prDraft.prTitle,
+            body = prDraft.prBody,
+            createdAt = prDraft.createdAt
+        )
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
@@ -2,6 +2,8 @@ package com.back.omos.domain.prdraft.repository
 
 import com.back.omos.domain.prdraft.entity.PrDraft
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 /**
  * PR 초안(PrDraft) 엔티티의 데이터 접근을 담당하는 Repository입니다.
@@ -19,10 +21,14 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface PrDraftRepository : JpaRepository<PrDraft, Long> {
 
     /**
-     * 특정 사용자의 PR 초안 목록을 생성일 내림차순으로 조회합니다.
+     * 특정 사용자의 PR 초안 목록을 이슈 정보와 함께 생성일 내림차순으로 조회합니다.
+     *
+     * <p>
+     * fetch join을 사용하여 issue를 한 번의 쿼리로 함께 조회합니다.
      *
      * @param githubId 조회할 사용자의 GitHub ID
-     * @return PR 초안 목록 (최신순)
+     * @return PR 초안 목록 (최신순, issue 포함)
      */
-    fun findAllByUserGithubIdOrderByCreatedAtDesc(githubId: String): List<PrDraft>
+    @Query("SELECT pd FROM PrDraft pd JOIN FETCH pd.issue WHERE pd.user.githubId = :githubId ORDER BY pd.createdAt DESC")
+    fun findAllWithIssueByUserGithubId(@Param("githubId") githubId: String): List<PrDraft>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
@@ -16,4 +16,13 @@ import org.springframework.data.jpa.repository.JpaRepository
  * @since 2026-04-21
  */
 
-interface PrDraftRepository : JpaRepository<PrDraft, Long>
+interface PrDraftRepository : JpaRepository<PrDraft, Long> {
+
+    /**
+     * 특정 사용자의 PR 초안 목록을 생성일 내림차순으로 조회합니다.
+     *
+     * @param githubId 조회할 사용자의 GitHub ID
+     * @return PR 초안 목록 (최신순)
+     */
+    fun findAllByUserGithubIdOrderByCreatedAtDesc(githubId: String): List<PrDraft>
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
@@ -31,4 +31,16 @@ interface PrDraftRepository : JpaRepository<PrDraft, Long> {
      */
     @Query("SELECT pd FROM PrDraft pd JOIN FETCH pd.issue WHERE pd.user.githubId = :githubId ORDER BY pd.createdAt DESC")
     fun findAllWithIssueByUserGithubId(@Param("githubId") githubId: String): List<PrDraft>
+
+    /**
+     * PR 초안 ID와 사용자 GitHub ID로 PR 초안을 조회합니다.
+     *
+     * <p>
+     * 소유자 확인을 DB 쿼리 레벨에서 수행하여 존재 여부 노출을 방지합니다.
+     *
+     * @param id PR 초안 ID
+     * @param githubId 조회할 사용자의 GitHub ID
+     * @return PR 초안 (없거나 소유자 불일치 시 null)
+     */
+    fun findByIdAndUserGithubId(id: Long, githubId: String): PrDraft?
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -5,10 +5,10 @@ import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 
 /**
- * PR 생성 기능을 제공하는 Service 인터페이스입니다.
+ * PR 초안 생성, 목록 조회, 삭제 기능을 제공하는 Service 인터페이스입니다.
  *
  * <p>
- * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 생성 이력을 조회하는 기능을 정의합니다.
+ * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 생성 이력 조회 및 삭제 기능을 정의합니다.
  *
  * <p><b>상속 정보:</b><br>
  * 별도의 상속 없이 Service 역할을 정의하는 인터페이스입니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -1,13 +1,14 @@
 package com.back.omos.domain.prdraft.service
 
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 
 /**
  * PR 생성 기능을 제공하는 Service 인터페이스입니다.
  *
  * <p>
- * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하는 기능을 정의합니다.
+ * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 생성 이력을 조회하는 기능을 정의합니다.
  *
  * <p><b>상속 정보:</b><br>
  * 별도의 상속 없이 Service 역할을 정의하는 인터페이스입니다.
@@ -16,5 +17,21 @@ import com.back.omos.domain.prdraft.dto.PrInfoRes
  * @since 2026-04-22
  */
 interface PrDraftService {
+
+    /**
+     * diff 내용과 이슈 정보를 기반으로 AI를 호출하여 PR 초안을 생성하고 저장합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param request PR 생성 요청 DTO (issueId, diffContent 포함)
+     * @return 생성된 PR 제목, 본문, GitHub URL
+     */
     fun create(githubId: String, request: CreatePrReq): PrInfoRes
+
+    /**
+     * 사용자가 생성한 PR 초안 목록을 최신순으로 조회합니다.
+     *
+     * @param githubId 조회할 사용자의 GitHub ID
+     * @return PR 초안 목록 (최신순)
+     */
+    fun getHistory(githubId: String): List<PrHistoryRes>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -34,4 +34,13 @@ interface PrDraftService {
      * @return PR 초안 목록 (최신순)
      */
     fun getHistory(githubId: String): List<PrHistoryRes>
+
+    /**
+     * PR 초안을 삭제합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 삭제할 PR 초안 ID
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    fun delete(githubId: String, prDraftId: Long)
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -108,12 +108,8 @@ class PrDraftServiceImpl(
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */
     override fun delete(githubId: String, prDraftId: Long) {
-        val prDraft = prDraftRepository.findById(prDraftId)
-            .orElseThrow { PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND) }
-
-        if (prDraft.user.githubId != githubId) {
-            throw PrDraftException(PrDraftErrorCode.PR_DRAFT_FORBIDDEN)
-        }
+        val prDraft = prDraftRepository.findByIdAndUserGithubId(prDraftId, githubId)
+            ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
 
         prDraftRepository.delete(prDraft)
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -2,6 +2,7 @@ package com.back.omos.domain.prdraft.service
 
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.ai.AiClient
 import com.back.omos.domain.prdraft.entity.PrDraft
@@ -43,6 +44,15 @@ class PrDraftServiceImpl(
     private val gitHubClient: GitHubClient
 ) : PrDraftService {
 
+    /**
+     * diff 내용과 이슈 정보를 기반으로 AI를 호출하여 PR 초안을 생성하고 저장합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param request PR 생성 요청 DTO (issueId, diffContent 포함)
+     * @return 생성된 PR 제목, 본문, GitHub URL
+     * @throws AuthException 존재하지 않는 githubId인 경우
+     * @throws IssueException 존재하지 않는 issueId인 경우
+     */
     override fun create(githubId: String, request: CreatePrReq): PrInfoRes {
         // 정보 조회
         val user = userRepository.findByGithubId(githubId)
@@ -75,6 +85,17 @@ class PrDraftServiceImpl(
             body = aiResult.body,
             githubUrl = githubUrl
         )
+    }
+
+    /**
+     * 사용자가 생성한 PR 초안 목록을 최신순으로 조회합니다.
+     *
+     * @param githubId 조회할 사용자의 GitHub ID
+     * @return PR 초안 목록 (최신순)
+     */
+    override fun getHistory(githubId: String): List<PrHistoryRes> {
+        return prDraftRepository.findAllByUserGithubIdOrderByCreatedAtDesc(githubId)
+            .map { PrHistoryRes.from(it) }
     }
 
     private fun buildGithubUrl(fullName: String, title: String, body: String): String {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -20,11 +20,11 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 /**
- * PR 생성 기능의 구현체입니다.
+ * PR 초안 생성, 목록 조회, 삭제 기능의 구현체입니다.
  *
  * <p>
- * diffContent와 Issue 정보를 기반으로 AI를 호출하여
- * PR 제목과 본문을 생성하는 로직을 담당합니다.
+ * diffContent와 Issue 정보를 기반으로 AI를 호출하여 PR 제목과 본문을 생성하고,
+ * 생성된 초안의 목록 조회 및 삭제 로직을 담당합니다.
  *
  * <p><b>상속 정보:</b><br>
  * {@link PrDraftService}를 구현합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -94,7 +94,7 @@ class PrDraftServiceImpl(
      * @return PR 초안 목록 (최신순)
      */
     override fun getHistory(githubId: String): List<PrHistoryRes> {
-        return prDraftRepository.findAllByUserGithubIdOrderByCreatedAtDesc(githubId)
+        return prDraftRepository.findAllWithIssueByUserGithubId(githubId)
             .map { PrHistoryRes.from(it) }
     }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -11,8 +11,10 @@ import com.back.omos.domain.prdraft.repository.PrDraftRepository
 import com.back.omos.domain.user.repository.UserRepository
 import com.back.omos.global.exception.errorCode.AuthErrorCode
 import com.back.omos.global.exception.errorCode.IssueErrorCode
+import com.back.omos.global.exception.errorCode.PrDraftErrorCode
 import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
+import com.back.omos.global.exception.exceptions.PrDraftException
 import org.springframework.stereotype.Service
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -96,6 +98,24 @@ class PrDraftServiceImpl(
     override fun getHistory(githubId: String): List<PrHistoryRes> {
         return prDraftRepository.findAllWithIssueByUserGithubId(githubId)
             .map { PrHistoryRes.from(it) }
+    }
+
+    /**
+     * PR 초안을 삭제합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 삭제할 PR 초안 ID
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    override fun delete(githubId: String, prDraftId: Long) {
+        val prDraft = prDraftRepository.findById(prDraftId)
+            .orElseThrow { PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND) }
+
+        if (prDraft.user.githubId != githubId) {
+            throw PrDraftException(PrDraftErrorCode.PR_DRAFT_FORBIDDEN)
+        }
+
+        prDraftRepository.delete(prDraft)
     }
 
     private fun buildGithubUrl(fullName: String, title: String, body: String): String {

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/PrDraftErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/PrDraftErrorCode.kt
@@ -1,0 +1,25 @@
+package com.back.omos.global.exception.errorCode
+
+import org.springframework.http.HttpStatus
+
+/**
+ * PR 초안 관련 예외에 대한 상수 값을 정의합니다.
+ *
+ * <p>
+ * {@code PrDraftErrorCode}는 {@link com.back.omos.global.exception.exceptions.PrDraftException PrDraftException}에서 사용됩니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link ErrorCode}의 구현체입니다.
+ *
+ * @author 5h6vm
+ * @see ErrorCode
+ * @see com.back.omos.global.exception.exceptions.PrDraftException PrDraftException
+ * @since 2026-04-27
+ */
+enum class PrDraftErrorCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+) : ErrorCode {
+    PR_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 PR 초안을 찾을 수 없습니다."),
+    PR_DRAFT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 PR 초안에 대한 권한이 없습니다."),
+}

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/PrDraftErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/PrDraftErrorCode.kt
@@ -21,5 +21,4 @@ enum class PrDraftErrorCode(
     override val message: String
 ) : ErrorCode {
     PR_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 PR 초안을 찾을 수 없습니다."),
-    PR_DRAFT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 PR 초안에 대한 권한이 없습니다."),
 }

--- a/omos/src/main/kotlin/com/back/omos/global/exception/exceptions/PrDraftException.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/exceptions/PrDraftException.kt
@@ -1,0 +1,21 @@
+package com.back.omos.global.exception.exceptions
+
+import com.back.omos.global.exception.errorCode.PrDraftErrorCode
+
+/**
+ * PR 초안 관련 처리 과정에서 발생하는 예외입니다.
+ *
+ * <p>{@link PrDraftErrorCode}의 값을 담습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link BaseException}의 구현 클래스입니다.
+ *
+ * @author 5h6vm
+ * @see PrDraftErrorCode
+ * @see BaseException
+ * @since 2026-04-27
+ */
+class PrDraftException : BaseException {
+    constructor(errorCode: PrDraftErrorCode) : super(errorCode)
+    constructor(errorCode: PrDraftErrorCode, logMessage: String) : super(errorCode, logMessage)
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.prdraft.controller
 
+import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.handler.OAuth2FailureHandler
@@ -21,9 +22,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
 
 @WebMvcTest(PrDraftController::class)
 @Import(SecurityConfig::class)
@@ -63,6 +66,33 @@ class PrDraftControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.status").value("success"))
                 .andExpect(jsonPath("$.data.title").value("feat: title"))
+        }
+    }
+
+    @Nested
+    inner class GetHistoryTest {
+
+        @Test
+        fun `목록 조회 정상 요청이면 200과 목록을 반환한다`() {
+            given(prDraftService.getHistory(any())).willReturn(
+                listOf(PrHistoryRes(1L, "owner/repo", "test issue", "feat: title", "body", LocalDateTime.now()))
+            )
+
+            mockMvc.perform(
+                get("/api/v1/pr/history")
+                    .with(authentication(mockAuth()))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data[0].title").value("feat: title"))
+                .andExpect(jsonPath("$.data[0].repoFullName").value("owner/repo"))
+                .andExpect(jsonPath("$.data[0].issueTitle").value("test issue"))
+        }
+
+        @Test
+        fun `인증 없이 목록 조회하면 401을 반환한다`() {
+            mockMvc.perform(get("/api/v1/pr/history"))
+                .andExpect(status().isUnauthorized)
         }
     }
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -22,6 +22,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -92,6 +93,26 @@ class PrDraftControllerTest {
         @Test
         fun `인증 없이 목록 조회하면 401을 반환한다`() {
             mockMvc.perform(get("/api/v1/pr/history"))
+                .andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Nested
+    inner class DeleteTest {
+
+        @Test
+        fun `삭제 정상 요청이면 200을 반환한다`() {
+            mockMvc.perform(
+                delete("/api/v1/pr/1")
+                    .with(authentication(mockAuth()))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("success"))
+        }
+
+        @Test
+        fun `인증 없이 삭제 요청하면 401을 반환한다`() {
+            mockMvc.perform(delete("/api/v1/pr/1"))
                 .andExpect(status().isUnauthorized)
         }
     }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -108,6 +108,7 @@ class PrDraftControllerTest {
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data").doesNotExist())
         }
 
         @Test

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -24,6 +24,7 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.verify
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.test.util.ReflectionTestUtils
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -85,6 +86,34 @@ class PrDraftServiceImplTest {
             service.create(githubId, req)
 
             verify(gitHubClient).fetchMergedPrs("owner/repo")
+        }
+    }
+
+    @Nested
+    inner class GetHistoryTest {
+
+        @Test
+        fun `PR 초안 목록을 최신순으로 반환한다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findAllWithIssueByUserGithubId(githubId)).willReturn(listOf(prDraft))
+
+            val result = service.getHistory(githubId)
+
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(1L)
+            assertThat(result[0].repoFullName).isEqualTo("owner/repo")
+            assertThat(result[0].issueTitle).isEqualTo("test issue")
+            assertThat(result[0].title).isEqualTo("feat: title")
+        }
+
+        @Test
+        fun `PR 초안이 없으면 빈 목록을 반환한다`() {
+            given(prDraftRepository.findAllWithIssueByUserGithubId(githubId)).willReturn(emptyList())
+
+            val result = service.getHistory(githubId)
+
+            assertThat(result).isEmpty()
         }
     }
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -125,7 +125,7 @@ class PrDraftServiceImplTest {
         fun `본인 소유 PR 초안이면 삭제한다`() {
             val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
-            given(prDraftRepository.findById(1L)).willReturn(Optional.of(prDraft))
+            given(prDraftRepository.findByIdAndUserGithubId(1L, githubId)).willReturn(prDraft)
 
             service.delete(githubId, 1L)
 
@@ -133,19 +133,8 @@ class PrDraftServiceImplTest {
         }
 
         @Test
-        fun `존재하지 않는 PR 초안이면 PrDraftException을 던진다`() {
-            given(prDraftRepository.findById(1L)).willReturn(Optional.empty())
-
-            assertThatThrownBy { service.delete(githubId, 1L) }
-                .isInstanceOf(PrDraftException::class.java)
-        }
-
-        @Test
-        fun `본인 소유가 아닌 PR 초안이면 PrDraftException을 던진다`() {
-            val otherUser = User(githubId = "otherUser")
-            val prDraft = PrDraft(user = otherUser, issue = issue, diffContent = "diff", prTitle = "title", prBody = "body")
-            ReflectionTestUtils.setField(prDraft, "id", 1L)
-            given(prDraftRepository.findById(1L)).willReturn(Optional.of(prDraft))
+        fun `존재하지 않거나 본인 소유가 아닌 PR 초안이면 PrDraftException을 던진다`() {
+            given(prDraftRepository.findByIdAndUserGithubId(1L, githubId)).willReturn(null)
 
             assertThatThrownBy { service.delete(githubId, 1L) }
                 .isInstanceOf(PrDraftException::class.java)

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -13,6 +13,7 @@ import com.back.omos.domain.user.entity.User
 import com.back.omos.domain.user.repository.UserRepository
 import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
+import com.back.omos.global.exception.exceptions.PrDraftException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -114,6 +115,40 @@ class PrDraftServiceImplTest {
             val result = service.getHistory(githubId)
 
             assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class DeleteTest {
+
+        @Test
+        fun `본인 소유 PR 초안이면 삭제한다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findById(1L)).willReturn(Optional.of(prDraft))
+
+            service.delete(githubId, 1L)
+
+            verify(prDraftRepository).delete(prDraft)
+        }
+
+        @Test
+        fun `존재하지 않는 PR 초안이면 PrDraftException을 던진다`() {
+            given(prDraftRepository.findById(1L)).willReturn(Optional.empty())
+
+            assertThatThrownBy { service.delete(githubId, 1L) }
+                .isInstanceOf(PrDraftException::class.java)
+        }
+
+        @Test
+        fun `본인 소유가 아닌 PR 초안이면 PrDraftException을 던진다`() {
+            val otherUser = User(githubId = "otherUser")
+            val prDraft = PrDraft(user = otherUser, issue = issue, diffContent = "diff", prTitle = "title", prBody = "body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findById(1L)).willReturn(Optional.of(prDraft))
+
+            assertThatThrownBy { service.delete(githubId, 1L) }
+                .isInstanceOf(PrDraftException::class.java)
         }
     }
 


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
prDraft 조회 기능, 삭제 기능 

## 🔗 관련 이슈
- Close #76 

## 🛠️ 주요 변경 사항
- [x] get history, delete {id} 구현
- [x] PrHistoryRes, ErrorCode, Exception 추가
- [x] 조회, 삭제 test 추가

## 🧪 테스트 결과
- testcode 확인
<img width="437" height="574" alt="image" src="https://github.com/user-attachments/assets/3c0421a9-7b20-4dc7-adfd-ff0cd4f4c0aa" />

- 실제 swagger 동작 확인
<img width="539" height="206" alt="image" src="https://github.com/user-attachments/assets/a275c8f6-8030-4f4c-8fad-4ac6090c233e" />


## 🧐 리뷰어에게
`main`으로 merge 됩니다.
mvp가 아닌 추가기능입니다.
수정은 불필요할 것 같아 조회, 삭제 기능만 구현하였습니다.
