### PR TITLE
[#81][FEAT] PrDraft 단건조회, 수정 기능 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -4,6 +4,7 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.UpdatePrReq
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
@@ -11,6 +12,7 @@ import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,11 +20,11 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * PR 초안 생성, 조회, 삭제 요청을 처리하는 Controller입니다.
+ * PR 초안 생성, 조회, 수정, 삭제 요청을 처리하는 Controller입니다.
  *
  * <p>
  * diff 내용과 이슈 정보를 받아 AI 기반 PR 초안을 생성하고,
- * 생성된 초안의 단건/목록 조회 및 삭제 기능을 제공합니다.
+ * 생성된 초안의 단건/목록 조회, 수정 및 삭제 기능을 제공합니다.
  * </p>
  *
  * <p><b>상속 정보:</b><br>
@@ -61,6 +63,15 @@ class PrDraftController(
         @AuthenticationPrincipal principal: OAuthPrincipal
     ): CommonResponse<List<PrHistoryRes>> {
         return CommonResponse.success(prDraftService.getHistory(principal.githubId))
+    }
+
+    @PatchMapping("/{id}")
+    fun update(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
+        @PathVariable id: Long,
+        @Valid @RequestBody req: UpdatePrReq
+    ): CommonResponse<PrDetailRes> {
+        return CommonResponse.success(prDraftService.update(principal.githubId, id, req))
     }
 
     @DeleteMapping("/{id}")

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -69,7 +69,7 @@ class PrDraftController(
     fun update(
         @AuthenticationPrincipal principal: OAuthPrincipal,
         @PathVariable id: Long,
-        @Valid @RequestBody req: UpdatePrReq
+        @RequestBody req: UpdatePrReq
     ): CommonResponse<PrDetailRes> {
         return CommonResponse.success(prDraftService.update(principal.githubId, id, req))
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -1,6 +1,7 @@
 package com.back.omos.domain.prdraft.controller
 
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.service.PrDraftService
@@ -17,11 +18,11 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * PR 초안 생성, 목록 조회, 삭제 요청을 처리하는 Controller입니다.
+ * PR 초안 생성, 조회, 삭제 요청을 처리하는 Controller입니다.
  *
  * <p>
  * diff 내용과 이슈 정보를 받아 AI 기반 PR 초안을 생성하고,
- * 생성된 초안의 목록 조회 및 삭제 기능을 제공합니다.
+ * 생성된 초안의 단건/목록 조회 및 삭제 기능을 제공합니다.
  * </p>
  *
  * <p><b>상속 정보:</b><br>
@@ -45,6 +46,14 @@ class PrDraftController(
         @Valid @RequestBody req: CreatePrReq
     ): CommonResponse<PrInfoRes> {
         return CommonResponse.success(prDraftService.create(principal.githubId, req))
+    }
+
+    @GetMapping("/{id}")
+    fun getOne(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
+        @PathVariable id: Long
+    ): CommonResponse<PrDetailRes> {
+        return CommonResponse.success(prDraftService.getOne(principal.githubId, id))
     }
 
     @GetMapping("/history")

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -69,7 +69,7 @@ class PrDraftController(
     fun update(
         @AuthenticationPrincipal principal: OAuthPrincipal,
         @PathVariable id: Long,
-        @RequestBody req: UpdatePrReq
+        @Valid @RequestBody req: UpdatePrReq
     ): CommonResponse<PrDetailRes> {
         return CommonResponse.success(prDraftService.update(principal.githubId, id, req))
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrDetailRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrDetailRes.kt
@@ -4,33 +4,39 @@ import com.back.omos.domain.prdraft.entity.PrDraft
 import java.time.LocalDateTime
 
 /**
- * PR 초안 목록 조회 결과를 응답으로 전달하는 DTO입니다.
+ * PR 초안 단건 조회 결과를 응답으로 전달하는 DTO입니다.
  *
  * <p>
- * 사용자가 생성한 PR 초안의 제목 및 생성 시각을 포함합니다.
+ * 목록 조회 응답({@link PrHistoryRes})과 달리 사용자가 입력한 diff 내용도 포함합니다.
  *
  * @property id PR 초안 ID
  * @property repoFullName 이슈가 속한 레포지토리 전체 이름 (예: owner/repo)
  * @property issueTitle 연결된 이슈 제목
  * @property title AI가 생성한 PR 제목
+ * @property body AI가 생성한 PR 본문
+ * @property diffContent 사용자가 입력한 코드 변경 내용
  * @property createdAt PR 초안 생성 시각
  *
  * @author 5h6vm
- * @since 2026-04-27
+ * @since 2026-04-28
  */
-data class PrHistoryRes(
+data class PrDetailRes(
     val id: Long,
     val repoFullName: String,
     val issueTitle: String,
     val title: String,
+    val body: String,
+    val diffContent: String,
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun from(prDraft: PrDraft) = PrHistoryRes(
+        fun from(prDraft: PrDraft) = PrDetailRes(
             id = prDraft.id!!,
             repoFullName = prDraft.issue.repoFullName,
             issueTitle = prDraft.issue.title,
             title = prDraft.prTitle,
+            body = prDraft.prBody,
+            diffContent = prDraft.diffContent,
             createdAt = prDraft.createdAt
         )
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/UpdatePrReq.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/UpdatePrReq.kt
@@ -1,5 +1,7 @@
 package com.back.omos.domain.prdraft.dto
 
+import jakarta.validation.constraints.Size
+
 /**
  * PR 초안 수정 요청 정보를 담는 DTO입니다.
  *
@@ -7,13 +9,14 @@ package com.back.omos.domain.prdraft.dto
  * 사용자가 직접 수정할 PR 제목과 본문을 전달할 때 사용됩니다.
  * null인 필드는 기존 값을 유지합니다.
  *
- * @property title 수정할 PR 제목 (null이면 기존 값 유지)
+ * @property title 수정할 PR 제목 (null이면 기존 값 유지, 최대 255자)
  * @property body 수정할 PR 본문 (null이면 기존 값 유지)
  *
  * @author 5h6vm
  * @since 2026-04-28
  */
 data class UpdatePrReq(
+    @field:Size(max = 255, message = "title은 255자를 초과할 수 없습니다.")
     val title: String?,
     val body: String?
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/UpdatePrReq.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/UpdatePrReq.kt
@@ -7,6 +7,9 @@ package com.back.omos.domain.prdraft.dto
  * 사용자가 직접 수정할 PR 제목과 본문을 전달할 때 사용됩니다.
  * null인 필드는 기존 값을 유지합니다.
  *
+ * @property title 수정할 PR 제목 (null이면 기존 값 유지)
+ * @property body 수정할 PR 본문 (null이면 기존 값 유지)
+ *
  * @author 5h6vm
  * @since 2026-04-28
  */

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/UpdatePrReq.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/UpdatePrReq.kt
@@ -1,0 +1,16 @@
+package com.back.omos.domain.prdraft.dto
+
+/**
+ * PR 초안 수정 요청 정보를 담는 DTO입니다.
+ *
+ * <p>
+ * 사용자가 직접 수정할 PR 제목과 본문을 전달할 때 사용됩니다.
+ * null인 필드는 기존 값을 유지합니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-28
+ */
+data class UpdatePrReq(
+    val title: String?,
+    val body: String?
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
@@ -43,4 +43,18 @@ interface PrDraftRepository : JpaRepository<PrDraft, Long> {
      * @return PR 초안 (없거나 소유자 불일치 시 null)
      */
     fun findByIdAndUserGithubId(id: Long, githubId: String): PrDraft?
+
+    /**
+     * PR 초안 ID와 사용자 GitHub ID로 PR 초안을 이슈 정보와 함께 조회합니다.
+     *
+     * <p>
+     * fetch join을 사용하여 issue를 한 번의 쿼리로 함께 조회하며,
+     * 소유자 확인을 DB 쿼리 레벨에서 수행하여 존재 여부 노출을 방지합니다.
+     *
+     * @param id PR 초안 ID
+     * @param githubId 조회할 사용자의 GitHub ID
+     * @return PR 초안 (없거나 소유자 불일치 시 null, issue 포함)
+     */
+    @Query("SELECT pd FROM PrDraft pd JOIN FETCH pd.issue WHERE pd.id = :id AND pd.user.githubId = :githubId")
+    fun findByIdWithIssueAndUserGithubId(@Param("id") id: Long, @Param("githubId") githubId: String): PrDraft?
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -4,12 +4,13 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.UpdatePrReq
 
 /**
- * PR 초안 생성, 조회, 삭제 기능을 제공하는 Service 인터페이스입니다.
+ * PR 초안 생성, 조회, 수정, 삭제 기능을 제공하는 Service 인터페이스입니다.
  *
  * <p>
- * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 단건/목록 조회 및 삭제 기능을 정의합니다.
+ * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 단건/목록 조회, 수정 및 삭제 기능을 정의합니다.
  *
  * <p><b>상속 정보:</b><br>
  * 별도의 상속 없이 Service 역할을 정의하는 인터페이스입니다.
@@ -45,6 +46,17 @@ interface PrDraftService {
      * @return PR 초안 목록 (최신순)
      */
     fun getHistory(githubId: String): List<PrHistoryRes>
+
+    /**
+     * PR 초안의 제목과 본문을 수정합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 수정할 PR 초안 ID
+     * @param request 수정할 제목과 본문
+     * @return 수정된 PR 초안 상세 정보
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    fun update(githubId: String, prDraftId: Long, request: UpdatePrReq): PrDetailRes
 
     /**
      * PR 초안을 삭제합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -1,14 +1,15 @@
 package com.back.omos.domain.prdraft.service
 
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 
 /**
- * PR 초안 생성, 목록 조회, 삭제 기능을 제공하는 Service 인터페이스입니다.
+ * PR 초안 생성, 조회, 삭제 기능을 제공하는 Service 인터페이스입니다.
  *
  * <p>
- * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 생성 이력 조회 및 삭제 기능을 정의합니다.
+ * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 단건/목록 조회 및 삭제 기능을 정의합니다.
  *
  * <p><b>상속 정보:</b><br>
  * 별도의 상속 없이 Service 역할을 정의하는 인터페이스입니다.
@@ -26,6 +27,16 @@ interface PrDraftService {
      * @return 생성된 PR 제목, 본문, GitHub URL
      */
     fun create(githubId: String, request: CreatePrReq): PrInfoRes
+
+    /**
+     * PR 초안 단건을 조회합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 조회할 PR 초안 ID
+     * @return PR 초안 상세 정보 (diffContent 포함)
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    fun getOne(githubId: String, prDraftId: Long): PrDetailRes
 
     /**
      * 사용자가 생성한 PR 초안 목록을 최신순으로 조회합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -52,7 +52,7 @@ interface PrDraftService {
      *
      * @param githubId 요청한 사용자의 GitHub ID
      * @param prDraftId 수정할 PR 초안 ID
-     * @param request 수정할 제목과 본문
+     * @param request 수정할 제목과 본문 (null인 필드는 기존 값 유지)
      * @return 수정된 PR 초안 상세 정보
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -132,7 +132,7 @@ class PrDraftServiceImpl(
         prDraft.prTitle = request.title ?: prDraft.prTitle
         prDraft.prBody = request.body ?: prDraft.prBody
 
-        return PrDetailRes.from(prDraft)
+        return PrDetailRes.from(prDraftRepository.save(prDraft))
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -5,6 +5,7 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.UpdatePrReq
 import com.back.omos.domain.prdraft.ai.AiClient
 import com.back.omos.domain.prdraft.entity.PrDraft
 import com.back.omos.domain.prdraft.github.GitHubClient
@@ -21,7 +22,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 /**
- * PR 초안 생성, 조회, 삭제 기능의 구현체입니다.
+ * PR 초안 생성, 조회, 수정, 삭제 기능의 구현체입니다.
  *
  * <p>
  * diffContent와 Issue 정보를 기반으로 AI를 호출하여 PR 제목과 본문을 생성하고,
@@ -113,6 +114,25 @@ class PrDraftServiceImpl(
     override fun getHistory(githubId: String): List<PrHistoryRes> {
         return prDraftRepository.findAllWithIssueByUserGithubId(githubId)
             .map { PrHistoryRes.from(it) }
+    }
+
+    /**
+     * PR 초안의 제목과 본문을 수정합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 수정할 PR 초안 ID
+     * @param request 수정할 제목과 본문
+     * @return 수정된 PR 초안 상세 정보
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    override fun update(githubId: String, prDraftId: Long, request: UpdatePrReq): PrDetailRes {
+        val prDraft = prDraftRepository.findByIdWithIssueAndUserGithubId(prDraftId, githubId)
+            ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
+
+        prDraft.prTitle = request.title ?: prDraft.prTitle
+        prDraft.prBody = request.body ?: prDraft.prBody
+
+        return PrDetailRes.from(prDraft)
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -2,6 +2,7 @@ package com.back.omos.domain.prdraft.service
 
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.ai.AiClient
@@ -20,7 +21,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 /**
- * PR 초안 생성, 목록 조회, 삭제 기능의 구현체입니다.
+ * PR 초안 생성, 조회, 삭제 기능의 구현체입니다.
  *
  * <p>
  * diffContent와 Issue 정보를 기반으로 AI를 호출하여 PR 제목과 본문을 생성하고,
@@ -87,6 +88,20 @@ class PrDraftServiceImpl(
             body = aiResult.body,
             githubUrl = githubUrl
         )
+    }
+
+    /**
+     * PR 초안 단건을 조회합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 조회할 PR 초안 ID
+     * @return PR 초안 상세 정보 (diffContent 포함)
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    override fun getOne(githubId: String, prDraftId: Long): PrDetailRes {
+        val prDraft = prDraftRepository.findByIdWithIssueAndUserGithubId(prDraftId, githubId)
+            ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
+        return PrDetailRes.from(prDraft)
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets
  *
  * <p>
  * diffContent와 Issue 정보를 기반으로 AI를 호출하여 PR 제목과 본문을 생성하고,
- * 생성된 초안의 목록 조회 및 삭제 로직을 담당합니다.
+ * 생성된 초안의 단건/목록 조회, 수정 및 삭제 로직을 담당합니다.
  *
  * <p><b>상속 정보:</b><br>
  * {@link PrDraftService}를 구현합니다.
@@ -121,7 +121,7 @@ class PrDraftServiceImpl(
      *
      * @param githubId 요청한 사용자의 GitHub ID
      * @param prDraftId 수정할 PR 초안 ID
-     * @param request 수정할 제목과 본문
+     * @param request 수정할 제목과 본문 (null인 필드는 기존 값 유지)
      * @return 수정된 PR 초안 상세 정보
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -123,6 +124,38 @@ class PrDraftControllerTest {
         @Test
         fun `인증 없이 목록 조회하면 401을 반환한다`() {
             mockMvc.perform(get("/api/v1/pr/history"))
+                .andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Nested
+    inner class UpdateTest {
+
+        @Test
+        fun `수정 정상 요청이면 200과 수정된 데이터를 반환한다`() {
+            given(prDraftService.update(any(), any(), any())).willReturn(
+                PrDetailRes(1L, "owner/repo", "test issue", "updated title", "updated body", "diff content", LocalDateTime.now())
+            )
+
+            mockMvc.perform(
+                patch("/api/v1/pr/1")
+                    .with(authentication(mockAuth()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"title": "updated title", "body": "updated body"}""")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.title").value("updated title"))
+                .andExpect(jsonPath("$.data.body").value("updated body"))
+        }
+
+        @Test
+        fun `인증 없이 수정 요청하면 401을 반환한다`() {
+            mockMvc.perform(
+                patch("/api/v1/pr/1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"title": "updated title", "body": "updated body"}""")
+            )
                 .andExpect(status().isUnauthorized)
         }
     }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.prdraft.controller
 
+import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
 import com.back.omos.domain.prdraft.service.PrDraftService
@@ -71,12 +72,41 @@ class PrDraftControllerTest {
     }
 
     @Nested
+    inner class GetOneTest {
+
+        @Test
+        fun `단건 조회 정상 요청이면 200과 상세 정보를 반환한다`() {
+            given(prDraftService.getOne(any(), any())).willReturn(
+                PrDetailRes(1L, "owner/repo", "test issue", "feat: title", "body", "diff content", LocalDateTime.now())
+            )
+
+            mockMvc.perform(
+                get("/api/v1/pr/1")
+                    .with(authentication(mockAuth()))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.repoFullName").value("owner/repo"))
+                .andExpect(jsonPath("$.data.issueTitle").value("test issue"))
+                .andExpect(jsonPath("$.data.title").value("feat: title"))
+                .andExpect(jsonPath("$.data.diffContent").value("diff content"))
+        }
+
+        @Test
+        fun `인증 없이 단건 조회하면 401을 반환한다`() {
+            mockMvc.perform(get("/api/v1/pr/1"))
+                .andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Nested
     inner class GetHistoryTest {
 
         @Test
         fun `목록 조회 정상 요청이면 200과 목록을 반환한다`() {
             given(prDraftService.getHistory(any())).willReturn(
-                listOf(PrHistoryRes(1L, "owner/repo", "test issue", "feat: title", "body", LocalDateTime.now()))
+                listOf(PrHistoryRes(1L, "owner/repo", "test issue", "feat: title", LocalDateTime.now()))
             )
 
             mockMvc.perform(

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -5,6 +5,7 @@ import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.prdraft.ai.AiClient
 import com.back.omos.domain.prdraft.ai.AiPrResult
 import com.back.omos.domain.prdraft.dto.CreatePrReq
+import com.back.omos.domain.prdraft.dto.UpdatePrReq
 import com.back.omos.domain.prdraft.entity.PrDraft
 import com.back.omos.domain.prdraft.github.GitHubClient
 import com.back.omos.domain.prdraft.github.GitHubPrRes
@@ -143,6 +144,54 @@ class PrDraftServiceImplTest {
             val result = service.getHistory(githubId)
 
             assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class UpdateTest {
+
+        @Test
+        fun `title과 body를 모두 전달하면 둘 다 수정된다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+
+            val result = service.update(githubId, 1L, UpdatePrReq("new title", "new body"))
+
+            assertThat(result.title).isEqualTo("new title")
+            assertThat(result.body).isEqualTo("new body")
+        }
+
+        @Test
+        fun `title이 null이면 기존 title을 유지한다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+
+            val result = service.update(githubId, 1L, UpdatePrReq(null, "new body"))
+
+            assertThat(result.title).isEqualTo("old title")
+            assertThat(result.body).isEqualTo("new body")
+        }
+
+        @Test
+        fun `body가 null이면 기존 body를 유지한다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+
+            val result = service.update(githubId, 1L, UpdatePrReq("new title", null))
+
+            assertThat(result.title).isEqualTo("new title")
+            assertThat(result.body).isEqualTo("old body")
+        }
+
+        @Test
+        fun `존재하지 않거나 본인 소유가 아닌 PR 초안이면 PrDraftException을 던진다`() {
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(null)
+
+            assertThatThrownBy { service.update(githubId, 1L, UpdatePrReq("new title", "new body")) }
+                .isInstanceOf(PrDraftException::class.java)
         }
     }
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -91,6 +91,34 @@ class PrDraftServiceImplTest {
     }
 
     @Nested
+    inner class GetOneTest {
+
+        @Test
+        fun `본인 소유 PR 초안이면 상세 정보를 반환한다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+
+            val result = service.getOne(githubId, 1L)
+
+            assertThat(result.id).isEqualTo(1L)
+            assertThat(result.repoFullName).isEqualTo("owner/repo")
+            assertThat(result.issueTitle).isEqualTo("test issue")
+            assertThat(result.title).isEqualTo("feat: title")
+            assertThat(result.body).isEqualTo("body")
+            assertThat(result.diffContent).isEqualTo("diff")
+        }
+
+        @Test
+        fun `존재하지 않거나 본인 소유가 아닌 PR 초안이면 PrDraftException을 던진다`() {
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(null)
+
+            assertThatThrownBy { service.getOne(githubId, 1L) }
+                .isInstanceOf(PrDraftException::class.java)
+        }
+    }
+
+    @Nested
     inner class GetHistoryTest {
 
         @Test


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
PrDraft 단건조회, 수정 기능 추가 및 다건조회시 body 출력 제거

## 🔗 관련 이슈
- Close #81 

## 🛠️ 주요 변경 사항
- [x] service, controller : 단건조회, 수정 로직 추가
- [x] dto : PrDetailRes, UpdatePrReq 추가 및 PrHistoryRes에서 body 제거
- [x] test: 관련 test 수정 및 추가

## 🧪 테스트 결과
<img width="522" height="668" alt="image" src="https://github.com/user-attachments/assets/432ce8ac-f446-4e09-a914-70b993a664fc" />

| <img width="786" height="579" alt="스크린샷 2026-04-28 105610" src="https://github.com/user-attachments/assets/9a009567-ac01-4f23-b722-05ae6e394045" /> | <img width="779" height="484" alt="스크린샷 2026-04-28 110101" src="https://github.com/user-attachments/assets/ce42bb48-fec7-4e25-9f0e-be12bea03f09" /> |
|---|---|


## 🧐 리뷰어에게
`main`으로 merge됩니다.
단순 단건조회, 수정에 대한 기능구현입니다
