### PR TITLE
[#72][FEAT] Issue 벡터 임베딩 기능 구현 , AI활용 이슈 추천 기능 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClient.kt
@@ -1,0 +1,29 @@
+package com.back.omos.domain.issue.ai
+
+import com.back.omos.domain.issue.dto.AIRecommendationResult
+import com.back.omos.domain.issue.entity.Issue
+
+/**
+ * Generative AI 모델을 사용하여 오픈소스 이슈 추천 로직을 수행하는 클라이언트 인터페이스입니다.
+ * <p>
+ * 사용자 프로필과 벡터 검색으로 추출된 후보군 이슈들을 결합하여(Augmentation),
+ * AI 모델에게 전달하고 가장 적합한 추천 항목과 그 근거를 생성(Generation)하는 역할을 담당합니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * 해당 인터페이스의 구현체는 Spring Context에 의해 빈(Bean)으로 관리되며,
+ * 비즈니스 로직 계층(Service)에서 주입받아 사용됩니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Spring AI 모듈 및 외부 LLM(GLM, Gemini 등) API와 연동하여 자연어 처리 및 분석을 수행합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-27
+ * @see com.back.omos.domain.recommend.client.IssueGlmClientImpl
+ */
+interface IssueGlmClient {
+    /**
+     * 유저 프로필과 유사도 기반으로 검색된 후보 이슈들을 분석하여
+     * 최적의 이슈를 선정하고 추천 사유를 생성합니다.
+     */
+    fun generateRecommendationReasons(userProfile: String, candidateIssues: List<Issue>): List<AIRecommendationResult>
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
@@ -1,0 +1,111 @@
+package com.back.omos.domain.issue.ai
+
+import com.back.omos.domain.issue.dto.AIRecommendationResult
+import com.back.omos.domain.issue.entity.Issue
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.core.type.TypeReference
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+
+/**
+ * Generative AI 모델과 통신하여 실제 추천 로직을 수행하는 클라이언트 구현체입니다.
+ * <p>
+ * Spring AI의 {@code ChatClient}를 통해 AI 모델에 정제된 프롬프트를 전달하며,
+ * 모델로부터 받은 JSON 형식의 응답을 {@code ObjectMapper}를 사용하여 데이터 객체 리스트로 변환합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link IssueGlmClient} 인터페이스를 구현합니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code IssueGlmClientImpl(ChatClient.Builder chatClientBuilder, ObjectMapper objectMapper)}  <br>
+ * AI 통신을 위한 클라이언트 빌더와 JSON 파싱을 위한 매퍼를 주입받습니다. <br>
+ *
+ * <p><b>빈 관리:</b><br>
+ * {@code @Component} 어노테이션을 통해 스프링 컨테이너에 의해 싱글톤 빈으로 관리됩니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * Spring AI (ChatClient) 및 Jackson (ObjectMapper) 라이브러리를 활용합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-27
+ * @see com.back.omos.domain.recommend.client.IssueGlmClient
+ */
+@Component
+class IssueGlmClientImpl(
+    chatClientBuilder: ChatClient.Builder,
+    private val objectMapper: ObjectMapper
+) : IssueGlmClient {
+
+    private val chatClient = chatClientBuilder.build()
+
+    override fun generateRecommendationReasons(
+        userProfile: String,
+        candidateIssues: List<Issue>
+    ): List<AIRecommendationResult> {
+        val prompt = buildRecommendPrompt(userProfile, candidateIssues)
+
+        val responseContent = chatClient.prompt()
+            .user(prompt)
+            .call()
+            .content() ?: throw RuntimeException("AI 응답 생성 실패")
+
+        // 문자열로 온 JSON을 List<AiRecommendationResult>로 변환
+        return try {
+            objectMapper.readValue(responseContent, object : TypeReference<List<AIRecommendationResult>>() {})
+        } catch (e: Exception) {
+            // 파싱 실패 시 예외 처리 (로그 출력 등)
+            emptyList()
+        }
+    }
+
+    /**
+     * 유저의 기술 스택과 후보 이슈 데이터를 하나로 묶는 프롬프트 엔지니어링
+     */
+    private fun buildRecommendPrompt(userProfile: String, candidateIssues: List<Issue>): String {
+        val issuesContext = candidateIssues.mapIndexed { index, issue ->
+            """
+            [후보 ${index + 1}]
+            - 제목: ${issue.title}
+            - 레포지토리: ${issue.repoFullName}
+            - 주요 라벨: ${issue.labels?.joinToString(", ") ?: "없음"}
+            - 이슈 요약: ${issue.content?.take(400) ?: "내용 없음"}
+            """.trimIndent()
+        }.joinToString("\n\n")
+
+        return """
+            당신은 개발자의 기술 스택과 오픈소스 이슈를 매칭하는 전문 컨설턴트입니다.
+            아래 제공된 '개발자 프로필'을 분석하고, '후보 이슈 리스트' 중에서 개발자에게 가장 추천할 만한 이슈 3개를 엄선하여 선정 이유를 작성해주세요.
+            
+            [개발자 프로필]
+            $userProfile
+            
+            [후보 이슈 리스트]
+            $issuesContext
+            
+            [지시 사항]
+            1. 후보 이슈들 중 개발자의 주요 사용 언어 및 관심사와 가장 부합하는 3개의 이슈를 선정하세요.
+            2. 선정된 각 이슈에 대해 왜 이 개발자에게 적합한지, 어떤 기술적 성장이 기대되는지 한국어로 상세히 설명하세요.
+            3. 결과는 반드시 유사도가 높은 순서대로 3개만 포함해야 합니다.
+            4. 반드시 아래 JSON 배열 형식으로만 응답하세요. (마크다운 코드 블록 제외, 순수 JSON만 출력)
+            
+            [출력 형식]
+            [
+              {
+                "title": "이슈 제목",
+                "repoName": "레포지토리 풀네임",
+                "reason": "추천 사유 및 기대되는 성장 포인트"
+              },
+              {
+                "title": "이슈 제목",
+                "repoName": "레포지토리 풀네임",
+                "reason": "추천 사유 및 기대되는 성장 포인트"
+              },
+              {
+                "title": "이슈 제목",
+                "repoName": "레포지토리 풀네임",
+                "reason": "추천 사유 및 기대되는 성장 포인트"
+              }
+            ]   
+        """.trimIndent()
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
@@ -2,9 +2,11 @@ package com.back.omos.domain.issue.ai
 
 import com.back.omos.domain.issue.dto.AIRecommendationResult
 import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.global.exception.errorCode.AiErrorCode
+import com.back.omos.global.exception.exceptions.AiException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.core.type.TypeReference
-import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.model.ChatModel
 import org.springframework.stereotype.Component
 
 /**
@@ -32,29 +34,27 @@ import org.springframework.stereotype.Component
  */
 @Component
 class IssueGlmClientImpl(
-    chatClientBuilder: ChatClient.Builder,
+    private val chatModel: ChatModel,
     private val objectMapper: ObjectMapper
 ) : IssueGlmClient {
 
-    private val chatClient = chatClientBuilder.build()
 
     override fun generateRecommendationReasons(
         userProfile: String,
         candidateIssues: List<Issue>
     ): List<AIRecommendationResult> {
-        val prompt = buildRecommendPrompt(userProfile, candidateIssues)
+        val promptText = buildRecommendPrompt(userProfile, candidateIssues)
 
-        val responseContent = chatClient.prompt()
-            .user(prompt)
-            .call()
-            .content() ?: throw RuntimeException("AI 응답 생성 실패")
+        val responseContent = try {
+            chatModel.call(promptText) ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY);
+        } catch (e: Exception) {
+            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED);
+        }
 
-        // 문자열로 온 JSON을 List<AiRecommendationResult>로 변환
         return try {
             objectMapper.readValue(responseContent, object : TypeReference<List<AIRecommendationResult>>() {})
         } catch (e: Exception) {
-            // 파싱 실패 시 예외 처리 (로그 출력 등)
-            emptyList()
+            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
     }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -6,6 +6,8 @@ import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.issue.service.IssueService
 import com.back.omos.domain.issue.service.RecommendService
 import com.back.omos.global.auth.principal.OAuthPrincipal
+import com.back.omos.global.exception.errorCode.IssueErrorCode
+import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.response.CommonResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -75,8 +77,7 @@ class IssueController(
 
             CommonResponse.success(response)
         } catch (e: Exception) {
-            //TODO 에러 로직 수정
-            CommonResponse.fail(e.message)
+            throw IssueException(IssueErrorCode.ISSUE_CRAWLING_FAIL);
         }
     }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -4,6 +4,7 @@ import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.issue.service.IssueService
+import com.back.omos.global.response.CommonResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -46,8 +47,9 @@ class IssueController(
      * 깃허브 API 동작 확인용으로 넣었습니다.
      */
     @GetMapping
-    fun getAllIssues(): ResponseEntity<List<Issue>> {
-        return ResponseEntity.ok(issueRepository.findAll())
+    fun getAllIssues(): CommonResponse<List<Issue>> {
+        val issues = issueRepository.findAll()
+        return CommonResponse.success(issues)
     }
 
     /**
@@ -60,17 +62,17 @@ class IssueController(
      * @author 유재원
      */
     @PostMapping("/crawl/search")
-    fun crawlBySearch(@RequestParam q: String): ResponseEntity<List<RecommendIssueRes>> {
+    fun crawlBySearch(@RequestParam q: String): CommonResponse<List<RecommendIssueRes>> {
         return try {
             val savedIssues = issueService.crawlAndSaveByQuery(q)
 
             // 엔티티 리스트를 DTO 리스트로 변환
             val response = savedIssues.map { RecommendIssueRes.from(it) }
 
-            ResponseEntity.ok(response)
+            CommonResponse.success(response)
         } catch (e: Exception) {
-            //ToDO 에러처리 로직 추가
-            ResponseEntity.internalServerError().build()
+            //TODO 에러 로직 수정
+            CommonResponse.fail(e.message)
         }
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -4,8 +4,11 @@ import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.issue.service.IssueService
+import com.back.omos.domain.issue.service.RecommendService
+import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -40,7 +43,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/issues")
 class IssueController(
     private val issueService: IssueService,
-    private val issueRepository: IssueRepository
+    private val issueRepository: IssueRepository,
+    private val recommendService: RecommendService
 ) {
     /**
      * 현재 수집한 모든 이슈를 보여줍니다.
@@ -74,5 +78,23 @@ class IssueController(
             //TODO 에러 로직 수정
             CommonResponse.fail(e.message)
         }
+    }
+
+    /**
+     * 로그인된 사용자의 기술 스택과 관심사를 분석하여 맞춤형 이슈를 추천합니다.
+     * <p>
+     * 인증된 사용자의 GitHub ID를 기반으로 프로필 벡터를 조회하며,
+     * 벡터 유사도 검색과 AI 분석(RAG)을 거쳐 최적의 이슈 3개를 선정해 반환합니다.
+     *
+     * @param principal 인증된 사용자의 세션 정보 ([OAuthPrincipal])
+     * @return AI가 생성한 상세 추천 사유를 포함한 [RecommendIssueRes]
+     * @author 유재원
+     */
+    @GetMapping("/recommend")
+    fun getRecommendation(
+        @AuthenticationPrincipal principal: OAuthPrincipal
+    ): CommonResponse<List<RecommendIssueRes>> {
+        val responses = recommendService.getPersonalizedRecommendation(principal.githubId)
+        return CommonResponse.success(responses)
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/AIRecommendationResult.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/AIRecommendationResult.kt
@@ -1,0 +1,17 @@
+package com.back.omos.domain.issue.dto
+
+/**
+ * AI 모델이 생성한 이슈 추천 결과를 구조화하여 담는 데이터 객체(DTO)입니다.
+ * <p>
+ * AI가 후보군 중 선정한 이슈의 핵심 식별 정보와
+ * 기술 스택 기반의 분석 사유를 매핑하여 서비스 계층으로 전달하는 역할을 수행합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-28
+ * @see com.back.omos.domain.recommend.client.IssueGlmClient
+ */
+data class AIRecommendationResult(
+    val title: String,    // 이슈 제목
+    val repoName: String, // 레포지토리 이름
+    val reason: String    // AI가 생성한 추천 사유
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/entity/Issue.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/entity/Issue.kt
@@ -69,12 +69,12 @@ class Issue(
      * 이슈 본문/제목 등의 의미(Context)를 임베딩한 벡터 데이터입니다.
      *
      * AI 기반의 유사도 검색이나 추천 기능 등에 사용됩니다.
-     * PostgreSQL의 pgvector 확장을 사용하며, 1536 차원의 벡터 공간을 가집니다.
+     * `gemini-embedding-2` 모델의 기본 출력 차원인 `3072`로 설정되어 있습니다.
      *
      * - **컨버터**: [DoubleArrayToVectorConverter]를 사용하여 DB 입출력을 처리합니다.
      */
     @Convert(converter = DoubleArrayToVectorConverter::class)
-    @Column(name = "issue_vector", columnDefinition = "vector(1536)")
+    @Column(name = "issue_vector", columnDefinition = "vector(3072)")
     var issueVector: DoubleArray? = null,
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/github/GithubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/github/GithubClient.kt
@@ -49,7 +49,7 @@ class GithubClient(
                 uriBuilder
                     .path("/search/issues")
                     .queryParam("q", normalizedQuery)
-                    .queryParam("per_page", 10)
+                    .queryParam("per_page", 3) // ToDo 한번에 가져올 갯수 정하기
                     .build()
             }
             .header("Authorization", "Bearer $token")

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/repository/IssueRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/repository/IssueRepository.kt
@@ -2,6 +2,8 @@ package com.back.omos.domain.issue.repository
 
 import com.back.omos.domain.issue.entity.Issue
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 /**
  * 이슈(Issue) 엔티티의 데이터 접근을 담당하는 Repository입니다.
@@ -24,4 +26,25 @@ interface IssueRepository : JpaRepository<Issue, Long> {
      * 결과가 없을 수 있으므로 반환 타입을 Issue? (Nullable)로 설정합니다.
      */
     fun findByRepoFullNameAndIssueNumber(repoFullName: String, issueNumber: Long): Issue?
+
+
+    /**
+     * 유저의 프로필 벡터와 유사한 이슈를 지정된 개수만큼 검색합니다.
+     *
+     * PostgreSQL의 `pgvector` 확장을 사용하여 유저 벡터와 이슈 벡터 간의
+     * 코사인 거리(Cosine Distance)를 기반으로 가장 유사도가 높은 이슈들을 추출합니다.
+     * * @param userVector 사용자의 기술 스택 및 관심사가 반영된 3072차원 임베딩 벡터
+     * @return 유사도가 높은 순서대로 정렬된 상위 5개의 [Issue] 리스트
+     */
+    @Query(
+        value = """
+            SELECT * FROM issues 
+            ORDER BY issue_vector <=> CAST(:userVector AS vector) 
+            LIMIT :limit
+        """, nativeQuery = true
+    )
+    fun findBySimilarity(
+        @Param("userVector") userVector: DoubleArray,
+        @Param("limit") limit: Int
+    ): List<Issue>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/repository/IssueRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/repository/IssueRepository.kt
@@ -39,9 +39,11 @@ interface IssueRepository : JpaRepository<Issue, Long> {
     @Query(
         value = """
             SELECT * FROM issues 
+            WHERE issue_vector IS NOT NULL 
             ORDER BY issue_vector <=> CAST(:userVector AS vector) 
             LIMIT :limit
-        """, nativeQuery = true
+        """,
+        nativeQuery = true
     )
     fun findBySimilarity(
         @Param("userVector") userVector: DoubleArray,

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueService.kt
@@ -48,15 +48,6 @@ interface IssueService {
      */
     fun deleteIssue(issueId: Long)
 
-    /**
-     * 사용자 맞춤 이슈 추천 목록을 반환합니다.
-     *
-     * @param userId 사용자 고유 식별자
-     * @param repositoryId 이슈를 추천받을 레포지토리 ID
-     * @param limit 추천받을 이슈 개수
-     * @return 추천된 이슈 목록
-     */
-    fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes>
 
     /**
      * 검색 쿼리를 기반으로 이슈를 전역적으로 수집하고 저장합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
@@ -7,12 +7,13 @@ import com.back.omos.domain.issue.dto.UpdateIssueReq
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.github.GithubClient
 import com.back.omos.domain.issue.repository.IssueRepository
-import com.back.omos.domain.repo.repository.RepoRepository
+import com.back.omos.global.ai.GeminiEmbeddingModel
 import com.back.omos.global.exception.errorCode.IssueErrorCode
 import com.back.omos.global.exception.exceptions.IssueException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.ai.document.Document
 
 /**
  * 이슈 관련 비즈니스 로직을 처리하는 서비스 구현체입니다.
@@ -24,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional
 class IssueServiceImpl(
     private val issueRepository: IssueRepository,
     private val githubClient: GithubClient,
-    private val repoRepository: RepoRepository,
+    private val embeddingModel: GeminiEmbeddingModel
 ) : IssueService {
 
     @Transactional
@@ -76,18 +77,46 @@ class IssueServiceImpl(
         return githubIssues.map { dto ->
             val fullName = dto.repositoryUrl.substringAfter("repos/")
 
-            // 1. 이미 있으면 가져오고, 없으면 새로 생성해서 저장
-            issueRepository.findByRepoFullNameAndIssueNumber(fullName, dto.number)
-                ?: issueRepository.save(
+            // 이미 존재하는 이슈인지 확인
+            val existingIssue = issueRepository.findByRepoFullNameAndIssueNumber(fullName, dto.number)
+
+            if (existingIssue != null) {
+                existingIssue // 이미 있다면 그대로 반환
+            } else {
+                //  신규 이슈라면 임베딩용 텍스트 조립
+                val textToEmbed = buildString {
+                    appendLine("GitHub Issue Information")
+                    appendLine("Title: ${dto.title}")
+                    appendLine("Labels: ${dto.labels.joinToString { it.name }}")
+                    if (!dto.body.isNullOrBlank()) {
+                        // 본문 1000자 제한
+                        appendLine("Content: ${dto.body.take(1000)}")
+                    }
+                }
+
+                // AI 임베딩 모델 호출
+                val floatArray = embeddingModel.embed(Document(textToEmbed))
+
+                // FloatArray -> DoubleArray 변환
+                val vector = if (floatArray.isNotEmpty()) {
+                    floatArray.map { it.toDouble() }.toDoubleArray()
+                } else {
+                    null
+                }
+
+                // DB 저장
+                issueRepository.save(
                     Issue(
                         repoFullName = fullName,
                         issueNumber = dto.number,
                         title = dto.title,
                         content = dto.body,
                         labels = dto.labels.map { it.name },
+                        issueVector = vector,
                         status = Issue.IssueStatus.OPEN
                     )
                 )
+            }
         }
     }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/IssueServiceImpl.kt
@@ -65,10 +65,6 @@ class IssueServiceImpl(
         issueRepository.delete(issue);
     }
 
-    override fun recommendIssues(userId: Long, repositoryId: Long, limit: Int): List<RecommendIssueRes> {
-        TODO("추천 로직 구현 필요")
-    }
-
 
     @Transactional
     override fun crawlAndSaveByQuery(query: String): List<Issue> {

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendService.kt
@@ -1,0 +1,28 @@
+package com.back.omos.domain.issue.service
+
+import com.back.omos.domain.issue.dto.RecommendIssueRes
+
+/**
+ * 사용자 맞춤형 추천 비즈니스 로직을 처리하는 서비스 인터페이스입니다.
+ *
+ * <p>
+ * 사용자의 GitHub 활동 데이터를 기반으로 생성된 벡터 프로필과
+ * 수집된 오픈소스 이슈들 간의 의미적 유사도를 분석하여 최적의 기여 기회를 제공합니다.
+ *
+ * @author 유재원
+ * @since 2026-04-25
+ */
+interface RecommendService {
+    /**
+     * 사용자의 GitHub 고유 ID를 기반으로 개인화된 오픈소스 이슈 추천 정보를 생성합니다.
+     * * <p>
+     * 이 메서드는 RAG(Retrieval-Augmented Generation) 패턴을 따르며 다음 과정을 수행합니다:
+     * 1. 사용자의 프로필 벡터를 활용한 벡터 유사도 검색 (Retrieval)
+     * 2. 검색된 이슈 후보들과 유저 스택 정보를 조합한 컨텍스트 구성 (Augmentation)
+     * 3. AI 모델(GLM)을 통한 최종 선정 및 맞춤형 추천 사유 생성 (Generation)
+     *
+     * @param githubId 추천을 진행할 사용자의 GitHub 고유 식별자
+     * @return AI가 선정한 최적의 이슈 정보와 상세 추천 사유를 포함한 List<RecommendIssueRes>
+     */
+    fun getPersonalizedRecommendation(githubId: String): List<RecommendIssueRes>
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
@@ -53,13 +53,20 @@ class RecommendServiceImpl(
         )
 
         // 6. 결과 반환
-        return aiRecommendationReasons.map { aiResult ->
-            // AI가 추천한 제목과 일치하는 원본 이슈 엔티티를 찾음
-            val matchedIssue = topIssues.find { it.title == aiResult.title } ?: topIssues[0]
+        return aiRecommendationReasons.mapNotNull { aiResult ->
+            // 제목과 레포지토리 이름이 모두 일치하는 이슈를 찾음
+            val matchedIssue = topIssues.find {
+                it.title == aiResult.title && it.repoFullName == aiResult.repoName
+            }
 
+            // 매칭되는 이슈를 못 찾으면 null처리
+            if (matchedIssue == null) {
+                return@mapNotNull null
+            }
+
+            // DTO로 변환
             RecommendIssueRes.from(matchedIssue).copy(
                 summary = aiResult.reason
-                // TODO: 유사도 점수계산 로직 추가
             )
         }
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
@@ -1,0 +1,66 @@
+package com.back.omos.domain.issue.service
+
+import com.back.omos.domain.issue.ai.IssueGlmClient
+import com.back.omos.domain.issue.dto.RecommendIssueRes
+import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.user.repository.UserRepository
+import com.back.omos.global.exception.errorCode.AuthErrorCode
+import com.back.omos.global.exception.errorCode.IssueErrorCode
+import com.back.omos.global.exception.exceptions.AuthException
+import com.back.omos.global.exception.exceptions.IssueException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 사용자 맞춤형 추천 비즈니스 로직을 처리하는 서비스 구현체입니다.
+ *
+ * @author 유재원
+ * @since 2026-04-27
+ */
+@Service
+class RecommendServiceImpl(
+    private val issueRepository: IssueRepository,
+    private val userRepository: UserRepository,
+    private val issueGlmClient: IssueGlmClient
+) : RecommendService {
+
+    @Transactional(readOnly = true)
+    override fun getPersonalizedRecommendation(githubId: String): List<RecommendIssueRes> {
+
+        // 1. 유저 조회
+        val user = userRepository.findByGithubId(githubId)
+            .orElseThrow { AuthException(AuthErrorCode.USER_NOT_FOUND, "GitHub ID [$githubId]에 해당하는 유저를 찾을 수 없습니다.") }
+
+        // 2. 벡터 가져오기
+        val userVector = user.profileVector
+            ?: throw AuthException(AuthErrorCode.USER_NOT_FOUND, "유저의 프로필 벡터가 존재하지 않습니다. 먼저 GitHub 분석을 완료해주세요.")
+
+        // 3. 유사 이슈 검색 현재 5개
+        val topIssues = issueRepository.findBySimilarity(userVector, 5)
+
+        if (topIssues.isEmpty()) {
+            throw IssueException(IssueErrorCode.ISSUE_NOT_FOUND, "추천할 수 있는 이슈가 DB에 없습니다.")
+        }
+
+        // 4. 컨텍스트 구성
+        val userStackText = user.primaryLanguages?.joinToString(", ") ?: "알 수 없음"
+        val userContext = "주요 사용 언어: $userStackText"
+
+        // 5. [Generation] AI 추천 사유 생성 (RAG)
+        val aiRecommendationReasons = issueGlmClient.generateRecommendationReasons(
+            userProfile = userContext,
+            candidateIssues = topIssues
+        )
+
+        // 6. 결과 반환
+        return aiRecommendationReasons.map { aiResult ->
+            // AI가 추천한 제목과 일치하는 원본 이슈 엔티티를 찾음
+            val matchedIssue = topIssues.find { it.title == aiResult.title } ?: topIssues[0]
+
+            RecommendIssueRes.from(matchedIssue).copy(
+                summary = aiResult.reason
+                // TODO: 유사도 점수계산 로직 추가
+            )
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AuthErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AuthErrorCode.kt
@@ -27,6 +27,7 @@ enum class AuthErrorCode(
     USER_UPDATE_FAIL(HttpStatus.BAD_REQUEST, "사용자 정보 수정에 실패하였습니다."),
     USER_DELETE_FAIL(HttpStatus.BAD_REQUEST, "사용자 삭제에 실패하였습니다."),
     USER_VECTOR_UPDATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 벡터 업데이트에 실패하였습니다."),
+    USER_VECTOR_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 프로필 벡터를 찾을 수 없습니다."),
 
     // 회원가입 및 로그인
     SIGNUP_FAIL(HttpStatus.BAD_REQUEST, "회원가입에 실패하였습니다."),

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/IssueErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/IssueErrorCode.kt
@@ -24,10 +24,11 @@ import org.springframework.http.HttpStatus
  * @since 2026-04-23
  * @see
  */
-enum class IssueErrorCode (
+enum class IssueErrorCode(
     override val httpStatus: HttpStatus,
-   override val message: String
+    override val message: String
 ) : ErrorCode {
     ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈를 찾을 수 없습니다."),
     ISSUE_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이슈입니다."),
+    ISSUE_CRAWLING_FAIL(HttpStatus.CONFLICT, "이슈 크롤링을 실패했습니다."),
 }


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
이슈를 깃허브에서 가져온 후 벡터 임베딩을 하여 저장해 놓습니다.
유저가 추천 이슈를 받을 때 서버에 있는 이슈들과 코사인 유사도를 계산하여 가장 유사한 5개의 이슈를 뽑고
그 이슈와 유저의 프로필 정보를 활용하여 AI가 후보 이슈 리스트 중에서 추천할 만한 이슈를 리스트로 3개를 뽑아주고 
선정이유를 작성하여 반환하게 됩니다. 

`IssueGlmClientImpl`에 주요한 프롬포트가 있으니 확인해주시면 될거 같습니다. 프롬포트는 계속 개선해 나아갈 예정입니다.

## 🔗 관련 이슈
- Close #72 

## 🛠️ 주요 변경 사항
- [ ] DTO AI 모델이 생성한 이슈 추천 결과를 담는 `AIRecommendationResult` 추가
- [ ] `RecommendService`에서 `IssueGlmClient`를 통해 AI호출후 결과 반환

## 🧐 리뷰어에게
`IssueGlmClientImpl`에 있는 프롬프트 쪽을 어떻게 개선하면 좋을까를 봐주시면 될거 같습니다. 
