### PR TITLE
[FEAT] GitHub Tree API 기반 관련 파일 탐색 고도화

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClient.kt
@@ -3,12 +3,13 @@ package com.back.omos.domain.analysis.ai
 /**
  * GLM API 호출 기능을 추상화한 인터페이스입니다.
  *
- * <p>
- * 서비스 계층은 이 인터페이스를 통해 GLM API를 호출하여
- * 이슈에 대한 코드 수정 가이드를 생성합니다.
+ * 서비스 계층은 이 인터페이스를 통해 GLM API와 통신하며,
+ * 이슈에 대한 코드 수정 가이드 생성([analyze])과
+ * 관련 파일 선별([selectFiles]) 두 가지 기능을 제공합니다.
  *
  * @author Jaewon Ryu
  * @since 2026-04-25
+ * @see GlmClientImpl
  */
 interface GlmClient {
 
@@ -16,10 +17,13 @@ interface GlmClient {
      * 이슈 정보와 관련 소스코드를 기반으로 코드 수정 가이드를 생성합니다.
      *
      * @param issueTitle 이슈 제목
-     * @param issueBody 이슈 본문
-     * @param labels 이슈 라벨 목록
-     * @param fileContents 관련 파일 경로 → 파일 내용 Map
-     * @return GLM이 생성한 분석 결과
+     * @param issueBody 이슈 본문. 본문이 없는 이슈의 경우 null을 전달하며,
+     *                  구현체는 null 시 "내용 없음"으로 대체하여 처리합니다.
+     * @param labels 이슈에 붙은 라벨 목록. 없으면 빈 리스트를 전달합니다.
+     * @param fileContents 관련 파일 경로와 내용의 맵 (key: 파일 경로, value: 파일 내용)
+     * @return GLM이 생성한 가이드라인·수도 코드·사이드 이펙트를 담은 [GlmAnalysisRes]
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GLM_API_FAIL — API 호출 실패, 응답이 null이거나 JSON 파싱에 실패한 경우
      */
     fun analyze(
         issueTitle: String,
@@ -27,4 +31,21 @@ interface GlmClient {
         labels: List<String>,
         fileContents: Map<String, String>
     ): GlmAnalysisRes
+
+    /**
+     * 레포지토리 파일 트리와 이슈 내용을 기반으로 수정이 필요한 파일 경로를 선별합니다.
+     *
+     * @param issueTitle 이슈 제목
+     * @param issueBody 이슈 본문. 본문이 없는 이슈의 경우 null을 전달하며,
+     *                  구현체는 null 시 "내용 없음"으로 대체하여 처리합니다.
+     * @param filePaths 선별 대상 파일 경로 목록 (레포지토리 전체 파일 트리)
+     * @return GLM이 선별한 관련 파일 경로 목록
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GLM_API_FAIL — API 호출 실패 또는 응답 JSON 파싱에 실패한 경우
+     */
+    fun selectFiles(
+        issueTitle: String,
+        issueBody: String?,
+        filePaths: List<String>
+    ): List<String>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
@@ -202,7 +202,9 @@ class GlmClientImpl(
         [출력 형식]
         {
             "guideline": "수정 방향 설명 (한국어)",
-            "pseudoCode": "Before:\\n[수정 전 코드]\\n\\nAfter:\\n[수정 후 코드] 형태의 문자열로 줘",
+            "pseudoCode": "수정이 필요한 파일과 위치, 변경 방향만 간략히 알려줘. 
+               완전한 코드를 작성하지 말고, 어느 함수/클래스의 어느 부분을 
+               어떤 방향으로 바꿔야 하는지만 설명해줘.",
             "sideEffects": "수정 시 발생할 수 있는 부작용 (한국어)"
         }
         """.trimIndent()

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
@@ -4,7 +4,7 @@ import com.back.omos.global.exception.errorCode.AnalysisErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
-import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.model.ChatModel
 import org.springframework.stereotype.Component
 
 /**
@@ -23,10 +23,9 @@ import org.springframework.stereotype.Component
  */
 @Component
 class GlmClientImpl(
-    chatClientBuilder: ChatClient.Builder,
+    private val chatModel: ChatModel,
     private val objectMapper: ObjectMapper
 ) : GlmClient {
-    private val chatClient = chatClientBuilder.build()
 
 
     private val log = LoggerFactory.getLogger(GlmClientImpl::class.java)
@@ -45,10 +44,7 @@ class GlmClientImpl(
         val prompt = buildPrompt(issueTitle, issueBody, labels, fileContents)
 
         return try {
-            val response = chatClient.prompt()
-                .user(prompt)
-                .call()
-                .content()
+            val response = chatModel.call(prompt)  // 여기 변경
                 ?: throw AnalysisException(
                     AnalysisErrorCode.GLM_API_FAIL,
                     "[GlmClientImpl#analyze] GLM 응답이 null입니다.",
@@ -57,6 +53,8 @@ class GlmClientImpl(
 
             parseResponse(response)
 
+        } catch (e: AnalysisException) {
+            throw e
         } catch (e: Exception) {
             log.error("[GlmClientImpl#analyze] GLM API 호출 실패: ${e.message}")
             throw AnalysisException(

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
@@ -8,14 +8,10 @@ import org.springframework.ai.chat.model.ChatModel
 import org.springframework.stereotype.Component
 
 /**
- * Spring AI ChatClient를 통해 GLM API를 호출하는 구현체입니다.
+ * Spring AI [ChatModel]을 통해 GLM API를 호출하는 [GlmClient] 구현체입니다.
  *
- * <p>
  * 이슈 정보와 관련 소스코드를 프롬프트로 구성하여 GLM API에 전달하고,
- * JSON 형태의 응답을 파싱하여 GlmAnalysisRes로 반환합니다.
- *
- * <p><b>상속 정보:</b><br>
- * {@link GlmClient}를 구현합니다.
+ * JSON 형태의 응답을 파싱하여 [GlmAnalysisRes]로 반환합니다.
  *
  * @author Jaewon Ryu
  * @since 2026-04-25
@@ -27,13 +23,20 @@ class GlmClientImpl(
     private val objectMapper: ObjectMapper
 ) : GlmClient {
 
-
     private val log = LoggerFactory.getLogger(GlmClientImpl::class.java)
 
     /**
-     * 이슈 정보와 소스코드를 기반으로 GLM API에 분석을 요청합니다.
+     * 이슈 정보와 소스코드를 기반으로 GLM API에 코드 분석을 요청합니다.
      *
-     * @throws AnalysisException GLM_API_FAIL - API 호출 실패 시
+     * 프롬프트를 구성하여 [ChatModel]에 전달하고, JSON 응답을 [GlmAnalysisRes]로 파싱합니다.
+     * 응답이 null이거나 JSON 파싱에 실패하면 [AnalysisException]을 던집니다.
+     *
+     * @param issueTitle 분석 대상 이슈 제목
+     * @param issueBody 분석 대상 이슈 본문 (없으면 null)
+     * @param labels 이슈에 붙은 라벨 목록
+     * @param fileContents 관련 파일 경로와 내용의 맵 (key: 파일 경로, value: 파일 내용)
+     * @return GLM API가 생성한 가이드라인·수도 코드·사이드 이펙트를 담은 [GlmAnalysisRes]
+     * @throws AnalysisException GLM_API_FAIL — API 응답이 null이거나 호출/파싱에 실패한 경우
      */
     override fun analyze(
         issueTitle: String,
@@ -44,7 +47,7 @@ class GlmClientImpl(
         val prompt = buildPrompt(issueTitle, issueBody, labels, fileContents)
 
         return try {
-            val response = chatModel.call(prompt)  // 여기 변경
+            val response = chatModel.call(prompt)
                 ?: throw AnalysisException(
                     AnalysisErrorCode.GLM_API_FAIL,
                     "[GlmClientImpl#analyze] GLM 응답이 null입니다.",
@@ -66,10 +69,113 @@ class GlmClientImpl(
     }
 
     /**
-     * GLM API에 전달할 프롬프트를 구성합니다.
+     * 이슈 정보와 파일 경로 목록을 기반으로 GLM API에 관련 파일 선별을 요청합니다.
      *
-     * 이슈 제목, 본문, 라벨, 관련 소스코드를 포함하며
-     * JSON 형태로만 응답하도록 지시합니다.
+     * 이슈 해결에 수정이 필요한 파일을 최대 5개 선별하여 반환합니다.
+     * JSON 파싱에 실패하거나 API 호출이 실패하면 [AnalysisException]을 던집니다.
+     *
+     * @param issueTitle 분석 대상 이슈 제목
+     * @param issueBody 분석 대상 이슈 본문 (없으면 null)
+     * @param filePaths 후보 파일 경로 목록
+     * @return GLM API가 선별한 관련 파일 경로 목록 (최대 5개)
+     * @throws AnalysisException GLM_API_FAIL — API 호출 또는 응답 파싱에 실패한 경우
+     */
+    override fun selectFiles(
+        issueTitle: String,
+        issueBody: String?,
+        filePaths: List<String>
+    ): List<String> {
+        val prompt = buildSelectFilesPrompt(issueTitle, issueBody, filePaths)
+
+        return try {
+            val response = chatModel.call(prompt)
+            parseFileList(response)
+        } catch (e: AnalysisException) {
+            throw e
+        } catch (e: Exception) {
+            log.error("[GlmClientImpl#selectFiles] GLM API 호출 실패: ${e.message}")
+            throw AnalysisException(
+                AnalysisErrorCode.GLM_API_FAIL,
+                "[GlmClientImpl#selectFiles] GLM API 호출 실패: ${e.message}",
+                "관련 파일 탐색에 실패했습니다."
+            )
+        }
+    }
+
+    /**
+     * 파일 선별 요청을 위한 프롬프트를 구성합니다.
+     *
+     * GLM이 반드시 `{ "files": [...] }` 형태의 JSON만 반환하도록 지시합니다.
+     *
+     * @param issueTitle 이슈 제목
+     * @param issueBody 이슈 본문 (없으면 null)
+     * @param filePaths 선별 대상 파일 경로 목록
+     * @return GLM API에 전달할 프롬프트 문자열
+     */
+    private fun buildSelectFilesPrompt(
+        issueTitle: String,
+        issueBody: String?,
+        filePaths: List<String>
+    ): String {
+        return """
+    아래 이슈를 해결하기 위해 수정이 필요한 파일을 골라줘.
+    반드시 아래 JSON 형식으로만 응답해. 설명이나 마크다운 없이 JSON만 출력해.
+    최대 5개까지만 선택해.
+    
+    [이슈 내용]
+    제목: $issueTitle
+    본문: ${issueBody ?: "내용 없음"}
+    
+    [파일 목록]
+    ${filePaths.joinToString("\n")}
+    
+    [출력 형식]
+    {
+        "files": ["파일경로1", "파일경로2"]
+    }
+    """.trimIndent()
+    }
+
+    /**
+     * GLM API의 파일 선별 응답 JSON을 파일 경로 목록으로 파싱합니다.
+     *
+     * 응답에 마크다운 코드 블록(` ```json `)이 포함된 경우 제거 후 파싱합니다.
+     * JSON에 `"files"` 키가 없거나 파싱에 실패하면 [AnalysisException]을 던집니다.
+     *
+     * @param response GLM API의 원본 응답 문자열
+     * @return 파싱된 파일 경로 목록
+     * @throws AnalysisException GLM_API_FAIL — JSON 파싱 실패 또는 `"files"` 키가 없는 경우
+     */
+    private fun parseFileList(response: String): List<String> {
+        return try {
+            val cleaned = response
+                .replace(Regex("```json\\s*"), "")
+                .replace(Regex("```\\s*"), "")
+                .trim()
+            val node = objectMapper.readTree(cleaned)
+            node.get("files").map { it.asText() }
+        } catch (e: Exception) {
+            log.error("[GlmClientImpl#parseFileList] JSON 파싱 실패: $response")
+            throw AnalysisException(
+                AnalysisErrorCode.GLM_API_FAIL,
+                "[GlmClientImpl#parseFileList] JSON 파싱 실패: ${e.message}",
+                "관련 파일 탐색 결과를 처리하는 데 실패했습니다."
+            )
+        }
+    }
+
+    /**
+     * 코드 분석 요청을 위한 프롬프트를 구성합니다.
+     *
+     * 이슈 제목·본문·라벨과 관련 소스코드를 포함하며,
+     * GLM이 반드시 `guideline`, `pseudoCode`, `sideEffects` 필드를 가진
+     * JSON만 반환하도록 지시합니다.
+     *
+     * @param issueTitle 이슈 제목
+     * @param issueBody 이슈 본문 (없으면 null)
+     * @param labels 이슈 라벨 목록
+     * @param fileContents 관련 파일 경로와 내용의 맵 (key: 파일 경로, value: 파일 내용)
+     * @return GLM API에 전달할 프롬프트 문자열
      */
     private fun buildPrompt(
         issueTitle: String,
@@ -96,20 +202,24 @@ class GlmClientImpl(
         [출력 형식]
         {
             "guideline": "수정 방향 설명 (한국어)",
-            "pseudoCode": "수정 방법을 보여주는 의사 코드 (한국어)",
+            "pseudoCode": "Before:\\n[수정 전 코드]\\n\\nAfter:\\n[수정 후 코드] 형태의 문자열로 줘",
             "sideEffects": "수정 시 발생할 수 있는 부작용 (한국어)"
         }
         """.trimIndent()
     }
 
     /**
-     * GLM API 응답 JSON을 GlmAnalysisRes로 파싱합니다.
+     * GLM API 응답 JSON을 [GlmAnalysisRes]로 파싱합니다.
      *
-     * @throws AnalysisException GLM_API_FAIL - JSON 파싱 실패 시
+     * 응답에 마크다운 코드 블록(` ```json `)이 포함된 경우 제거 후 파싱합니다.
+     * Jackson 역직렬화에 실패하면 [AnalysisException]을 던집니다.
+     *
+     * @param response GLM API의 원본 응답 문자열
+     * @return 파싱된 [GlmAnalysisRes]
+     * @throws AnalysisException GLM_API_FAIL — JSON 파싱 실패 시
      */
     private fun parseResponse(response: String): GlmAnalysisRes {
         return try {
-            // ```json ... ``` 형태로 올 경우 제거
             val cleaned = response
                 .replace(Regex("```json\\s*"), "")
                 .replace(Regex("```\\s*"), "")

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
@@ -89,6 +89,11 @@ class GlmClientImpl(
 
         return try {
             val response = chatModel.call(prompt)
+                ?: throw AnalysisException(
+                    AnalysisErrorCode.GLM_API_FAIL,
+                    "[GlmClientImpl#selectFiles] GLM 응답이 null입니다.",
+                    "관련 파일 탐색에 실패했습니다."
+                )
             parseFileList(response)
         } catch (e: AnalysisException) {
             throw e
@@ -153,7 +158,15 @@ class GlmClientImpl(
                 .replace(Regex("```\\s*"), "")
                 .trim()
             val node = objectMapper.readTree(cleaned)
-            node.get("files").map { it.asText() }
+            val filesNode = node.get("files")
+                ?: throw AnalysisException(
+                    AnalysisErrorCode.GLM_API_FAIL,
+                    "[GlmClientImpl#parseFileList] 'files' 키가 없습니다.",
+                    "관련 파일 탐색 결과를 처리하는 데 실패했습니다."
+                )
+            filesNode.map { it.asText() }
+        } catch (e: AnalysisException) {  // 추가!
+            throw e
         } catch (e: Exception) {
             log.error("[GlmClientImpl#parseFileList] JSON 파싱 실패: $response")
             throw AnalysisException(

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClient.kt
@@ -3,45 +3,66 @@ package com.back.omos.domain.analysis.github
 /**
  * GitHub API 호출 기능을 추상화한 인터페이스입니다.
  *
- * <p>
- * 서비스 계층은 이 인터페이스를 통해 GitHub API를 호출하여
- * 이슈 정보 및 관련 소스코드를 가져옵니다.
- *
- * <p><b>상속 정보:</b><br>
- * 별도의 상속 없이 GitHub API 호출 역할을 정의하는 인터페이스입니다.
+ * 서비스 계층은 이 인터페이스를 통해 이슈 정보 조회([fetchIssue]),
+ * 코드 검색([searchCode]), 파일 내용 조회([fetchFileContent]),
+ * 파일 트리 조회([fetchTree]) 기능을 사용합니다.
  *
  * @author Jaewon Ryu
  * @since 2026-04-24
+ * @see GitHubClientImpl
  */
 interface GitHubClient {
 
     /**
-     * 이슈 정보를 fetch합니다.
+     * 특정 이슈의 상세 정보를 조회합니다.
      *
-     * @param owner 레포지토리 소유자 (e.g. "spring-projects")
-     * @param repo 레포지토리명 (e.g. "spring-boot")
-     * @param issueNumber 이슈 번호
-     * @return 이슈 제목, 본문, 라벨 포함한 응답
+     * @param owner 레포지토리 소유자 (예: `"spring-projects"`)
+     * @param repo 레포지토리명 (예: `"spring-boot"`)
+     * @param issueNumber 조회할 이슈 번호
+     * @return 이슈 제목·본문·라벨을 포함한 [GitHubIssueRes]
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GITHUB_API_FAIL — API 호출 실패 또는 이슈를 찾을 수 없는 경우
      */
     fun fetchIssue(owner: String, repo: String, issueNumber: Int): GitHubIssueRes
 
     /**
-     * 이슈 키워드로 관련 소스코드를 검색합니다.
+     * 이슈 키워드를 기반으로 레포지토리 내 관련 소스코드를 검색합니다.
      *
      * @param keyword 검색 키워드 (이슈 제목 기반)
      * @param owner 레포지토리 소유자
      * @param repo 레포지토리명
-     * @return 검색된 파일 목록
+     * @return 키워드와 매칭된 파일 목록을 담은 [GitHubCodeSearchRes]
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GITHUB_API_FAIL — API 호출 실패 또는 Rate Limit 초과 시
      */
     fun searchCode(keyword: String, owner: String, repo: String): GitHubCodeSearchRes
 
     /**
-     * 파일 raw content를 fetch합니다.
+     * 특정 파일의 raw 내용을 조회합니다.
+     *
+     * 파일이 존재하지 않거나 조회에 실패하면 null을 반환합니다.
+     * 호출부는 null을 정상 케이스(파일 없음)로 처리해야 합니다.
      *
      * @param owner 레포지토리 소유자
      * @param repo 레포지토리명
-     * @param path 파일 경로 (e.g. "src/main/kotlin/Example.kt")
-     * @return 디코딩된 파일 내용, 없으면 null
+     * @param path 조회할 파일 경로 (예: `"src/main/kotlin/Example.kt"`)
+     * @return 디코딩된 파일 내용 문자열. 파일이 없거나 조회 실패 시 null
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GITHUB_API_FAIL — 네트워크 오류 등 복구 불가능한 API 실패 시
      */
     fun fetchFileContent(owner: String, repo: String, path: String): String?
+
+    /**
+     * 레포지토리의 전체 파일 경로 목록을 조회합니다.
+     *
+     * 디렉토리는 제외하고 파일 경로만 반환합니다.
+     * 규모가 큰 레포지토리의 경우 응답에 시간이 걸릴 수 있습니다.
+     *
+     * @param owner 레포지토리 소유자
+     * @param repo 레포지토리명
+     * @return 레포지토리 내 전체 파일 경로 목록 (디렉토리 제외)
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GITHUB_API_FAIL — API 호출 실패 또는 Rate Limit 초과 시
+     */
+    fun fetchTree(owner: String, repo: String): List<String>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -130,4 +130,27 @@ class GitHubClientImpl(
             null
         }
     }
+    override fun fetchTree(owner: String, repo: String): List<String> {
+        return try {
+            val response = restClient.get()
+                .uri("/repos/$owner/$repo/git/trees/HEAD?recursive=1")
+                .retrieve()
+                .body(GitHubTreeRes::class.java)
+                ?: throw AnalysisException(
+                    AnalysisErrorCode.GITHUB_API_FAIL,
+                    "[GitHubClientImpl#fetchTree] 응답이 null입니다: $owner/$repo",
+                    "레포지토리 파일 목록을 가져오는 데 실패했습니다."
+                )
+
+            response.tree
+                .filter { it.type == "blob" }
+                .map { it.path }
+        } catch (e: RestClientResponseException) {
+            throw AnalysisException(
+                AnalysisErrorCode.GITHUB_API_FAIL,
+                "[GitHubClientImpl#fetchTree] HTTP ${e.statusCode}: $owner/$repo",
+                "레포지토리 파일 목록을 가져오는 데 실패했습니다."
+            )
+        }
+    }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -142,9 +142,20 @@ class GitHubClientImpl(
                     "레포지토리 파일 목록을 가져오는 데 실패했습니다."
                 )
 
+            // truncated=true면 대형 레포로 판단, 부분 목록으로 분석 진행 시 오탐 가능성 있음
+            if (response.truncated) {
+                throw AnalysisException(
+                    AnalysisErrorCode.GITHUB_API_FAIL,
+                    "[GitHubClientImpl#fetchTree] 트리 결과가 잘렸습니다: $owner/$repo",
+                    "레포지토리가 너무 커서 전체 파일 목록을 가져올 수 없습니다."
+                )
+            }
+
             response.tree
                 .filter { it.type == "blob" }
                 .map { it.path }
+        } catch (e: AnalysisException) {
+            throw e
         } catch (e: RestClientResponseException) {
             throw AnalysisException(
                 AnalysisErrorCode.GITHUB_API_FAIL,

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubTreeRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubTreeRes.kt
@@ -1,0 +1,14 @@
+package com.back.omos.domain.analysis.github
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitHubTreeRes(
+    val tree: List<GitHubTreeItem>
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitHubTreeItem(
+    val path: String,
+    val type: String  // "blob" = 파일, "tree" = 디렉토리
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubTreeRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubTreeRes.kt
@@ -2,13 +2,29 @@ package com.back.omos.domain.analysis.github
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
+/**
+ * GitHub Git Tree API 응답 최상위 객체입니다.
+ *
+ * GET /repos/{owner}/{repo}/git/trees/{tree_sha}?recursive=1
+ *
+ * @property tree 트리에 포함된 파일/디렉토리 항목 목록
+ * @property truncated 응답이 잘렸는지 여부.
+ *           레포 크기가 크면 GitHub가 일부 항목만 반환하고 true로 설정합니다.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GitHubTreeRes(
-    val tree: List<GitHubTreeItem>
+    val tree: List<GitHubTreeItem>,
+    val truncated: Boolean = false
 )
 
+/**
+ * GitHub Git Tree API 응답의 개별 항목입니다.
+ *
+ * @property path 파일 또는 디렉토리의 경로 (예: "src/main/kotlin/Foo.kt")
+ * @property type 항목 유형. "blob" = 파일, "tree" = 디렉토리
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class GitHubTreeItem(
     val path: String,
-    val type: String  // "blob" = 파일, "tree" = 디렉토리
+    val type: String
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerService.kt
@@ -4,38 +4,53 @@ import com.back.omos.domain.analysis.dto.GuideResponseDto
 import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
 
 /**
- * 코드에 대한 전체적인 역할을 적습니다.
- * <p>
- * 코드에 대한 작동 원리 등을 적습니다.
+ * 이슈에 대한 코드 수정 가이드 및 수도 코드 조회 기능을 정의하는 서비스 인터페이스입니다.
  *
- * <p><b>상속 정보:</b><br>
- * 상속 정보를 적습니다.
+ * 서비스 계층은 이 인터페이스를 통해 GitHub 이슈를 분석하고,
+ * 분석 결과([GuideResponseDto], [PseudoCodeResponseDto])를 반환합니다.
  *
- * <p><b>주요 생성자:</b><br>
- * {@code ContextAnalyzerService(String example)} <br>
- * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
- *
- * <p><b>빈 관리:</b><br>
- * 필요 시 빈 관리에 대한 내용을 적습니다.
- *
- * <p><b>외부 모듈:</b><br>
- * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ * **캐시 정책:**
+ * 분석 결과가 이미 존재하면 즉시 반환하고, 없으면 GitHub API와 GLM API를
+ * 통해 새로운 분석 결과를 생성합니다.
+ * 이슈 수정 여부에 따른 캐시 갱신은 현재 미구현 상태입니다. ([TODO])
  *
  * @author Jaewon Ryu
  * @since 2026-04-22
- * @see
+ * @see ContextAnalyzerServiceImpl
  */
 interface ContextAnalyzerService {
 
     /**
      * 이슈에 대한 코드 수정 가이드를 조회합니다.
-     * 캐시된 결과가 있고 이슈가 수정되지 않았으면 캐시를 반환하고,
-     * 이슈가 수정됐거나 캐시가 없으면 새로 분석합니다.
+     *
+     * 분석 결과가 캐시되어 있으면 즉시 반환합니다.
+     * 캐시가 없으면 GitHub API와 GLM API를 통해 분석 결과를 생성하고 저장한 뒤 반환합니다.
+     *
+     * @param issueId 조회할 이슈의 식별자
+     * @return 파일 경로 목록·가이드라인·사이드 이펙트를 담은 [GuideResponseDto]
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         ISSUE_NOT_FOUND — 이슈가 존재하지 않는 경우
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GITHUB_API_FAIL — GitHub API 호출에 실패한 경우
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GLM_API_FAIL — GLM API 호출 또는 응답 파싱에 실패한 경우
      */
     fun getGuide(issueId: Long): GuideResponseDto
 
     /**
-     * 이슈에 대한 의사 코드를 조회합니다.
+     * 이슈에 대한 수도 코드를 조회합니다.
+     *
+     * 분석 결과가 캐시되어 있으면 즉시 반환합니다.
+     * 캐시가 없으면 GitHub API와 GLM API를 통해 분석 결과를 생성하고 저장한 뒤 반환합니다.
+     *
+     * @param issueId 조회할 이슈의 식별자
+     * @return 파일 경로 목록·수도 코드를 담은 [PseudoCodeResponseDto]
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         ISSUE_NOT_FOUND — 이슈가 존재하지 않는 경우
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GITHUB_API_FAIL — GitHub API 호출에 실패한 경우
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         GLM_API_FAIL — GLM API 호출 또는 응답 파싱에 실패한 경우
      */
     fun getPseudoCode(issueId: Long): PseudoCodeResponseDto
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -17,20 +17,21 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Context Analyzer의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
- * <p>
- * 이슈에 대한 코드 수정 가이드 조회 요청을 처리하며,
- * 캐시된 분석 결과가 유효하면 즉시 반환하고,
- * 이슈가 수정되었거나 캐시가 없으면 GLM API를 호출하여 새로운 분석 결과를 생성합니다.
+ * [ContextAnalyzerService]의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
  *
- * <p><b>캐시 갱신 정책:</b><br>
- * 이슈의 updatedAt과 분석 결과의 createdAt을 비교하여,
- * 이슈가 분석 이후 수정된 경우에만 가이드를 재생성합니다.
- * 기존 결과가 있으면 동일 row를 업데이트하고, 없으면 새로 생성합니다.
+ * 이슈에 대한 코드 수정 가이드 및 수도 코드 조회 요청을 처리합니다.
+ *
+ * <p><b>현재 캐시 정책:</b><br>
+ * [AnalysisResultRepository]에 해당 이슈의 분석 결과가 존재하면 즉시 반환합니다.
+ * 분석 결과가 없는 경우에만 GitHub API와 GLM API를 통해 새 분석 결과를 생성하고 저장합니다.
+ *
+ * <p><b>캐시 갱신 (미구현 — TODO):</b><br>
+ * [isIssueModifiedAfterAnalysis]를 통해 이슈의 updatedAt과 분석 결과의 createdAt을 비교,
+ * 이슈가 분석 이후 수정된 경우 가이드를 재생성하는 로직이 설계되어 있으나 아직 적용되지 않았습니다.
  *
  * <p><b>외부 모듈:</b><br>
- * GitHub API — 관련 소스코드 수집 <br>
- * GLM API — 코드 수정 가이드 생성
+ * GitHub API — 관련 소스코드 수집<br>
+ * GLM API — 코드 수정 가이드 및 수도 코드 생성
  *
  * @author Jaewon Ryu
  * @since 2026-04-22
@@ -89,17 +90,38 @@ class ContextAnalyzerServiceImpl(
 
     /**
      * 이슈가 분석 이후 수정되었는지 판단합니다.
+     *
+     * TODO: [getGuide], [getPseudoCode]의 캐시 갱신 조건으로 연결 필요.
+     *       현재 이 메서드는 호출되지 않으므로 캐시 무효화가 동작하지 않습니다.
+     *
+     * @param issue 캐시 유효성을 검사할 이슈
+     * @param result 비교 대상인 기존 분석 결과
+     * @return 이슈의 [Issue.updatedAt]이 분석 결과의 [AnalysisResult.createdAt]보다 늦으면 true
      */
     private fun isIssueModifiedAfterAnalysis(issue: Issue, result: AnalysisResult): Boolean {
         return issue.updatedAt.isAfter(result.createdAt)
     }
 
     /**
-     * GitHub API로 소스코드를 수집하고 GLM API로 분석 결과를 생성합니다.
+     * GitHub API로 관련 소스코드를 수집하고 GLM API로 분석 결과를 생성한 뒤 저장합니다.
+     *
+     * 처리 흐름:
+     * 1. [Issue.repoFullName]에서 owner/repo 파싱
+     * 2. GitHub API로 이슈 상세 정보 fetch
+     * 3. GitHub API로 레포지토리 전체 파일 트리 fetch 후 지원 확장자로 필터링
+     * 4. 이슈 제목 키워드와 매칭되는 파일 경로 선별 (매칭 없으면 상위 5개 폴백)
+     * 5. 선택된 파일의 내용 fetch
+     * 6. 선택된 파일 경로를 JSON 배열 문자열로 직렬화
+     * 7. GLM API로 가이드·수도 코드·사이드 이펙트 분석 수행
+     *
+     * @param issue 분석 대상 이슈
+     * @return 저장된 [AnalysisResult]
+     * @throws AnalysisException [Issue.repoFullName] 형식이 `owner/repo`가 아닌 경우,
+     *                           또는 GitHub/GLM API 호출에 실패하는 경우
      */
     private fun generateAnalysis(issue: Issue): AnalysisResult {
 
-        // 1. repositoryId로 Repo 조회 → owner/repo 파싱
+        // 1. repoFullName에서 owner/repo 파싱
         val parts = issue.repoFullName.split("/")
         if (parts.size != 2) {
             throw AnalysisException(
@@ -113,22 +135,38 @@ class ContextAnalyzerServiceImpl(
         // 2. 이슈 정보 fetch
         val issueInfo = gitHubClient.fetchIssue(owner, repoName, issue.issueNumber.toInt())
 
-        // 3. 이슈 제목으로 관련 파일 검색
-        val searchResult = gitHubClient.searchCode(issueInfo.title, owner, repoName)
+        // 3. 레포 전체 파일 트리 fetch 후 지원 확장자(.ts/.js/.kt/.java/.py/.go/.rs/.cpp)로 필터링
+        val allFilePaths = gitHubClient.fetchTree(owner, repoName)
+            .filter { path ->
+                path.endsWith(".ts") || path.endsWith(".js") ||
+                        path.endsWith(".kt") || path.endsWith(".java") ||
+                        path.endsWith(".py") || path.endsWith(".go") ||
+                        path.endsWith(".rs") || path.endsWith(".cpp")
+            }
 
-        // 4. 검색된 파일들 내용 fetch (최대 5개로 제한)
-        val fileContents = searchResult.items
+        val keywords = issueInfo.title
+            .lowercase()
+            .split(" ", "-", "_", ".")
+            .filter { it.length > 3 }
+
+        // 4. 키워드 매칭 파일 우선 선별, 매칭 결과 없으면 상위 5개로 폴백
+        val selectedPaths = allFilePaths
+            .filter { path -> keywords.any { keyword -> path.lowercase().contains(keyword) } }
             .take(5)
-            .mapNotNull { item ->
-                val content = gitHubClient.fetchFileContent(owner, repoName, item.path)
-                if (content != null) item.path to content else null
+            .ifEmpty { allFilePaths.take(5) }
+
+        // 5. 선택된 파일 내용 fetch (fetch 실패 시 해당 파일 제외)
+        val fileContents = selectedPaths
+            .mapNotNull { path ->
+                val content = gitHubClient.fetchFileContent(owner, repoName, path)
+                if (content != null) path to content else null
             }
             .toMap()
 
-        // 5. filePaths JSON 직렬화
+        // 6. filePaths JSON 직렬화
         val filePaths = objectMapper.writeValueAsString(fileContents.keys.toList())
 
-        // 6. GLM API로 가이드 생성
+        // 7. GLM API로 가이드 생성
         val labels = issueInfo.labels.map { it.name }
         val glmResult = glmClient.analyze(
             issueTitle = issueInfo.title,
@@ -163,9 +201,14 @@ class ContextAnalyzerServiceImpl(
     }
 
     /**
-     * JSON 배열 문자열을 List<String>으로 파싱합니다.
+     * JSON 배열 문자열을 [List]<[String]>으로 파싱합니다.
      *
-     * @param filePaths JSON 배열 형태의 파일 경로 문자열
+     * [AnalysisResult.filePaths]는 [generateAnalysis]에서 Jackson으로 직렬화된 값이므로
+     * 정상적인 흐름에서는 항상 유효한 JSON입니다.
+     * 단, DB에 비정상적인 값이 저장된 경우 [com.fasterxml.jackson.core.JsonProcessingException]이
+     * 발생할 수 있으므로, 필요 시 호출부에서 [AnalysisException]으로 래핑하는 것을 고려하세요.
+     *
+     * @param filePaths JSON 배열 형태의 파일 경로 문자열 (예: `["src/Foo.kt","src/Bar.kt"]`)
      * @return 파싱된 파일 경로 목록
      */
     private fun parseFilePaths(filePaths: String): List<String> {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -120,8 +120,6 @@ class ContextAnalyzerServiceImpl(
      *                           또는 GitHub/GLM API 호출에 실패하는 경우
      */
     private fun generateAnalysis(issue: Issue): AnalysisResult {
-
-        // 1. repoFullName에서 owner/repo 파싱
         val parts = issue.repoFullName.split("/")
         if (parts.size != 2) {
             throw AnalysisException(
@@ -132,10 +130,9 @@ class ContextAnalyzerServiceImpl(
         }
         val (owner, repoName) = parts
 
-        // 2. 이슈 정보 fetch
         val issueInfo = gitHubClient.fetchIssue(owner, repoName, issue.issueNumber.toInt())
 
-        // 3. 레포 전체 파일 트리 fetch 후 지원 확장자(.ts/.js/.kt/.java/.py/.go/.rs/.cpp)로 필터링
+        // 1단계: 확장자 필터링
         val allFilePaths = gitHubClient.fetchTree(owner, repoName)
             .filter { path ->
                 path.endsWith(".ts") || path.endsWith(".js") ||
@@ -144,18 +141,24 @@ class ContextAnalyzerServiceImpl(
                         path.endsWith(".rs") || path.endsWith(".cpp")
             }
 
+        // 2단계: 키워드 프리필터링으로 GLM에 넘길 후보를 MAX_CANDIDATE_FILES 이하로 제한
         val keywords = issueInfo.title
             .lowercase()
             .split(" ", "-", "_", ".")
             .filter { it.length > 3 }
 
-        // 4. 키워드 매칭 파일 우선 선별, 매칭 결과 없으면 상위 5개로 폴백
-        val selectedPaths = allFilePaths
+        val candidatePaths = allFilePaths
             .filter { path -> keywords.any { keyword -> path.lowercase().contains(keyword) } }
-            .take(5)
-            .ifEmpty { allFilePaths.take(5) }
+            .take(MAX_CANDIDATE_FILES)
+            .ifEmpty { allFilePaths.take(MAX_CANDIDATE_FILES) }
 
-        // 5. 선택된 파일 내용 fetch (fetch 실패 시 해당 파일 제외)
+        // 3단계: 좁혀진 후보 내에서 GLM이 최종 선별
+        val selectedPaths = glmClient.selectFiles(
+            issueTitle = issueInfo.title,
+            issueBody = issueInfo.body,
+            filePaths = candidatePaths
+        )
+
         val fileContents = selectedPaths
             .mapNotNull { path ->
                 val content = gitHubClient.fetchFileContent(owner, repoName, path)
@@ -163,10 +166,7 @@ class ContextAnalyzerServiceImpl(
             }
             .toMap()
 
-        // 6. filePaths JSON 직렬화
         val filePaths = objectMapper.writeValueAsString(fileContents.keys.toList())
-
-        // 7. GLM API로 가이드 생성
         val labels = issueInfo.labels.map { it.name }
         val glmResult = glmClient.analyze(
             issueTitle = issueInfo.title,
@@ -175,14 +175,19 @@ class ContextAnalyzerServiceImpl(
             fileContents = fileContents
         )
 
-        val newResult = AnalysisResult(
-            issue = issue,
-            filePaths = filePaths,
-            guideline = glmResult.guideline,
-            pseudoCode = glmResult.pseudoCode,
-            sideEffects = glmResult.sideEffects
+        return analysisResultRepository.save(
+            AnalysisResult(
+                issue = issue,
+                filePaths = filePaths,
+                guideline = glmResult.guideline,
+                pseudoCode = glmResult.pseudoCode,
+                sideEffects = glmResult.sideEffects
+            )
         )
-        return analysisResultRepository.save(newResult)
+    }
+
+    companion object {
+        private const val MAX_CANDIDATE_FILES = 30  // GLM에 넘기는 후보 파일 최대 개수
     }
 
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -152,12 +152,18 @@ class ContextAnalyzerServiceImpl(
             .take(MAX_CANDIDATE_FILES)
             .ifEmpty { allFilePaths.take(MAX_CANDIDATE_FILES) }
 
-        // 3단계: 좁혀진 후보 내에서 GLM이 최종 선별
+// 3단계: 좁혀진 후보 내에서 GLM이 최종 선별 + 결과 검증
+        val candidatePathsSet = candidatePaths.toSet()
         val selectedPaths = glmClient.selectFiles(
             issueTitle = issueInfo.title,
             issueBody = issueInfo.body,
             filePaths = candidatePaths
         )
+            .asSequence()
+            .filter { it in candidatePathsSet }  // 후보 외 경로 제거
+            .distinct()                           // 중복 제거
+            .take(MAX_SELECT_FILES)               // 최대 5개 강제 제한
+            .toList()
 
         val fileContents = selectedPaths
             .mapNotNull { path ->
@@ -188,6 +194,7 @@ class ContextAnalyzerServiceImpl(
 
     companion object {
         private const val MAX_CANDIDATE_FILES = 30  // GLM에 넘기는 후보 파일 최대 개수
+        private const val MAX_SELECT_FILES = 5       // GLM이 최종 선별하는 파일 최대 개수
     }
 
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -193,8 +193,10 @@ class ContextAnalyzerServiceImpl(
     }
 
     companion object {
-        private const val MAX_CANDIDATE_FILES = 30  // GLM에 넘기는 후보 파일 최대 개수
-        private const val MAX_SELECT_FILES = 5       // GLM이 최종 선별하는 파일 최대 개수
+        /** GLM에 넘기는 후보 파일 최대 개수. 테스트 결과 30개 초과 시 GLM 응답 품질 저하 및 토큰 초과 가능성이 있어 설정. */
+        private const val MAX_CANDIDATE_FILES = 30
+        /** GLM이 최종 선별하는 파일 최대 개수. 5개 초과 시 fetchFileContent 호출 증가로 응답 지연 발생. */
+        private const val MAX_SELECT_FILES = 5
     }
 
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -73,13 +73,8 @@ class ContextAnalyzerServiceImplTest {
     // 테스트용 픽스처 (공통으로 쓰는 더미 데이터)
     // ──────────────────────────────────────────
 
-    private val mockRepo = Repo(
-        fullName = "spring-projects/spring-boot",
-        url = "https://github.com/spring-projects/spring-boot"
-    )
-
     private val mockIssue = Issue(
-        repositoryId = 1L,
+        repoFullName = "spring-projects/spring-boot",
         issueNumber = 42L,
         title = "Fix NullPointerException",
         content = "이슈 본문",
@@ -145,7 +140,6 @@ class ContextAnalyzerServiceImplTest {
             // given
             given(issueRepository.findById(1L)).willReturn(Optional.of(mockIssue))
             given(analysisResultRepository.findByIssueId(1L)).willReturn(null)
-            given(repoRepository.findById(1L)).willReturn(Optional.of(mockRepo))
             given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42))
                 .willReturn(mockIssueInfo)
             given(gitHubClient.searchCode("Fix NullPointerException", "spring-projects", "spring-boot"))

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -142,29 +142,30 @@ class ContextAnalyzerServiceImplTest {
             given(analysisResultRepository.findByIssueId(1L)).willReturn(null)
             given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42))
                 .willReturn(mockIssueInfo)
-            given(gitHubClient.searchCode("Fix NullPointerException", "spring-projects", "spring-boot"))
-                .willReturn(mockSearchResult)
+            given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
+                .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
+            given(glmClient.selectFiles(any(), anyOrNull(), any()))
+                .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
             given(gitHubClient.fetchFileContent("spring-projects", "spring-boot", "src/main/kotlin/com/example/UserService.kt"))
                 .willReturn("fun userService() { ... }")
-            given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
             given(glmClient.analyze(any(), anyOrNull(), any(), any()))
                 .willReturn(GlmAnalysisRes(
                     guideline = "가이드라인",
                     pseudoCode = "의사코드",
                     sideEffects = "부작용"
                 ))
+            given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
 
             // when
             val result = contextAnalyzerService.getGuide(1L)
 
             // then
             assertNotNull(result)
-            // GitHub API 호출됐는지 검증
             then(gitHubClient).should().fetchIssue("spring-projects", "spring-boot", 42)
-            then(gitHubClient).should().searchCode("Fix NullPointerException", "spring-projects", "spring-boot")
+            then(gitHubClient).should().fetchTree("spring-projects", "spring-boot")
+            then(glmClient).should().selectFiles(any(), anyOrNull(), any())
             then(analysisResultRepository).should().save(any())
         }
-
         @Test
         @DisplayName("이슈가 없으면 AnalysisException을 던진다")
         fun `이슈 없으면 예외 던짐`() {


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
GitHub Code Search API 기반의 v1 파일 탐색 방식을 GitHub Tree API + 3단계 필터링 기반의 v2로 개선했습니다.
v1에서는 이슈 제목 키워드로 Code Search를 수행했는데, 이슈 제목이 길거나 특수문자가 포함된 경우 검색 결과가 0개로 나와 filePaths가 비어있는 문제가 있었습니다.

## 🔗 관련 이슈
- Close #78

## 🛠️ 주요 변경 사항
- [x] `GitHubClient.fetchTree()` 구현 — GitHub Tree API로 레포 전체 파일 트리 fetch
- [x] `GitHubTreeRes`, `GitHubTreeItem` DTO 추가
- [x] `GlmClient.selectFiles()` 구현 — 파일 탐색용 GLM 프롬프트 분리
- [x] `generateAnalysis()` 흐름 개선 — Code Search 제거, 3단계 필터링으로 교체
- [x] `ContextAnalyzerServiceImplTest` 업데이트 — fetchTree/selectFiles Mock 추가

## 🔍 v1 → v2 개선 내용

### 문제 (v1)
이슈 제목 → GitHub Code Search API
→ 이슈 제목이 길거나 특수문자 포함 시 검색 결과 0개
→ filePaths 비어있음
→ GLM이 이슈 내용만으로 가이드 생성 (파일 컨텍스트 없음)

### 해결 (v2) — 3단계 필터링
1단계 — 확장자 필터링
fetchTree()로 가져온 전체 파일 트리에서
지원 언어 확장자만 남깁니다. (.ts, .js, .kt, .java, .py, .go, .rs, .cpp)
전체 파일 수백 개 → 소스코드 파일만

2단계 — 키워드 프리필터링 (MAX_CANDIDATE_FILES: 30)
이슈 제목을 공백/하이픈/언더스코어 기준으로 토크나이징하여 키워드를 추출하고,
파일 경로에 키워드가 포함된 파일을 우선 선별합니다.
키워드 매칭 결과가 없으면 확장자 필터링된 파일 상위 30개로 폴백합니다.
소스코드 파일 → 이슈 관련 후보 최대 30개

3단계 — GLM 최종 선별
30개 이하의 후보 경로를 glmClient.selectFiles()에 전달하여
이슈 제목·본문을 함께 고려한 최종 관련 파일 5개를 선별합니다.
후보 30개 → 최종 파일 5개

## 🧪 테스트 결과

**단위 테스트 5개 전체 통과 (561ms)**
<img width="651" height="192" alt="image" src="https://github.com/user-attachments/assets/1858e0d6-827a-4b82-bf77-7cfb04a3c5f8" />

**GET /api/v1/issues/{issueId}/guide (1m 32s)**
microsoft/vscode 이슈 #312509 기반 실제 테스트
- filePaths에 이슈 관련 파일 정상 탐색 확인
- guideline, sideEffects 생성 확인
<img width="1593" height="411" alt="image" src="https://github.com/user-attachments/assets/31523945-3caf-4136-9e4a-2b4eb4fc78f5" />

**GET /api/v1/issues/{issueId}/pseudo (66ms)**
- 캐시 HIT 확인 (두 번째 호출 시 GitHub/GLM API 재호출 없음)
- pseudoCode 정상 반환 확인
<img width="1583" height="382" alt="image" src="https://github.com/user-attachments/assets/17b12c6d-3cec-4f55-af6a-2b81f52cbd9d" />

## 🧐 리뷰어에게

**프롬프트 할루시네이션 대응**
pseudoCode가 완전한 코드를 생성하면 할루시네이션 위험이 높아져, 어느 함수/클래스의 어느 부분을 어떤 방향으로 바꿔야 하는지만 설명하도록 프롬프트를 수정했습니다.

**응답 시간**
현재 1분 30초 ~ 3분 이내 수준입니다.
GLM을 두 번 호출(selectFiles + analyze)하는 구조로 인해 응답 시간이 길어졌습니다.

**레포 규모에 따른 성능 차이**
키워드 프리필터링의 정확도는 레포 규모에 크게 영향을 받습니다.

- 대규모 레포 (microsoft/vscode, 파일 수만 개): 키워드가 파일 경로에 매칭되지 않는 경우가 많아 폴백(상위 30개)으로 처리됨 → 정확도 낮음, 응답 시간 ~1분 30초
- 소규모 레포 (hensu-project/hensu, 파일 수백 개): 키워드 매칭이 정확히 동작하여 관련 파일 5개 정확하게 선별됨 → 정확도 높음

fet/be/context-analyzer 브랜치로 병합합니다.

이후에 main에서 test 후에 main으로 merge 하겠습니다.