### PR TITLE
[#83][FEAT] Pr 번역 기능 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/AiClient.kt
@@ -1,7 +1,7 @@
 package com.back.omos.domain.prdraft.ai
 
 /**
- * PR 초안 생성을 위한 AI 호출 기능을 추상화한 인터페이스입니다.
+ * PR 초안 생성 및 번역을 위한 AI 호출 기능을 추상화한 인터페이스입니다.
  *
  * <p>
  * 서비스 계층은 이 인터페이스를 통해 AI 모델에 프롬프트를 전달하고,
@@ -25,4 +25,13 @@ interface AiClient {
      * @return AI가 생성한 PR 제목 및 본문
      */
     fun generatePrDraft(prompt: String): AiPrResult
+
+    /**
+     * 한국어 PR 제목과 본문을 영어로 번역합니다.
+     *
+     * @param title 번역할 PR 제목 (한국어)
+     * @param body 번역할 PR 본문 (한국어)
+     * @return 영어로 번역된 PR 제목 및 본문
+     */
+    fun translate(title: String, body: String): AiPrResult
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/MockAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/MockAiClient.kt
@@ -36,4 +36,20 @@ class MockAiClient : AiClient {
             """.trimIndent()
         )
     }
+
+    override fun translate(title: String, body: String): AiPrResult {
+        return AiPrResult(
+            title = "fix: mock PR title",
+            body = """
+                ## Changes
+                - Generated PR draft based on diff content.
+
+                ## How to Test
+                - Verified the related feature directly.
+
+                ## Related Issue
+                - close #123
+            """.trimIndent()
+        )
+    }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -39,6 +39,29 @@ class SpringAiClient(
         return parseResponse(response)
     }
 
+    override fun translate(title: String, body: String): AiPrResult {
+        val prompt = """
+            Translate the following Korean PR title and body into natural English.
+            Return only the JSON below with no extra text.
+            {
+              "title": "translated title",
+              "body": "translated body"
+            }
+
+            [Korean Title]
+            $title
+
+            [Korean Body]
+            $body
+        """.trimIndent()
+
+        val response = chatModel.call(prompt)
+            .takeIf { it.isNotBlank() }
+            ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+
+        return parseResponse(response)
+    }
+
     private fun parseResponse(response: String): AiPrResult {
         val json = extractJson(response)
             ?: run {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -31,6 +31,13 @@ class SpringAiClient(
 
     private val logger = KotlinLogging.logger {}
 
+    /**
+     * 전달받은 프롬프트를 GLM에 전달하여 PR 초안을 생성합니다.
+     *
+     * @param prompt AI에게 전달할 PR 생성 프롬프트
+     * @return AI가 생성한 PR 제목 및 본문
+     * @throws AiException AI 응답이 비어 있거나 JSON 파싱에 실패한 경우
+     */
     override fun generatePrDraft(prompt: String): AiPrResult {
         val response = chatModel.call(prompt)
             .takeIf { it.isNotBlank() }
@@ -39,6 +46,14 @@ class SpringAiClient(
         return parseResponse(response)
     }
 
+    /**
+     * 한국어 PR 제목과 본문을 영어로 번역합니다.
+     *
+     * @param title 번역할 PR 제목 (한국어)
+     * @param body 번역할 PR 본문 (한국어)
+     * @return 영어로 번역된 PR 제목 및 본문
+     * @throws AiException AI 응답이 비어 있거나 JSON 파싱에 실패한 경우
+     */
     override fun translate(title: String, body: String): AiPrResult {
         val prompt = """
             Translate the following Korean PR title and body into natural English.
@@ -62,6 +77,13 @@ class SpringAiClient(
         return parseResponse(response)
     }
 
+    /**
+     * AI 응답 문자열에서 JSON을 추출하고 [AiPrResult]로 역직렬화합니다.
+     *
+     * @param response AI 원본 응답 문자열
+     * @return 파싱된 PR 제목 및 본문
+     * @throws AiException JSON 추출 또는 역직렬화에 실패한 경우
+     */
     private fun parseResponse(response: String): AiPrResult {
         val json = extractJson(response)
             ?: run {
@@ -79,6 +101,12 @@ class SpringAiClient(
         }
     }
 
+    /**
+     * 로그에 민감한 AI 응답 원문 대신 길이와 SHA-256 해시 앞 16자리를 반환합니다.
+     *
+     * @param value 로깅할 문자열
+     * @return 길이와 해시 정보를 담은 안전한 로그 문자열
+     */
     private fun safeLog(value: String): String {
         val hash = MessageDigest.getInstance("SHA-256")
             .digest(value.toByteArray())
@@ -87,6 +115,16 @@ class SpringAiClient(
         return "len=${value.length}, sha256=$hash"
     }
 
+    /**
+     * AI 응답에서 JSON 객체를 추출합니다.
+     *
+     * <p>
+     * 마크다운 코드 블록(```json ... ```)이 있으면 그 안의 내용을 우선 추출하고,
+     * 없으면 중괄호 패턴으로 JSON 객체를 탐색합니다.
+     *
+     * @param response AI 원본 응답 문자열
+     * @return 추출된 JSON 문자열, 찾지 못한 경우 null
+     */
     private fun extractJson(response: String): String? {
         val fenceMatch = Regex("""```(?:json)?\s*([\s\S]*?)```""").find(response)
         if (fenceMatch != null) return fenceMatch.groupValues[1].trim()

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -4,6 +4,7 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.dto.UpdatePrReq
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.principal.OAuthPrincipal
@@ -20,11 +21,11 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * PR 초안 생성, 조회, 수정, 삭제 요청을 처리하는 Controller입니다.
+ * PR 초안 생성, 조회, 수정, 번역, 삭제 요청을 처리하는 Controller입니다.
  *
  * <p>
  * diff 내용과 이슈 정보를 받아 AI 기반 PR 초안을 생성하고,
- * 생성된 초안의 단건/목록 조회, 수정 및 삭제 기능을 제공합니다.
+ * 생성된 초안의 단건/목록 조회, 수정, 영어 번역 및 삭제 기능을 제공합니다.
  * </p>
  *
  * <p><b>상속 정보:</b><br>
@@ -72,6 +73,14 @@ class PrDraftController(
         @Valid @RequestBody req: UpdatePrReq
     ): CommonResponse<PrDetailRes> {
         return CommonResponse.success(prDraftService.update(principal.githubId, id, req))
+    }
+
+    @PostMapping("/{id}/translate")
+    fun translate(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
+        @PathVariable id: Long
+    ): CommonResponse<PrTranslateRes> {
+        return CommonResponse.success(prDraftService.translate(principal.githubId, id))
     }
 
     @DeleteMapping("/{id}")

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrInfoRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrInfoRes.kt
@@ -4,18 +4,15 @@ package com.back.omos.domain.prdraft.dto
  * 생성된 PR 정보를 응답으로 전달하는 DTO입니다.
  *
  * <p>
- * AI를 통해 생성된 PR 제목과 본문, 그리고 GitHub PR 생성 페이지 URL을 포함합니다.
- * githubUrl을 통해 제목과 본문이 미리 채워진 GitHub PR 작성 창으로 바로 이동할 수 있습니다.
+ * AI를 통해 생성된 PR 제목과 본문을 포함합니다.
  *
  * @property title AI가 생성한 PR 제목
  * @property body AI가 생성한 PR 본문
- * @property githubUrl 제목과 본문이 pre-fill된 GitHub PR 생성 URL
  *
  * @author 5h6vm
  * @since 2026-04-22
  */
 data class PrInfoRes(
     val title: String,
-    val body: String,
-    val githubUrl: String
+    val body: String
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrInfoRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrInfoRes.kt
@@ -4,8 +4,9 @@ package com.back.omos.domain.prdraft.dto
  * 생성된 PR 정보를 응답으로 전달하는 DTO입니다.
  *
  * <p>
- * AI를 통해 생성된 PR 제목과 본문을 포함합니다.
+ * AI를 통해 생성된 PR 초안의 id, 제목, 본문을 포함합니다.
  *
+ * @property id 생성된 PR 초안 ID
  * @property title AI가 생성한 PR 제목
  * @property body AI가 생성한 PR 본문
  *
@@ -13,6 +14,7 @@ package com.back.omos.domain.prdraft.dto
  * @since 2026-04-22
  */
 data class PrInfoRes(
+    val id: Long,
     val title: String,
     val body: String
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrTranslateRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrTranslateRes.kt
@@ -1,0 +1,20 @@
+package com.back.omos.domain.prdraft.dto
+
+/**
+ * PR 초안 번역 결과를 응답으로 전달하는 DTO입니다.
+ *
+ * <p>
+ * 영어로 번역된 PR 제목과 본문, 그리고 해당 내용이 pre-fill된 GitHub PR 작성 창 URL을 포함합니다.
+ *
+ * @property titleEn 영어로 번역된 PR 제목
+ * @property bodyEn 영어로 번역된 PR 본문
+ * @property githubUrl 번역된 제목과 본문이 pre-fill된 GitHub PR 생성 URL
+ *
+ * @author 5h6vm
+ * @since 2026-04-28
+ */
+data class PrTranslateRes(
+    val titleEn: String,
+    val bodyEn: String,
+    val githubUrl: String
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -63,6 +63,7 @@ class PrDraftPromptBuilder {
         return """
             당신은 오픈소스 프로젝트의 PR 초안 작성 도우미입니다.
             아래 diff를 바탕으로 PR 제목과 본문을 작성하세요.
+            반드시 제목과 본문 모두 한국어로 작성하세요.
             $contextSection
             [Diff]
             ${req.diffContent}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -25,7 +25,7 @@ interface PrDraftService {
      *
      * @param githubId 요청한 사용자의 GitHub ID
      * @param request PR 생성 요청 DTO (issueId, diffContent 포함)
-     * @return 생성된 PR 제목, 본문, GitHub URL
+     * @return 생성된 PR 제목, 본문
      */
     fun create(githubId: String, request: CreatePrReq): PrInfoRes
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -4,13 +4,14 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.dto.UpdatePrReq
 
 /**
- * PR 초안 생성, 조회, 수정, 삭제 기능을 제공하는 Service 인터페이스입니다.
+ * PR 초안 생성, 조회, 수정, 삭제, 번역 기능을 제공하는 Service 인터페이스입니다.
  *
  * <p>
- * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 단건/목록 조회, 수정 및 삭제 기능을 정의합니다.
+ * 사용자의 코드 변경 내용(diff)을 기반으로 PR 제목과 본문을 생성하고, 단건/목록 조회, 수정, 삭제 및 영어 번역 기능을 정의합니다.
  *
  * <p><b>상속 정보:</b><br>
  * 별도의 상속 없이 Service 역할을 정의하는 인터페이스입니다.
@@ -57,6 +58,16 @@ interface PrDraftService {
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */
     fun update(githubId: String, prDraftId: Long, request: UpdatePrReq): PrDetailRes
+
+    /**
+     * PR 초안의 제목과 본문을 영어로 번역하고 GitHub PR 작성 URL을 반환합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 번역할 PR 초안 ID
+     * @return 영어 제목, 본문, GitHub URL
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    fun translate(githubId: String, prDraftId: Long): PrTranslateRes
 
     /**
      * PR 초안을 삭제합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -19,6 +19,8 @@ import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.PrDraftException
 import org.springframework.stereotype.Service
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 /**
  * PR 초안 생성, 조회, 수정, 삭제 기능의 구현체입니다.
@@ -147,10 +149,28 @@ class PrDraftServiceImpl(
         // AI로 제목/본문 영어 번역
         val translated = aiClient.translate(prDraft.prTitle, prDraft.prBody)
 
-        // TODO: GitHub URL 빌드
+        // GitHub URL 빌드
+        val githubUrl = buildGithubUrl(prDraft.issue.repoFullName, translated.title, translated.body)
 
-        // TODO: PrTranslateRes 반환
-        TODO()
+        return PrTranslateRes(
+            titleEn = translated.title,
+            bodyEn = translated.body,
+            githubUrl = githubUrl
+        )
+    }
+
+    /**
+     * 번역된 제목과 본문을 GitHub PR 작성 페이지 URL로 조합합니다.
+     *
+     * @param fullName 레포지토리 전체 이름 (예: owner/repo)
+     * @param title URL에 삽입할 PR 제목
+     * @param body URL에 삽입할 PR 본문
+     * @return pre-fill된 GitHub PR 생성 URL
+     */
+    private fun buildGithubUrl(fullName: String, title: String, body: String): String {
+        val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8).replace("+", "%20")
+        val encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8).replace("+", "%20")
+        return "https://github.com/$fullName/compare?quick_pull=1&title=$encodedTitle&body=$encodedBody"
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -18,8 +18,6 @@ import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.PrDraftException
 import org.springframework.stereotype.Service
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 /**
  * PR 초안 생성, 조회, 수정, 삭제 기능의 구현체입니다.
@@ -53,7 +51,7 @@ class PrDraftServiceImpl(
      *
      * @param githubId 요청한 사용자의 GitHub ID
      * @param request PR 생성 요청 DTO (issueId, diffContent 포함)
-     * @return 생성된 PR 제목, 본문, GitHub URL
+     * @return 생성된 PR 제목, 본문
      * @throws AuthException 존재하지 않는 githubId인 경우
      * @throws IssueException 존재하지 않는 issueId인 경우
      */
@@ -74,8 +72,6 @@ class PrDraftServiceImpl(
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)
 
-        val githubUrl = buildGithubUrl(issue.repoFullName, aiResult.title, aiResult.body)
-
         prDraftRepository.save(PrDraft(
             user = user,
             issue = issue,
@@ -86,8 +82,7 @@ class PrDraftServiceImpl(
 
         return PrInfoRes(
             title = aiResult.title,
-            body = aiResult.body,
-            githubUrl = githubUrl
+            body = aiResult.body
         )
     }
 
@@ -149,9 +144,4 @@ class PrDraftServiceImpl(
         prDraftRepository.delete(prDraft)
     }
 
-    private fun buildGithubUrl(fullName: String, title: String, body: String): String {
-        val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8).replace("+", "%20")
-        val encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8).replace("+", "%20")
-        return "https://github.com/$fullName/compare?quick_pull=1&title=$encodedTitle&body=$encodedBody"
-    }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -144,7 +144,8 @@ class PrDraftServiceImpl(
         val prDraft = prDraftRepository.findByIdWithIssueAndUserGithubId(prDraftId, githubId)
             ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
 
-        // TODO: AI로 제목/본문 영어 번역
+        // AI로 제목/본문 영어 번역
+        val translated = aiClient.translate(prDraft.prTitle, prDraft.prBody)
 
         // TODO: GitHub URL 빌드
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -5,6 +5,7 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.dto.UpdatePrReq
 import com.back.omos.domain.prdraft.ai.AiClient
 import com.back.omos.domain.prdraft.entity.PrDraft
@@ -128,6 +129,27 @@ class PrDraftServiceImpl(
         prDraft.prBody = request.body ?: prDraft.prBody
 
         return PrDetailRes.from(prDraftRepository.save(prDraft))
+    }
+
+    /**
+     * PR 초안의 제목과 본문을 영어로 번역하고 GitHub PR 작성 URL을 반환합니다.
+     *
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @param prDraftId 번역할 PR 초안 ID
+     * @return 영어 제목, 본문, GitHub URL
+     * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
+     */
+    override fun translate(githubId: String, prDraftId: Long): PrTranslateRes {
+        // PR 초안 조회 (소유권 확인)
+        val prDraft = prDraftRepository.findByIdWithIssueAndUserGithubId(prDraftId, githubId)
+            ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
+
+        // TODO: AI로 제목/본문 영어 번역
+
+        // TODO: GitHub URL 빌드
+
+        // TODO: PrTranslateRes 반환
+        TODO()
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -75,7 +75,7 @@ class PrDraftServiceImpl(
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)
 
-        prDraftRepository.save(PrDraft(
+        val saved = prDraftRepository.save(PrDraft(
             user = user,
             issue = issue,
             diffContent = request.diffContent,
@@ -84,6 +84,7 @@ class PrDraftServiceImpl(
         ))
 
         return PrInfoRes(
+            id = saved.id!!,
             title = aiResult.title,
             body = aiResult.body
         )

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -3,6 +3,7 @@ package com.back.omos.domain.prdraft.controller
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.handler.OAuth2FailureHandler
 import com.back.omos.global.auth.handler.OAuth2SuccessHandler
@@ -157,6 +158,33 @@ class PrDraftControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"title": "updated title", "body": "updated body"}""")
             )
+                .andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Nested
+    inner class TranslateTest {
+
+        @Test
+        fun `번역 정상 요청이면 200과 번역 결과를 반환한다`() {
+            given(prDraftService.translate(any(), any())).willReturn(
+                PrTranslateRes("fix: mock PR title", "## Changes\n- Generated PR draft.", "https://github.com/owner/repo/compare?quick_pull=1&title=fix%3A%20mock%20PR%20title&body=...")
+            )
+
+            mockMvc.perform(
+                post("/api/v1/pr/1/translate")
+                    .with(authentication(mockAuth()))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.titleEn").value("fix: mock PR title"))
+                .andExpect(jsonPath("$.data.bodyEn").exists())
+                .andExpect(jsonPath("$.data.githubUrl").exists())
+        }
+
+        @Test
+        fun `인증 없이 번역 요청하면 401을 반환한다`() {
+            mockMvc.perform(post("/api/v1/pr/1/translate"))
                 .andExpect(status().isUnauthorized)
         }
     }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -57,7 +57,7 @@ class PrDraftControllerTest {
         @Test
         fun `정상 요청이면 200과 success 응답을 반환한다`() {
             given(prDraftService.create(any(), any())).willReturn(
-                PrInfoRes("feat: title", "body")
+                PrInfoRes(1L, "feat: title", "body")
             )
 
             mockMvc.perform(
@@ -68,6 +68,7 @@ class PrDraftControllerTest {
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.id").value(1L))
                 .andExpect(jsonPath("$.data.title").value("feat: title"))
         }
     }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -57,7 +57,7 @@ class PrDraftControllerTest {
         @Test
         fun `정상 요청이면 200과 success 응답을 반환한다`() {
             given(prDraftService.create(any(), any())).willReturn(
-                PrInfoRes("feat: title", "body", "https://github.com/owner/repo/compare")
+                PrInfoRes("feat: title", "body")
             )
 
             mockMvc.perform(

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -163,6 +163,7 @@ class PrDraftServiceImplTest {
             val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
 
             val result = service.update(githubId, 1L, UpdatePrReq("new title", "new body"))
 
@@ -175,6 +176,7 @@ class PrDraftServiceImplTest {
             val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
 
             val result = service.update(githubId, 1L, UpdatePrReq(null, "new body"))
 
@@ -187,6 +189,7 @@ class PrDraftServiceImplTest {
             val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
 
             val result = service.update(githubId, 1L, UpdatePrReq("new title", null))
 
@@ -199,6 +202,33 @@ class PrDraftServiceImplTest {
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(null)
 
             assertThatThrownBy { service.update(githubId, 1L, UpdatePrReq("new title", "new body")) }
+                .isInstanceOf(PrDraftException::class.java)
+        }
+    }
+
+    @Nested
+    inner class TranslateTest {
+
+        @Test
+        fun `본인 소유 PR 초안이면 번역 결과와 GitHub URL을 반환한다`() {
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: 제목", prBody = "본문")
+            ReflectionTestUtils.setField(prDraft, "id", 1L)
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
+            given(aiClient.translate("feat: 제목", "본문")).willReturn(AiPrResult("feat: title", "body"))
+
+            val result = service.translate(githubId, 1L)
+
+            assertThat(result.titleEn).isEqualTo("feat: title")
+            assertThat(result.bodyEn).isEqualTo("body")
+            assertThat(result.githubUrl).contains("owner/repo")
+            assertThat(result.githubUrl).contains("quick_pull=1")
+        }
+
+        @Test
+        fun `존재하지 않거나 본인 소유가 아닌 PR 초안이면 PrDraftException을 던진다`() {
+            given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(null)
+
+            assertThatThrownBy { service.translate(githubId, 1L) }
                 .isInstanceOf(PrDraftException::class.java)
         }
     }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -64,10 +64,15 @@ class PrDraftServiceImplTest {
             given(gitHubClient.fetchContributing("owner/repo")).willReturn("contributing content")
             given(prDraftPromptBuilder.build(req, "contributing content", emptyList())).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("feat: title", "body"))
-            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
+            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
+                val prDraft = it.arguments[0] as PrDraft
+                ReflectionTestUtils.setField(prDraft, "id", 1L)
+                prDraft
+            }
 
             val result = service.create(githubId, req)
 
+            assertThat(result.id).isEqualTo(1L)
             assertThat(result.title).isEqualTo("feat: title")
             assertThat(result.body).isEqualTo("body")
             verify(prDraftRepository).save(any(PrDraft::class.java))
@@ -82,7 +87,11 @@ class PrDraftServiceImplTest {
             given(gitHubClient.fetchMergedPrs("owner/repo")).willReturn(prs)
             given(prDraftPromptBuilder.build(req, null, prs)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("title", "body"))
-            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
+            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
+                val prDraft = it.arguments[0] as PrDraft
+                ReflectionTestUtils.setField(prDraft, "id", 1L)
+                prDraft
+            }
 
             service.create(githubId, req)
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -70,7 +70,6 @@ class PrDraftServiceImplTest {
 
             assertThat(result.title).isEqualTo("feat: title")
             assertThat(result.body).isEqualTo("body")
-            assertThat(result.githubUrl).contains("owner/repo")
             verify(prDraftRepository).save(any(PrDraft::class.java))
         }
 


### PR DESCRIPTION

<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
한국어로 생성된 pr을 url로 반영하기 전 영어로 번역해주는 기능

## 🔗 관련 이슈
- Close #83

## 🛠️ 주요 변경 사항
- [ ] controller, service : 번역기능 추가
- [ ] pr 생성응답에 id 추가 (생성 직후 후속 api 호출 가능)
- [ ] ai 프롬프트 한국어 생성 추가
- [ ] 관련 test 추가 및 수정

## 🧪 테스트 결과
<img width="260" height="278" alt="스크린샷 2026-04-28 161029" src="https://github.com/user-attachments/assets/debb763d-b203-4486-b7f6-309eac7dffdc" />

| <img width="785" height="249" alt="스크린샷 2026-04-28 152823" src="https://github.com/user-attachments/assets/170e5f81-bb2e-4f8d-ba08-8cf3a5bc9d35" /> | <img width="795" height="415" alt="스크린샷 2026-04-28 153133" src="https://github.com/user-attachments/assets/43710b7c-dce3-4ffc-a1b9-c65d146eae97" /> |
|---|---|
| 한국어 생성 | 영어 번역 |


## 🧐 리뷰어에게
`main`으로 merge 됩니다.
사용자 언어를 지정하는 방식이 아니고 한국어로 고정하였습니다 (promptbuilder)
