### PR TITLE
[#86][FEAT] 사용자별 이슈 분석 이력 저장 기능 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/controller/ContextAnalyzerController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/controller/ContextAnalyzerController.kt
@@ -3,9 +3,11 @@ package com.back.omos.domain.analysis.controller
 import com.back.omos.domain.analysis.dto.GuideResponseDto
 import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
 import com.back.omos.domain.analysis.service.ContextAnalyzerService
+import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
 
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -28,24 +30,27 @@ class ContextAnalyzerController(
     /**
      * 이슈에 대한 코드 수정 가이드 조회
      *
-     * 캐시에 분석 결과가 있으면 즉시 반환하고, 없으면 GitHub 소스코드 수집 →
-     * GLM API 분석 → DB 저장 순으로 처리한 뒤 반환합니다.
+     * 사용자별 캐시 → 횟수 제한 → 이슈별 캐시 → 신규 생성 순으로 처리합니다.
      *
-     * - 캐시 HIT: 저장된 분석 결과를 즉시 반환
+     * - 사용자 캐시 HIT: 해당 사용자의 기존 요청 결과를 즉시 반환
+     * - 이슈 캐시 HIT: 다른 사용자의 분석 결과를 재사용
      * - 캐시 MISS: 신규 분석 생성 후 반환 (시간 소요)
      *
+     * @param principal 인증된 사용자의 세션 정보 ([OAuthPrincipal])
      * @param issueId 분석할 이슈의 고유 식별자
      * @return [GuideResponseDto] 수정 대상 파일 경로, 가이드라인, 사이드 이펙트 포함
      * @throws AnalysisException ISSUE_NOT_FOUND - 이슈가 존재하지 않는 경우
+     * @throws AnalysisException ANALYSIS_RATE_LIMIT_EXCEEDED - 일일 분석 요청 횟수 초과 시
      * @throws AnalysisException GITHUB_API_FAIL - GitHub API 호출 실패 시
      * @throws AnalysisException GLM_API_FAIL - GLM API 호출 실패 시
      * @throws AnalysisException ANALYSIS_GENERATION_FAIL - 분석 생성 중 오류 발생 시
      */
     @GetMapping("/{issueId}/guide")
     fun getGuide(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
         @PathVariable issueId: Long
     ): ResponseEntity<CommonResponse<GuideResponseDto>> {
-        val result = contextAnalyzerService.getGuide(issueId)
+        val result = contextAnalyzerService.getGuide(issueId, principal.githubId)
         return ResponseEntity.ok(
             CommonResponse.success(result)
         )
@@ -54,24 +59,27 @@ class ContextAnalyzerController(
     /**
      * 이슈에 대한 의사 코드(Pseudo Code) 조회
      *
-     * 캐시에 분석 결과가 있으면 즉시 반환하고, 없으면 GitHub 소스코드 수집 →
-     * GLM API 분석 → DB 저장 순으로 처리한 뒤 반환합니다.
+     * 사용자별 캐시 → 횟수 제한 → 이슈별 캐시 → 신규 생성 순으로 처리합니다.
      *
-     * - 캐시 HIT: 저장된 분석 결과를 즉시 반환
+     * - 사용자 캐시 HIT: 해당 사용자의 기존 요청 결과를 즉시 반환
+     * - 이슈 캐시 HIT: 다른 사용자의 분석 결과를 재사용
      * - 캐시 MISS: 신규 분석 생성 후 반환 (시간 소요)
      *
+     * @param principal 인증된 사용자의 세션 정보 ([OAuthPrincipal])
      * @param issueId 분석할 이슈의 고유 식별자
      * @return [PseudoCodeResponseDto] 수정 대상 파일 경로, 의사 코드 포함
      * @throws AnalysisException ISSUE_NOT_FOUND - 이슈가 존재하지 않는 경우
+     * @throws AnalysisException ANALYSIS_RATE_LIMIT_EXCEEDED - 일일 분석 요청 횟수 초과 시
      * @throws AnalysisException GITHUB_API_FAIL - GitHub API 호출 실패 시
      * @throws AnalysisException GLM_API_FAIL - GLM API 호출 실패 시
      * @throws AnalysisException ANALYSIS_GENERATION_FAIL - 분석 생성 중 오류 발생 시
      */
     @GetMapping("/{issueId}/pseudo")
     fun getPseudoCode(
+        @AuthenticationPrincipal principal: OAuthPrincipal,
         @PathVariable issueId: Long
     ): ResponseEntity<CommonResponse<PseudoCodeResponseDto>> {
-        val result = contextAnalyzerService.getPseudoCode(issueId)
+        val result = contextAnalyzerService.getPseudoCode(issueId, principal.githubId)
         return ResponseEntity.ok(
             CommonResponse.success(result)
         )

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/entity/UserAnalysisRequest.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/entity/UserAnalysisRequest.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 /**
  * 사용자의 분석 요청을 저장하는 엔티티입니다.
@@ -30,7 +31,13 @@ import jakarta.persistence.Table
  * @see User
  */
 @Entity
-@Table(name = "user_analysis_requests")
+@Table(
+    name = "user_analysis_requests",
+    uniqueConstraints = [UniqueConstraint(
+        name = "uk_user_analysis_request_user_result",
+        columnNames = ["user_id", "analysis_result_id"]
+    )]
+)
 class UserAnalysisRequest(
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/entity/UserAnalysisRequest.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/entity/UserAnalysisRequest.kt
@@ -1,0 +1,67 @@
+package com.back.omos.domain.analysis.entity
+
+import com.back.omos.domain.user.entity.User
+import com.back.omos.global.jpa.entity.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+/**
+ * 사용자의 분석 요청을 저장하는 엔티티입니다.
+ *
+ * 사용자가 특정 이슈에 대한 분석을 요청할 때 생성되며,
+ * 분석 완료 전(PENDING)에는 [analysisResult]가 null이고
+ * 분석 완료 후(COMPLETED)에 [AnalysisResult]와 연결됩니다.
+ *
+ * 동일 이슈에 여러 사용자가 요청할 수 있으며, 이 경우 [AnalysisResult]를 재사용합니다.
+ * 같은 사용자가 이미 분석된 이슈에 재요청하면 새로운 레코드를 생성하지 않고
+ * 기존 [AnalysisResult]를 반환합니다.
+ *
+ * [BaseEntity]를 상속받아 다음 필드들을 자동으로 관리합니다:
+ * - `id`: 시스템 내부 식별자 (Long, PK)
+ * - `createdAt`: 요청 생성 일시 (횟수 제한 계산의 기준이 됩니다)
+ * - `updatedAt`: 엔티티 수정 일시
+ *
+ * @author MintyU
+ * @since 2026-04-28
+ * @see AnalysisResult
+ * @see User
+ */
+@Entity
+@Table(name = "user_analysis_requests")
+class UserAnalysisRequest(
+
+    /**
+     * 분석을 요청한 사용자입니다.
+     *
+     * 한 사용자는 여러 이슈에 대해 분석을 요청할 수 있으며,
+     * [createdAt]을 기준으로 기간 내 요청 횟수를 집계하여 횟수 제한에 활용합니다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User,
+
+    /**
+     * 요청에 대응하는 분석 결과입니다.
+     *
+     * 분석 요청 직후에는 null(PENDING 상태)이며,
+     * Context Analyzer가 분석을 완료하면 해당 [AnalysisResult]와 연결됩니다(COMPLETED 상태).
+     * 동일 이슈에 대한 기존 [AnalysisResult]가 있으면 새로 생성하지 않고 재사용합니다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "analysis_result_id", nullable = true)
+    var analysisResult: AnalysisResult? = null
+
+) : BaseEntity() {
+
+    /**
+     * 분석 결과를 연결하여 요청을 COMPLETED 상태로 전환합니다.
+     *
+     * @param result 완료된 분석 결과
+     */
+    fun complete(result: AnalysisResult) {
+        this.analysisResult = result
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
@@ -1,0 +1,54 @@
+package com.back.omos.domain.analysis.repository
+
+import com.back.omos.domain.analysis.entity.UserAnalysisRequest
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+
+/**
+ * [UserAnalysisRequest] 엔티티에 대한 데이터 액세스 인터페이스입니다.
+ *
+ * 기본적인 CRUD 연산은 [JpaRepository]에서 제공하며,
+ * 횟수 제한 검사, 중복 요청 탐지, 이슈 목록 분석 여부 조회를 위한 메서드를 추가로 정의합니다.
+ *
+ * @author MintyU
+ * @since 2026-04-28
+ */
+interface UserAnalysisRequestRepository : JpaRepository<UserAnalysisRequest, Long> {
+
+    /**
+     * 특정 사용자의 기간 내 분석 요청 횟수를 조회합니다.
+     *
+     * [from] 이상 [to] 미만의 [UserAnalysisRequest.createdAt]을 가진 레코드를 집계하며,
+     * 서비스 레이어에서 허용 횟수 초과 여부를 판단하는 데 사용됩니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param from 집계 시작 일시 (포함)
+     * @param to 집계 종료 일시 (포함)
+     * @return 해당 기간의 요청 횟수
+     */
+    fun countByUserIdAndCreatedAtBetween(userId: Long, from: LocalDateTime, to: LocalDateTime): Long
+
+    /**
+     * 특정 사용자가 특정 이슈에 대해 완료된 분석 요청을 조회합니다.
+     *
+     * 같은 사용자가 이미 분석된 이슈에 재요청할 때 기존 레코드를 반환하기 위해 사용됩니다.
+     * [UserAnalysisRequest.analysisResult]가 null인(PENDING) 레코드는 조회되지 않습니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param issueId 조회할 이슈의 ID
+     * @return 완료된 분석 요청, 없으면 null
+     */
+    fun findByUserIdAndAnalysisResultIssueId(userId: Long, issueId: Long): UserAnalysisRequest?
+
+    /**
+     * 특정 사용자가 분석을 요청한 이슈 ID 목록을 기반으로 완료된 요청 목록을 조회합니다.
+     *
+     * 이슈 목록 응답에 `isAnalyzed`, `analysisResultId` 필드를 채우기 위해 사용됩니다.
+     * [UserAnalysisRequest.analysisResult]가 null인(PENDING) 레코드는 조회되지 않습니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param issueIds 조회 대상 이슈 ID 목록
+     * @return 해당 이슈들에 대한 완료된 분석 요청 목록
+     */
+    fun findAllByUserIdAndAnalysisResultIssueIdIn(userId: Long, issueIds: List<Long>): List<UserAnalysisRequest>
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
@@ -38,7 +38,7 @@ interface UserAnalysisRequestRepository : JpaRepository<UserAnalysisRequest, Lon
      * @param issueId 조회할 이슈의 ID
      * @return 완료된 분석 요청, 없으면 null
      */
-    fun findByUserIdAndAnalysisResultIssueId(userId: Long, issueId: Long): UserAnalysisRequest?
+    fun findFirstByUserIdAndAnalysisResultIssueId(userId: Long, issueId: Long): UserAnalysisRequest?
 
     /**
      * 특정 사용자가 분석을 요청한 이슈 ID 목록을 기반으로 완료된 요청 목록을 조회합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerService.kt
@@ -23,34 +23,44 @@ interface ContextAnalyzerService {
     /**
      * 이슈에 대한 코드 수정 가이드를 조회합니다.
      *
-     * 분석 결과가 캐시되어 있으면 즉시 반환합니다.
-     * 캐시가 없으면 GitHub API와 GLM API를 통해 분석 결과를 생성하고 저장한 뒤 반환합니다.
+     * 사용자별 캐시 확인 → 일일 횟수 제한 검사 → 이슈별 캐시 확인 → 신규 분석 생성 순으로 처리합니다.
+     * 같은 사용자가 동일 이슈에 재요청하면 기존 결과를 즉시 반환합니다.
      *
      * @param issueId 조회할 이슈의 식별자
+     * @param githubId 요청한 사용자의 GitHub ID
      * @return 파일 경로 목록·가이드라인·사이드 이펙트를 담은 [GuideResponseDto]
      * @throws com.back.omos.global.exception.exceptions.AnalysisException
      *         ISSUE_NOT_FOUND — 이슈가 존재하지 않는 경우
      * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         ANALYSIS_RATE_LIMIT_EXCEEDED — 일일 분석 요청 횟수를 초과한 경우
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
      *         GITHUB_API_FAIL — GitHub API 호출에 실패한 경우
      * @throws com.back.omos.global.exception.exceptions.AnalysisException
      *         GLM_API_FAIL — GLM API 호출 또는 응답 파싱에 실패한 경우
+     * @throws com.back.omos.global.exception.exceptions.AuthException
+     *         USER_NOT_FOUND — 사용자가 존재하지 않는 경우
      */
-    fun getGuide(issueId: Long): GuideResponseDto
+    fun getGuide(issueId: Long, githubId: String): GuideResponseDto
 
     /**
      * 이슈에 대한 수도 코드를 조회합니다.
      *
-     * 분석 결과가 캐시되어 있으면 즉시 반환합니다.
-     * 캐시가 없으면 GitHub API와 GLM API를 통해 분석 결과를 생성하고 저장한 뒤 반환합니다.
+     * 사용자별 캐시 확인 → 일일 횟수 제한 검사 → 이슈별 캐시 확인 → 신규 분석 생성 순으로 처리합니다.
+     * 같은 사용자가 동일 이슈에 재요청하면 기존 결과를 즉시 반환합니다.
      *
      * @param issueId 조회할 이슈의 식별자
+     * @param githubId 요청한 사용자의 GitHub ID
      * @return 파일 경로 목록·수도 코드를 담은 [PseudoCodeResponseDto]
      * @throws com.back.omos.global.exception.exceptions.AnalysisException
      *         ISSUE_NOT_FOUND — 이슈가 존재하지 않는 경우
      * @throws com.back.omos.global.exception.exceptions.AnalysisException
+     *         ANALYSIS_RATE_LIMIT_EXCEEDED — 일일 분석 요청 횟수를 초과한 경우
+     * @throws com.back.omos.global.exception.exceptions.AnalysisException
      *         GITHUB_API_FAIL — GitHub API 호출에 실패한 경우
      * @throws com.back.omos.global.exception.exceptions.AnalysisException
      *         GLM_API_FAIL — GLM API 호출 또는 응답 파싱에 실패한 경우
+     * @throws com.back.omos.global.exception.exceptions.AuthException
+     *         USER_NOT_FOUND — 사용자가 존재하지 않는 경우
      */
-    fun getPseudoCode(issueId: Long): PseudoCodeResponseDto
+    fun getPseudoCode(issueId: Long, githubId: String): PseudoCodeResponseDto
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -4,17 +4,23 @@ import com.back.omos.domain.analysis.ai.GlmClient
 import com.back.omos.domain.analysis.dto.GuideResponseDto
 import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
 import com.back.omos.domain.analysis.entity.AnalysisResult
+import com.back.omos.domain.analysis.entity.UserAnalysisRequest
 import com.back.omos.domain.analysis.github.GitHubClient
 import com.back.omos.domain.analysis.repository.AnalysisResultRepository
+import com.back.omos.domain.analysis.repository.UserAnalysisRequestRepository
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.user.repository.UserRepository
 import com.back.omos.global.exception.errorCode.AnalysisErrorCode
+import com.back.omos.global.exception.errorCode.AuthErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
+import com.back.omos.global.exception.exceptions.AuthException
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 /**
  * [ContextAnalyzerService]의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
@@ -41,7 +47,9 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ContextAnalyzerServiceImpl(
     private val analysisResultRepository: AnalysisResultRepository,
+    private val userAnalysisRequestRepository: UserAnalysisRequestRepository,
     private val issueRepository: IssueRepository,
+    private val userRepository: UserRepository,
     @Qualifier(("analysisGitHubClientImpl"))
     private val gitHubClient: GitHubClient,
     private val glmClient: GlmClient,
@@ -49,43 +57,69 @@ class ContextAnalyzerServiceImpl(
 ) : ContextAnalyzerService {
 
     @Transactional
-    override fun getGuide(issueId: Long): GuideResponseDto {
-        val issue = issueRepository.findById(issueId)
-            .orElseThrow {
-                AnalysisException(
-                    AnalysisErrorCode.ISSUE_NOT_FOUND,
-                    "[ContextAnalyzerServiceImpl#getGuide] 이슈를 찾을 수 없습니다: issueId=$issueId",
-                    "해당 이슈를 찾을 수 없습니다."
-                )
-            }
-
-        val cached = analysisResultRepository.findByIssueId(issueId)
-        if (cached != null) {
-            return toGuideDto(cached)
-        }
-
-        val analysisResult = generateAnalysis(issue)
-        return toGuideDto(analysisResult)
+    override fun getGuide(issueId: Long, githubId: String): GuideResponseDto {
+        return toGuideDto(resolveOrCreateAnalysis(issueId, githubId))
     }
 
     @Transactional
-    override fun getPseudoCode(issueId: Long): PseudoCodeResponseDto {
+    override fun getPseudoCode(issueId: Long, githubId: String): PseudoCodeResponseDto {
+        return toPseudoCodeDto(resolveOrCreateAnalysis(issueId, githubId))
+    }
+
+    /**
+     * 분석 결과를 반환합니다.
+     *
+     * 사용자별 캐시 확인 → 일일 횟수 제한 검사 → 이슈별 캐시 확인(재사용) → 신규 생성 순으로 처리합니다.
+     * 새로운 요청이 발생할 경우 [UserAnalysisRequest]를 저장하여 이력을 기록합니다.
+     *
+     * @param issueId 분석할 이슈의 식별자
+     * @param githubId 요청한 사용자의 GitHub ID
+     * @return 분석 결과 [AnalysisResult]
+     */
+    private fun resolveOrCreateAnalysis(issueId: Long, githubId: String): AnalysisResult {
         val issue = issueRepository.findById(issueId)
             .orElseThrow {
                 AnalysisException(
                     AnalysisErrorCode.ISSUE_NOT_FOUND,
-                    "[ContextAnalyzerServiceImpl#getPseudoCode] 이슈를 찾을 수 없습니다: issueId=$issueId",
+                    "[ContextAnalyzerServiceImpl#resolveOrCreateAnalysis] 이슈를 찾을 수 없습니다: issueId=$issueId",
                     "해당 이슈를 찾을 수 없습니다."
                 )
             }
 
-        val cached = analysisResultRepository.findByIssueId(issueId)
-        if (cached != null) {
-            return toPseudoCodeDto(cached)
+        val user = userRepository.findByGithubId(githubId)
+            .orElseThrow {
+                AuthException(
+                    AuthErrorCode.USER_NOT_FOUND,
+                    "[ContextAnalyzerServiceImpl#resolveOrCreateAnalysis] 사용자를 찾을 수 없습니다: githubId=$githubId"
+                )
+            }
+
+        // 해당 이슈에 대해 사용자가 이미 완료된 요청을 가지고 있으면 즉시 반환 (횟수 미차감)
+        val existingRequest = userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(user.id!!, issueId)
+        if (existingRequest != null) {
+            return existingRequest.analysisResult!!
         }
 
-        val analysisResult = generateAnalysis(issue)
-        return toPseudoCodeDto(analysisResult)
+        // 새 요청이므로 일일 횟수 제한 검사
+        val now = LocalDateTime.now()
+        val startOfDay = now.toLocalDate().atStartOfDay()
+        val requestCount = userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(user.id!!, startOfDay, now)
+        if (requestCount >= DAILY_REQUEST_LIMIT) {
+            throw AnalysisException(
+                AnalysisErrorCode.ANALYSIS_RATE_LIMIT_EXCEEDED,
+                "[ContextAnalyzerServiceImpl#resolveOrCreateAnalysis] 일일 분석 요청 횟수 초과: userId=${user.id}, count=$requestCount"
+            )
+        }
+
+        // 이슈에 대한 분석 결과가 이미 존재하면 재사용, 없으면 신규 생성
+        val analysisResult = analysisResultRepository.findByIssueId(issueId) ?: generateAnalysis(issue)
+
+        // 사용자 분석 요청 이력 저장
+        userAnalysisRequestRepository.save(
+            UserAnalysisRequest(user = user).apply { complete(analysisResult) }
+        )
+
+        return analysisResult
     }
 
     /**
@@ -197,6 +231,8 @@ class ContextAnalyzerServiceImpl(
         private const val MAX_CANDIDATE_FILES = 30
         /** GLM이 최종 선별하는 파일 최대 개수. 5개 초과 시 fetchFileContent 호출 증가로 응답 지연 발생. */
         private const val MAX_SELECT_FILES = 5
+        /** 사용자 1인당 하루 최대 분석 요청 횟수. */
+        private const val DAILY_REQUEST_LIMIT = 5L
     }
 
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -95,7 +95,7 @@ class ContextAnalyzerServiceImpl(
             }
 
         // 해당 이슈에 대해 사용자가 이미 완료된 요청을 가지고 있으면 즉시 반환 (횟수 미차감)
-        val existingRequest = userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(user.id!!, issueId)
+        val existingRequest = userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(user.id!!, issueId)
         if (existingRequest != null) {
             return existingRequest.analysisResult!!
         }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -86,7 +86,7 @@ class ContextAnalyzerServiceImpl(
                 )
             }
 
-        val user = userRepository.findByGithubId(githubId)
+        val user = userRepository.findByGithubIdWithLock(githubId)
             .orElseThrow {
                 AuthException(
                     AuthErrorCode.USER_NOT_FOUND,

--- a/omos/src/main/kotlin/com/back/omos/domain/user/repository/UserRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/user/repository/UserRepository.kt
@@ -1,7 +1,10 @@
 package com.back.omos.domain.user.repository
 
 import com.back.omos.domain.user.entity.User
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
@@ -41,4 +44,18 @@ interface UserRepository : JpaRepository<User, Long> {
      * @return 해당 이메일을 가진 사용자를 포함한 [Optional] 객체
      */
     fun findByEmail(email: String): Optional<User>
+
+    /**
+     * GitHub 고유 ID로 사용자를 조회하며 배타적 락(X-lock)을 획득합니다.
+     *
+     * 일일 분석 요청 횟수 제한의 TOCTOU 경쟁 조건을 방지하기 위해 사용됩니다.
+     * 락은 트랜잭션이 커밋되거나 롤백될 때까지 유지되므로,
+     * 동일 사용자의 동시 요청이 count 조회 → 저장을 직렬화하여 초과 요청을 방지합니다.
+     *
+     * @param githubId 조회할 GitHub 고유 ID
+     * @return 해당 ID를 가진 사용자를 포함한 [Optional] 객체
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.githubId = :githubId")
+    fun findByGithubIdWithLock(githubId: String): Optional<User>
 }

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AnalysisErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/AnalysisErrorCode.kt
@@ -24,6 +24,7 @@ enum class AnalysisErrorCode(
 ) : ErrorCode {
     ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈를 찾을 수 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이슈에 대한 분석 결과가 존재하지 않습니다."),
+    ANALYSIS_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "오늘의 분석 요청 횟수를 초과하였습니다."),
     ANALYSIS_GENERATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "코드 분석 가이드 생성에 실패하였습니다."),
     GITHUB_API_FAIL(HttpStatus.BAD_GATEWAY, "GitHub API 호출에 실패하였습니다."),
     GLM_API_FAIL(HttpStatus.BAD_GATEWAY, "GLM API 호출에 실패하였습니다.");

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -130,7 +130,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(completedRequest)
 
@@ -149,7 +149,7 @@ class ContextAnalyzerServiceImplTest {
         fun `이슈 캐시 HIT시 즉시 반환`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
@@ -172,7 +172,7 @@ class ContextAnalyzerServiceImplTest {
         fun `캐시 MISS시 GitHub API 호출`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
@@ -223,7 +223,7 @@ class ContextAnalyzerServiceImplTest {
         fun `사용자 없으면 예외 던짐`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.empty())
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.empty())
 
             // when & then
             assertThrows<AuthException> {
@@ -236,7 +236,7 @@ class ContextAnalyzerServiceImplTest {
         fun `횟수 초과 시 예외 던짐`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
@@ -263,7 +263,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(completedRequest)
 
@@ -281,7 +281,7 @@ class ContextAnalyzerServiceImplTest {
         fun `이슈 캐시 HIT시 즉시 반환`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
@@ -315,7 +315,7 @@ class ContextAnalyzerServiceImplTest {
         fun `사용자 없으면 예외 던짐`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.empty())
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.empty())
 
             // when & then
             assertThrows<AuthException> {
@@ -328,7 +328,7 @@ class ContextAnalyzerServiceImplTest {
         fun `횟수 초과 시 예외 던짐`() {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -131,7 +131,7 @@ class ContextAnalyzerServiceImplTest {
             val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(completedRequest)
 
             // when
@@ -141,7 +141,7 @@ class ContextAnalyzerServiceImplTest {
             assertNotNull(result)
             assertEquals("TODO: GLM 연동 후 실제 가이드 생성", result.guideline)
             then(gitHubClient).shouldHaveNoInteractions()
-            then(userAnalysisRequestRepository).should().findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID)
+            then(userAnalysisRequestRepository).should().findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID)
         }
 
         @Test
@@ -150,7 +150,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(0L)
@@ -173,7 +173,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(0L)
@@ -237,7 +237,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(5L)
@@ -264,7 +264,7 @@ class ContextAnalyzerServiceImplTest {
             val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(completedRequest)
 
             // when
@@ -282,7 +282,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(0L)
@@ -329,7 +329,7 @@ class ContextAnalyzerServiceImplTest {
             // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(5L)

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -1,31 +1,33 @@
 package com.back.omos.domain.analysis.service
 
-import com.back.omos.domain.analysis.ai.GlmClient
 import com.back.omos.domain.analysis.ai.GlmAnalysisRes
-import com.back.omos.domain.analysis.dto.GuideResponseDto
-import com.back.omos.domain.analysis.dto.PseudoCodeResponseDto
+import com.back.omos.domain.analysis.ai.GlmClient
 import com.back.omos.domain.analysis.entity.AnalysisResult
+import com.back.omos.domain.analysis.entity.UserAnalysisRequest
 import com.back.omos.domain.analysis.github.GitHubClient
-import com.back.omos.domain.analysis.github.GitHubCodeSearchItem
-import com.back.omos.domain.analysis.github.GitHubCodeSearchRes
 import com.back.omos.domain.analysis.github.GitHubIssueRes
 import com.back.omos.domain.analysis.repository.AnalysisResultRepository
+import com.back.omos.domain.analysis.repository.UserAnalysisRequestRepository
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
-import com.back.omos.domain.repo.entity.Repo
-import com.back.omos.domain.repo.repository.RepoRepository
+import com.back.omos.domain.user.entity.User
+import com.back.omos.domain.user.repository.UserRepository
 import com.back.omos.global.exception.exceptions.AnalysisException
-import org.junit.jupiter.api.Assertions.*
+import com.back.omos.global.exception.exceptions.AuthException
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.mockito.Mock
-import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
+import org.mockito.Mockito.lenient
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.springframework.test.context.ActiveProfiles
@@ -48,7 +50,13 @@ class ContextAnalyzerServiceImplTest {
     private lateinit var analysisResultRepository: AnalysisResultRepository
 
     @Mock
+    private lateinit var userAnalysisRequestRepository: UserAnalysisRequestRepository
+
+    @Mock
     private lateinit var issueRepository: IssueRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
 
     @Mock
     private lateinit var gitHubClient: GitHubClient
@@ -56,17 +64,29 @@ class ContextAnalyzerServiceImplTest {
     @Mock
     private lateinit var glmClient: GlmClient
 
+    @Mock
+    private lateinit var mockUser: User
+
     private lateinit var contextAnalyzerService: ContextAnalyzerServiceImpl
 
     @BeforeEach
     fun setUp() {
+        lenient().`when`(mockUser.id).thenReturn(USER_ID)
         contextAnalyzerService = ContextAnalyzerServiceImpl(
             analysisResultRepository = analysisResultRepository,
+            userAnalysisRequestRepository = userAnalysisRequestRepository,
             issueRepository = issueRepository,
+            userRepository = userRepository,
             gitHubClient = gitHubClient,
             glmClient = glmClient,
             objectMapper = ObjectMapper()
         )
+    }
+
+    companion object {
+        private const val GITHUB_ID = "test-user"
+        private const val USER_ID = 1L
+        private const val ISSUE_ID = 1L
     }
 
     // ──────────────────────────────────────────
@@ -88,17 +108,6 @@ class ContextAnalyzerServiceImplTest {
         labels = emptyList()
     )
 
-    private val mockSearchResult = GitHubCodeSearchRes(
-        totalCount = 1,
-        items = listOf(
-            GitHubCodeSearchItem(
-                name = "UserService.kt",
-                path = "src/main/kotlin/com/example/UserService.kt",
-                htmlUrl = "https://github.com/..."
-            )
-        )
-    )
-
     private val mockAnalysisResult = AnalysisResult(
         issue = mockIssue,
         filePaths = """["src/main/kotlin/com/example/UserService.kt"]""",
@@ -116,30 +125,59 @@ class ContextAnalyzerServiceImplTest {
     inner class GetGuide {
 
         @Test
-        @DisplayName("캐시 HIT - 분석 결과가 이미 있으면 GitHub API 호출 없이 즉시 반환한다")
-        fun `캐시 HIT시 즉시 반환`() {
+        @DisplayName("사용자 캐시 HIT - 동일 이슈에 재요청하면 GitHub API 호출 없이 즉시 반환한다")
+        fun `사용자 캐시 HIT시 즉시 반환`() {
             // given
-            given(issueRepository.findById(1L)).willReturn(Optional.of(mockIssue))
-            given(analysisResultRepository.findByIssueId(1L)).willReturn(mockAnalysisResult)
+            val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(completedRequest)
 
             // when
-            val result = contextAnalyzerService.getGuide(1L)
+            val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+
+            // then
+            assertNotNull(result)
+            assertEquals("TODO: GLM 연동 후 실제 가이드 생성", result.guideline)
+            then(gitHubClient).shouldHaveNoInteractions()
+            then(userAnalysisRequestRepository).should().findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID)
+        }
+
+        @Test
+        @DisplayName("이슈 캐시 HIT - 다른 사용자의 분석 결과가 있으면 재사용하고 요청 이력을 저장한다")
+        fun `이슈 캐시 HIT시 즉시 반환`() {
+            // given
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(0L)
+            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(mockAnalysisResult)
+
+            // when
+            val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
 
             // then
             assertNotNull(result)
             assertEquals(listOf("src/main/kotlin/com/example/UserService.kt"), result.filePaths)
             assertEquals("TODO: GLM 연동 후 실제 가이드 생성", result.guideline)
-
-            // GitHub API 호출 안 됐는지 검증
             then(gitHubClient).shouldHaveNoInteractions()
+            then(userAnalysisRequestRepository).should().save(any())
         }
 
         @Test
         @DisplayName("캐시 MISS - 분석 결과가 없으면 GitHub API 호출 후 저장한다")
         fun `캐시 MISS시 GitHub API 호출`() {
             // given
-            given(issueRepository.findById(1L)).willReturn(Optional.of(mockIssue))
-            given(analysisResultRepository.findByIssueId(1L)).willReturn(null)
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(0L)
+            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
             given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42))
                 .willReturn(mockIssueInfo)
             given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
@@ -157,7 +195,7 @@ class ContextAnalyzerServiceImplTest {
             given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
 
             // when
-            val result = contextAnalyzerService.getGuide(1L)
+            val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
 
             // then
             assertNotNull(result)
@@ -165,7 +203,9 @@ class ContextAnalyzerServiceImplTest {
             then(gitHubClient).should().fetchTree("spring-projects", "spring-boot")
             then(glmClient).should().selectFiles(any(), anyOrNull(), any())
             then(analysisResultRepository).should().save(any())
+            then(userAnalysisRequestRepository).should().save(any())
         }
+
         @Test
         @DisplayName("이슈가 없으면 AnalysisException을 던진다")
         fun `이슈 없으면 예외 던짐`() {
@@ -173,8 +213,38 @@ class ContextAnalyzerServiceImplTest {
             given(issueRepository.findById(999L)).willReturn(Optional.empty())
 
             // when & then
-            assertThrows(AnalysisException::class.java) {
-                contextAnalyzerService.getGuide(999L)
+            assertThrows<AnalysisException> {
+                contextAnalyzerService.getGuide(999L, GITHUB_ID)
+            }
+        }
+
+        @Test
+        @DisplayName("사용자가 없으면 AuthException을 던진다")
+        fun `사용자 없으면 예외 던짐`() {
+            // given
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.empty())
+
+            // when & then
+            assertThrows<AuthException> {
+                contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+            }
+        }
+
+        @Test
+        @DisplayName("일일 분석 요청 횟수 초과 시 AnalysisException을 던진다")
+        fun `횟수 초과 시 예외 던짐`() {
+            // given
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(5L)
+
+            // when & then
+            assertThrows<AnalysisException> {
+                contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
             }
         }
     }
@@ -188,19 +258,44 @@ class ContextAnalyzerServiceImplTest {
     inner class GetPseudoCode {
 
         @Test
-        @DisplayName("캐시 HIT - 분석 결과가 이미 있으면 GitHub API 호출 없이 즉시 반환한다")
-        fun `캐시 HIT시 즉시 반환`() {
+        @DisplayName("사용자 캐시 HIT - 동일 이슈에 재요청하면 GitHub API 호출 없이 즉시 반환한다")
+        fun `사용자 캐시 HIT시 즉시 반환`() {
             // given
-            given(issueRepository.findById(1L)).willReturn(Optional.of(mockIssue))
-            given(analysisResultRepository.findByIssueId(1L)).willReturn(mockAnalysisResult)  // 추가!
+            val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(completedRequest)
 
             // when
-            val result = contextAnalyzerService.getPseudoCode(1L)
+            val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
             // then
             assertNotNull(result)
             assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
             then(gitHubClient).shouldHaveNoInteractions()
+        }
+
+        @Test
+        @DisplayName("이슈 캐시 HIT - 다른 사용자의 분석 결과가 있으면 재사용하고 요청 이력을 저장한다")
+        fun `이슈 캐시 HIT시 즉시 반환`() {
+            // given
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(0L)
+            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(mockAnalysisResult)
+
+            // when
+            val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+
+            // then
+            assertNotNull(result)
+            assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
+            then(gitHubClient).shouldHaveNoInteractions()
+            then(userAnalysisRequestRepository).should().save(any())
         }
 
         @Test
@@ -210,8 +305,38 @@ class ContextAnalyzerServiceImplTest {
             given(issueRepository.findById(999L)).willReturn(Optional.empty())
 
             // when & then
-            assertThrows(AnalysisException::class.java) {
-                contextAnalyzerService.getPseudoCode(999L)
+            assertThrows<AnalysisException> {
+                contextAnalyzerService.getPseudoCode(999L, GITHUB_ID)
+            }
+        }
+
+        @Test
+        @DisplayName("사용자가 없으면 AuthException을 던진다")
+        fun `사용자 없으면 예외 던짐`() {
+            // given
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.empty())
+
+            // when & then
+            assertThrows<AuthException> {
+                contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+            }
+        }
+
+        @Test
+        @DisplayName("일일 분석 요청 횟수 초과 시 AnalysisException을 던진다")
+        fun `횟수 초과 시 예외 던짐`() {
+            // given
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubId(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(5L)
+
+            // when & then
+            assertThrows<AnalysisException> {
+                contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
             }
         }
     }


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

 ## 📝 요약                                                                                                                                                                                                                                                                                                                                                                    
  사용자별 분석 요청 이력을 추적하는 `UserAnalysisRequest` 엔티티 및 레포지토리를 구현하고, 서비스·컨트롤러에 연동합니다.                                                                                                                                                                                                                                                       
  분석 요청 시 사용자 인증을 적용하고, 사용자별 캐시 재사용 및 일일 횟수 제한(5회) 로직을 추가합니다.                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                 
  ## 🔗 관련 이슈                                                                                                                                                                                                                                                                                                                                                               
  - Close #86 
                                                                                                                                                                    
  ## 🛠 주요 변경 사항                                                                                                                                                                                                                                                                                                                                                          
  - [x] `UserAnalysisRequest` 엔티티 추가 — 사용자·분석 결과 간 다대일 관계, PENDING/COMPLETED 상태 관리                                                                                                                                                                                                                                                                        
  - [x] `UserAnalysisRequestRepository` 추가 — 횟수 제한 집계, 중복 요청 탐지, 이슈별 분석 여부 조회 메서드 정의
  - [x] `ContextAnalyzerService` 인터페이스 변경 — `getGuide`, `getPseudoCode`에 `githubId: String` 파라미터 추가
  - [x] `ContextAnalyzerServiceImpl` 변경 — `resolveOrCreateAnalysis`로 로직 통합 (사용자 캐시 HIT → 횟수 제한 → 이슈 캐시 재사용 → 신규 생성 순)
  - [x] `ContextAnalyzerController` 변경 — `@AuthenticationPrincipal` 적용, `principal.githubId`를 서비스로 전달
  - [x] `AnalysisErrorCode`에 `ANALYSIS_RATE_LIMIT_EXCEEDED` 추가
  - [x] `ContextAnalyzerServiceImplTest` 수정 — 변경된 서비스 구조에 맞춰 Mock 및 테스트 케이스 업데이트

## 🧪 테스트 결과
<img width="744" height="468" alt="image" src="https://github.com/user-attachments/assets/2d1339b4-5bf2-46b6-8dd2-21426caa2017" />

변경된 analysis 도메인에 맞게 테스트코드가 변경되었습니다.

