### PR TITLE
[#90][FEAT] Pr Diff Github에서 가져오기

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/CreatePrReq.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/CreatePrReq.kt
@@ -6,16 +6,16 @@ import jakarta.validation.constraints.Positive
 /**
  * PR 생성 요청 정보를 담는 DTO입니다.
  *
- * <p>
- * 사용자가 선택한 Issue와 코드 변경 내용(diff)을 기반으로
- * PR 제목과 본문 생성을 요청할 때 사용됩니다.
- *
  * @author 5h6vm
  * @since 2026-04-21
  */
 data class CreatePrReq(
-    @field:Positive(message = "issueId는 1 이상이어야 합니다.")
-    val issueId: Long,
-    @field:NotBlank(message = "diffContent는 비어 있을 수 없습니다.")
-    val diffContent: String
+    @field:NotBlank(message = "upstreamRepo는 비어 있을 수 없습니다.")
+    val upstreamRepo: String,
+    @field:Positive(message = "githubIssueNumber는 1 이상이어야 합니다.")
+    val githubIssueNumber: Long,
+    @field:NotBlank(message = "baseBranch는 비어 있을 수 없습니다.")
+    val baseBranch: String,
+    @field:NotBlank(message = "headBranch는 비어 있을 수 없습니다.")
+    val headBranch: String
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
@@ -66,7 +66,16 @@ class PrDraft(
      * diff 내용을 기반으로 AI가 생성한 설명(변경 사항, 테스트 방법 등)을 포함합니다.
      */
     @Column(name = "pr_body", nullable = false, columnDefinition = "TEXT")
-    var prBody: String
+    var prBody: String,
+
+    @Column(name = "base_branch", nullable = false)
+    var baseBranch: String,
+
+    @Column(name = "head_branch", nullable = false)
+    var headBranch: String,
+
+    @Column(name = "fork_owner", nullable = false)
+    var forkOwner: String
 
 ) : BaseEntity() {
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/entity/PrDraft.kt
@@ -68,12 +68,23 @@ class PrDraft(
     @Column(name = "pr_body", nullable = false, columnDefinition = "TEXT")
     var prBody: String,
 
+    /**
+     * GitHub PR 생성 시 기준이 되는 upstream 브랜치입니다. (예: main)
+     */
     @Column(name = "base_branch", nullable = false)
     var baseBranch: String,
 
+    /**
+     * 포크한 사용자의 작업 브랜치입니다. (예: fix/issue-123)
+     */
     @Column(name = "head_branch", nullable = false)
     var headBranch: String,
 
+    /**
+     * 포크한 사용자의 GitHub 로그인명입니다.
+     *
+     * GitHub Compare URL 생성 시 {forkOwner}:{headBranch} 형식으로 사용됩니다.
+     */
     @Column(name = "fork_owner", nullable = false)
     var forkOwner: String
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
@@ -43,7 +43,7 @@ interface GitHubClient {
      *
      * @param upstreamRepo owner/repo 형식의 upstream 레포지토리
      * @param baseBranch 기준 브랜치 (예: main)
-     * @param forkOwner 포크한 사용자의 GitHub ID
+     * @param forkOwner 포크한 사용자의 GitHub 로그인명
      * @param headBranch 작업 브랜치 (예: fix/issue-123)
      * @return 변경된 파일들의 patch를 합친 diff 문자열
      */

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
@@ -37,4 +37,15 @@ interface GitHubClient {
      * @return merged PR 목록, 없거나 실패 시 빈 리스트
      */
     fun fetchMergedPrs(fullName: String): List<GitHubPrRes>
+
+    /**
+     * GitHub Compare API로 두 브랜치 간의 diff를 가져옵니다.
+     *
+     * @param upstreamRepo owner/repo 형식의 upstream 레포지토리
+     * @param baseBranch 기준 브랜치 (예: main)
+     * @param forkOwner 포크한 사용자의 GitHub ID
+     * @param headBranch 작업 브랜치 (예: fix/issue-123)
+     * @return 변경된 파일들의 patch를 합친 diff 문자열
+     */
+    fun fetchDiff(upstreamRepo: String, baseBranch: String, forkOwner: String, headBranch: String): String
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -1,5 +1,7 @@
 package com.back.omos.domain.prdraft.github
 
+import com.back.omos.global.exception.errorCode.PrDraftErrorCode
+import com.back.omos.global.exception.exceptions.PrDraftException
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -128,7 +130,7 @@ class GitHubClientImpl(
      * @param forkOwner 포크한 사용자의 GitHub 로그인명
      * @param headBranch 작업 브랜치 (예: fix/issue-123)
      * @return 변경된 파일들의 patch를 합친 diff 문자열
-     * @throws com.back.omos.global.exception.exceptions.PrDraftException 브랜치 또는 레포지토리를 찾을 수 없는 경우
+     * @throws PrDraftException 브랜치 또는 레포지토리를 찾을 수 없는 경우
      */
     override fun fetchDiff(upstreamRepo: String, baseBranch: String, forkOwner: String, headBranch: String): String {
         return try {
@@ -143,9 +145,7 @@ class GitHubClientImpl(
                 ?: ""
         } catch (e: RestClientResponseException) {
             if (e.statusCode.value() == 404) {
-                throw com.back.omos.global.exception.exceptions.PrDraftException(
-                    com.back.omos.global.exception.errorCode.PrDraftErrorCode.DIFF_NOT_FOUND
-                )
+                throw PrDraftException(PrDraftErrorCode.DIFF_NOT_FOUND)
             }
             logger.warn { "GitHub Compare API 오류: $upstreamRepo ($baseBranch...$forkOwner:$headBranch) - ${e.statusCode}" }
             throw e

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -125,20 +125,34 @@ class GitHubClientImpl(
      *
      * @param upstreamRepo owner/repo 형식의 upstream 레포지토리
      * @param baseBranch 기준 브랜치 (예: main)
-     * @param forkOwner 포크한 사용자의 GitHub ID
+     * @param forkOwner 포크한 사용자의 GitHub 로그인명
      * @param headBranch 작업 브랜치 (예: fix/issue-123)
      * @return 변경된 파일들의 patch를 합친 diff 문자열
+     * @throws com.back.omos.global.exception.exceptions.PrDraftException 브랜치 또는 레포지토리를 찾을 수 없는 경우
      */
     override fun fetchDiff(upstreamRepo: String, baseBranch: String, forkOwner: String, headBranch: String): String {
-        val response = restClient.get()
-            .uri("/repos/$upstreamRepo/compare/$baseBranch...$forkOwner:$headBranch")
-            .retrieve()
-            .body(GitHubCompareRes::class.java)
+        return try {
+            val response = restClient.get()
+                .uri("/repos/$upstreamRepo/compare/$baseBranch...$forkOwner:$headBranch")
+                .retrieve()
+                .body(GitHubCompareRes::class.java)
 
-        return response?.files
-            ?.filter { !it.patch.isNullOrBlank() }
-            ?.joinToString("\n") { "--- ${it.filename}\n${it.patch}" }
-            ?: ""
+            response?.files
+                ?.filter { !it.patch.isNullOrBlank() }
+                ?.joinToString("\n") { "--- ${it.filename}\n${it.patch}" }
+                ?: ""
+        } catch (e: RestClientResponseException) {
+            if (e.statusCode.value() == 404) {
+                throw com.back.omos.global.exception.exceptions.PrDraftException(
+                    com.back.omos.global.exception.errorCode.PrDraftErrorCode.DIFF_NOT_FOUND
+                )
+            }
+            logger.warn { "GitHub Compare API 오류: $upstreamRepo ($baseBranch...$forkOwner:$headBranch) - ${e.statusCode}" }
+            throw e
+        } catch (e: RestClientException) {
+            logger.warn { "GitHub Compare API 네트워크 오류: $upstreamRepo - ${e.message}" }
+            throw e
+        }
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -116,6 +116,32 @@ class GitHubClientImpl(
     }
 
     /**
+     * GitHub Compare API로 두 브랜치 간의 diff를 가져옵니다.
+     *
+     * <p>
+     * upstream 레포지토리의 baseBranch와 포크 사용자의 headBranch를 비교합니다.
+     * 변경된 파일의 patch를 filename 헤더와 함께 합쳐 하나의 문자열로 반환합니다.
+     * patch가 없는 파일(바이너리 등)은 건너뜁니다.
+     *
+     * @param upstreamRepo owner/repo 형식의 upstream 레포지토리
+     * @param baseBranch 기준 브랜치 (예: main)
+     * @param forkOwner 포크한 사용자의 GitHub ID
+     * @param headBranch 작업 브랜치 (예: fix/issue-123)
+     * @return 변경된 파일들의 patch를 합친 diff 문자열
+     */
+    override fun fetchDiff(upstreamRepo: String, baseBranch: String, forkOwner: String, headBranch: String): String {
+        val response = restClient.get()
+            .uri("/repos/$upstreamRepo/compare/$baseBranch...$forkOwner:$headBranch")
+            .retrieve()
+            .body(GitHubCompareRes::class.java)
+
+        return response?.files
+            ?.filter { !it.patch.isNullOrBlank() }
+            ?.joinToString("\n") { "--- ${it.filename}\n${it.patch}" }
+            ?: ""
+    }
+
+    /**
      * GitHub Contents API로 단일 파일의 내용을 가져옵니다.
      *
      * <p>

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubCompareRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubCompareRes.kt
@@ -1,0 +1,35 @@
+package com.back.omos.domain.prdraft.github
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GitHub Compare API 응답을 담는 DTO입니다.
+ *
+ * <p>
+ * 두 브랜치 간의 변경된 파일 목록을 포함하며,
+ * 각 파일의 diff(patch)를 추출하는 데 사용됩니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-29
+ * @see GitHubClientImpl
+ */
+data class GitHubCompareRes(
+
+    @JsonProperty("files")
+    val files: List<GitHubFileRes>?
+)
+
+/**
+ * GitHub Compare API 응답 내 개별 파일 변경 정보를 담는 DTO입니다.
+ *
+ * <p>
+ * 바이너리 파일이나 변경량이 너무 큰 파일의 경우 patch가 null로 반환됩니다.
+ */
+data class GitHubFileRes(
+
+    @JsonProperty("filename")
+    val filename: String,
+
+    @JsonProperty("patch")
+    val patch: String?
+)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -1,6 +1,5 @@
 package com.back.omos.domain.prdraft.service
 
-import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.github.GitHubPrRes
 import org.springframework.core.io.ClassPathResource
 import org.springframework.stereotype.Component
@@ -45,13 +44,12 @@ class PrDraftPromptBuilder {
     /**
      * PR 초안 생성을 위한 프롬프트 문자열을 구성합니다.
      *
-     * @param req PR 생성 요청 DTO
      * @param diffContent GitHub Compare API로 가져온 diff 내용
      * @param contributing CONTRIBUTING.md 내용 (없으면 null)
      * @param prs 참고용 기존 병합 PR 목록
      * @return AI에 전달할 프롬프트 문자열
      */
-    fun build(req: CreatePrReq, diffContent: String, contributing: String?, prs: List<GitHubPrRes>): String {
+    fun build(diffContent: String, contributing: String?, prs: List<GitHubPrRes>): String {
         val contextSection = when {
             contributing != null -> "\n[CONTRIBUTING.md]\n$contributing\n"
             prs.isNotEmpty() -> {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -45,12 +45,13 @@ class PrDraftPromptBuilder {
     /**
      * PR 초안 생성을 위한 프롬프트 문자열을 구성합니다.
      *
-     * @param req PR 생성 요청 DTO (diff 내용 포함)
+     * @param req PR 생성 요청 DTO
+     * @param diffContent GitHub Compare API로 가져온 diff 내용
      * @param contributing CONTRIBUTING.md 내용 (없으면 null)
      * @param prs 참고용 기존 병합 PR 목록
      * @return AI에 전달할 프롬프트 문자열
      */
-    fun build(req: CreatePrReq, contributing: String?, prs: List<GitHubPrRes>): String {
+    fun build(req: CreatePrReq, diffContent: String, contributing: String?, prs: List<GitHubPrRes>): String {
         val contextSection = when {
             contributing != null -> "\n[CONTRIBUTING.md]\n$contributing\n"
             prs.isNotEmpty() -> {
@@ -66,7 +67,7 @@ class PrDraftPromptBuilder {
             반드시 제목과 본문 모두 한국어로 작성하세요.
             $contextSection
             [Diff]
-            ${req.diffContent}
+            $diffContent
 
             반드시 아래 JSON 형식으로만 응답하세요.
             {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -53,13 +53,13 @@ class PrDraftServiceImpl(
     private val logger = KotlinLogging.logger {}
 
     /**
-     * diff 내용과 이슈 정보를 기반으로 AI를 호출하여 PR 초안을 생성하고 저장합니다.
+     * GitHub Compare API로 diff를 가져와 AI를 호출하여 PR 초안을 생성하고 저장합니다.
      *
      * @param githubId 요청한 사용자의 GitHub ID
-     * @param request PR 생성 요청 DTO (issueId, diffContent 포함)
+     * @param request PR 생성 요청 DTO (upstreamRepo, githubIssueNumber, baseBranch, headBranch 포함)
      * @return 생성된 PR 제목, 본문
-     * @throws AuthException 존재하지 않는 githubId인 경우
-     * @throws IssueException 존재하지 않는 issueId인 경우
+     * @throws AuthException 존재하지 않는 githubId이거나 GitHub 로그인명이 없는 경우
+     * @throws IssueException 존재하지 않는 issue인 경우
      */
     override fun create(githubId: String, request: CreatePrReq): PrInfoRes {
         // 정보 조회

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -18,7 +18,6 @@ import com.back.omos.global.exception.errorCode.PrDraftErrorCode
 import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.PrDraftException
-import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -50,8 +49,6 @@ class PrDraftServiceImpl(
     private val gitHubClient: GitHubClient
 ) : PrDraftService {
 
-    private val logger = KotlinLogging.logger {}
-
     /**
      * GitHub Compare API로 diff를 가져와 AI를 호출하여 PR 초안을 생성하고 저장합니다.
      *
@@ -77,7 +74,7 @@ class PrDraftServiceImpl(
         val prs = if (contributing == null) gitHubClient.fetchMergedPrs(request.upstreamRepo) else emptyList()
 
         // prompt 작성
-        val prompt = prDraftPromptBuilder.build(request, diffContent, contributing, prs)
+        val prompt = prDraftPromptBuilder.build(diffContent, contributing, prs)
 
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -87,7 +87,10 @@ class PrDraftServiceImpl(
             issue = issue,
             diffContent = diffContent,
             prTitle = aiResult.title,
-            prBody = aiResult.body
+            prBody = aiResult.body,
+            baseBranch = request.baseBranch,
+            headBranch = request.headBranch,
+            forkOwner = forkOwner
         ))
 
         return PrInfoRes(
@@ -158,7 +161,7 @@ class PrDraftServiceImpl(
         val translated = aiClient.translate(prDraft.prTitle, prDraft.prBody)
 
         // GitHub URL 빌드
-        val githubUrl = buildGithubUrl(prDraft.issue.repoFullName, translated.title, translated.body)
+        val githubUrl = buildGithubUrl(prDraft.issue.repoFullName, prDraft.baseBranch, prDraft.forkOwner, prDraft.headBranch, translated.title, translated.body)
 
         return PrTranslateRes(
             titleEn = translated.title,
@@ -175,10 +178,10 @@ class PrDraftServiceImpl(
      * @param body URL에 삽입할 PR 본문
      * @return pre-fill된 GitHub PR 생성 URL
      */
-    private fun buildGithubUrl(fullName: String, title: String, body: String): String {
+    private fun buildGithubUrl(fullName: String, baseBranch: String, forkOwner: String, headBranch: String, title: String, body: String): String {
         val encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8).replace("+", "%20")
         val encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8).replace("+", "%20")
-        return "https://github.com/$fullName/compare?quick_pull=1&title=$encodedTitle&body=$encodedBody"
+        return "https://github.com/$fullName/compare/$baseBranch...$forkOwner:$headBranch?quick_pull=1&title=$encodedTitle&body=$encodedBody"
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -62,15 +62,18 @@ class PrDraftServiceImpl(
         // 정보 조회
         val user = userRepository.findByGithubId(githubId)
             .orElseThrow { AuthException(AuthErrorCode.USER_NOT_FOUND) }
-        val issue = issueRepository.findById(request.issueId)
-            .orElseThrow { IssueException(IssueErrorCode.ISSUE_NOT_FOUND) }
+        val issue = issueRepository.findByRepoFullNameAndIssueNumber(request.upstreamRepo, request.githubIssueNumber)
+            ?: throw IssueException(IssueErrorCode.ISSUE_NOT_FOUND)
+
+        // GitHub Compare API로 diff 가져오기
+        val diffContent = gitHubClient.fetchDiff(request.upstreamRepo, request.baseBranch, githubId, request.headBranch)
 
         // prompt에게 줄 pr 형식 정보
-        val contributing = gitHubClient.fetchContributing(issue.repoFullName)
-        val prs = if (contributing == null) gitHubClient.fetchMergedPrs(issue.repoFullName) else emptyList()
+        val contributing = gitHubClient.fetchContributing(request.upstreamRepo)
+        val prs = if (contributing == null) gitHubClient.fetchMergedPrs(request.upstreamRepo) else emptyList()
 
         // prompt 작성
-        val prompt = prDraftPromptBuilder.build(request, contributing, prs)
+        val prompt = prDraftPromptBuilder.build(request, diffContent, contributing, prs)
 
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)
@@ -78,7 +81,7 @@ class PrDraftServiceImpl(
         val saved = prDraftRepository.save(PrDraft(
             user = user,
             issue = issue,
-            diffContent = request.diffContent,
+            diffContent = diffContent,
             prTitle = aiResult.title,
             prBody = aiResult.body
         ))

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -18,6 +18,7 @@ import com.back.omos.global.exception.errorCode.PrDraftErrorCode
 import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.PrDraftException
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -49,6 +50,8 @@ class PrDraftServiceImpl(
     private val gitHubClient: GitHubClient
 ) : PrDraftService {
 
+    private val logger = KotlinLogging.logger {}
+
     /**
      * diff 내용과 이슈 정보를 기반으로 AI를 호출하여 PR 초안을 생성하고 저장합니다.
      *
@@ -65,8 +68,9 @@ class PrDraftServiceImpl(
         val issue = issueRepository.findByRepoFullNameAndIssueNumber(request.upstreamRepo, request.githubIssueNumber)
             ?: throw IssueException(IssueErrorCode.ISSUE_NOT_FOUND)
 
-        // GitHub Compare API로 diff 가져오기
-        val diffContent = gitHubClient.fetchDiff(request.upstreamRepo, request.baseBranch, githubId, request.headBranch)
+        // GitHub Compare API로 diff 가져오기 (forkOwner는 GitHub 로그인명)
+        val forkOwner = user.name ?: throw AuthException(AuthErrorCode.USER_NOT_FOUND)
+        val diffContent = gitHubClient.fetchDiff(request.upstreamRepo, request.baseBranch, forkOwner, request.headBranch)
 
         // prompt에게 줄 pr 형식 정보
         val contributing = gitHubClient.fetchContributing(request.upstreamRepo)

--- a/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/PrDraftErrorCode.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/exception/errorCode/PrDraftErrorCode.kt
@@ -21,4 +21,5 @@ enum class PrDraftErrorCode(
     override val message: String
 ) : ErrorCode {
     PR_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 PR 초안을 찾을 수 없습니다."),
+    DIFF_NOT_FOUND(HttpStatus.NOT_FOUND, "브랜치 또는 레포지토리를 찾을 수 없습니다."),
 }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -45,7 +45,7 @@ class PrDraftControllerTest {
     @MockitoBean private lateinit var oauth2FailureHandler: OAuth2FailureHandler
     @MockitoBean private lateinit var jwtProvider: JwtProvider
 
-    private val validBody = """{"issueId": 1, "diffContent": "@@ -1 +1 @@\n-old\n+new"}"""
+    private val validBody = """{"upstreamRepo": "owner/repo", "githubIssueNumber": 1, "baseBranch": "main", "headBranch": "fix/issue-123"}"""
 
     private fun mockAuth() = UsernamePasswordAuthenticationToken(
         OAuthPrincipal("testUser", emptyMap()), null,
@@ -214,23 +214,23 @@ class PrDraftControllerTest {
     inner class ValidationTest {
 
         @Test
-        fun `issueId가 0이면 400을 반환한다`() {
+        fun `githubIssueNumber가 0이면 400을 반환한다`() {
             mockMvc.perform(
                 post("/api/v1/pr")
                     .with(authentication(mockAuth()))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"issueId": 0, "diffContent": "@@ -1 +1 @@"}""")
+                    .content("""{"upstreamRepo": "owner/repo", "githubIssueNumber": 0, "baseBranch": "main", "headBranch": "fix/issue-123"}""")
             )
                 .andExpect(status().isBadRequest)
         }
 
         @Test
-        fun `diffContent가 비어있으면 400을 반환한다`() {
+        fun `upstreamRepo가 비어있으면 400을 반환한다`() {
             mockMvc.perform(
                 post("/api/v1/pr")
                     .with(authentication(mockAuth()))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"issueId": 1, "diffContent": ""}""")
+                    .content("""{"upstreamRepo": "", "githubIssueNumber": 1, "baseBranch": "main", "headBranch": "fix/issue-123"}""")
             )
                 .andExpect(status().isBadRequest)
         }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImplTest.kt
@@ -1,6 +1,8 @@
 package com.back.omos.domain.prdraft.github
 
+import com.back.omos.global.exception.exceptions.PrDraftException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -74,6 +76,31 @@ class GitHubClientImplTest {
             val result = gitHubClient.fetchMergedPrs("omos-nonexistent/repo")
 
             assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class DiffTest {
+
+        @Test
+        fun `같은 브랜치를 비교하면 빈 문자열을 반환한다`() {
+            val result = gitHubClient.fetchDiff("facebook/react", "main", "facebook", "main")
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `존재하지 않는 레포에서 PrDraftException을 던진다`() {
+            assertThatThrownBy {
+                gitHubClient.fetchDiff("omos-nonexistent/repo", "main", "nobody", "feat/x")
+            }.isInstanceOf(PrDraftException::class.java)
+        }
+
+        @Test
+        fun `존재하지 않는 브랜치에서 PrDraftException을 던진다`() {
+            assertThatThrownBy {
+                gitHubClient.fetchDiff("facebook/react", "main", "facebook", "nonexistent-branch-xyz")
+            }.isInstanceOf(PrDraftException::class.java)
         }
     }
 }

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -42,9 +42,10 @@ class PrDraftServiceImplTest {
     private lateinit var service: PrDraftServiceImpl
 
     private val githubId = "testUser"
-    private val req = CreatePrReq(issueId = 1L, diffContent = "@@ -1 +1 @@\n-old\n+new")
+    private val req = CreatePrReq(upstreamRepo = "owner/repo", githubIssueNumber = 1L, baseBranch = "main", headBranch = "fix/issue-123")
     private val user = User(githubId = githubId)
     private val issue = Issue(repoFullName = "owner/repo", issueNumber = 1L, title = "test issue")
+    private val diffContent = "@@ -1 +1 @@\n-old\n+new"
 
     @BeforeEach
     fun setUp() {
@@ -60,9 +61,10 @@ class PrDraftServiceImplTest {
         @Test
         fun `contributing 있을 때 AI 호출 후 결과를 저장하고 반환한다`() {
             given(userRepository.findByGithubId(githubId)).willReturn(Optional.of(user))
-            given(issueRepository.findById(1L)).willReturn(Optional.of(issue))
+            given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
+            given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn("contributing content")
-            given(prDraftPromptBuilder.build(req, "contributing content", emptyList())).willReturn("prompt")
+            given(prDraftPromptBuilder.build(req, diffContent, "contributing content", emptyList())).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("feat: title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft
@@ -82,10 +84,11 @@ class PrDraftServiceImplTest {
         fun `contributing 없을 때 기존 PR 목록을 가져와 프롬프트를 빌드한다`() {
             val prs = listOf(GitHubPrRes("pr title", "pr body", "2026-01-01"))
             given(userRepository.findByGithubId(githubId)).willReturn(Optional.of(user))
-            given(issueRepository.findById(1L)).willReturn(Optional.of(issue))
+            given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
+            given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn(null)
             given(gitHubClient.fetchMergedPrs("owner/repo")).willReturn(prs)
-            given(prDraftPromptBuilder.build(req, null, prs)).willReturn("prompt")
+            given(prDraftPromptBuilder.build(req, diffContent, null, prs)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft
@@ -268,9 +271,9 @@ class PrDraftServiceImplTest {
         }
 
         @Test
-        fun `존재하지 않는 issueId면 IssueException을 던진다`() {
+        fun `존재하지 않는 issue면 IssueException을 던진다`() {
             given(userRepository.findByGithubId(githubId)).willReturn(Optional.of(user))
-            given(issueRepository.findById(1L)).willReturn(Optional.empty())
+            given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(null)
 
             assertThatThrownBy { service.create(githubId, req) }
                 .isInstanceOf(IssueException::class.java)

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -107,7 +107,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `본인 소유 PR 초안이면 상세 정보를 반환한다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
 
@@ -135,7 +135,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `PR 초안 목록을 최신순으로 반환한다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findAllWithIssueByUserGithubId(githubId)).willReturn(listOf(prDraft))
 
@@ -163,7 +163,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `title과 body를 모두 전달하면 둘 다 수정된다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
@@ -176,7 +176,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `title이 null이면 기존 title을 유지한다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
@@ -189,7 +189,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `body가 null이면 기존 body를 유지한다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "old title", prBody = "old body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer { it.arguments[0] }
@@ -214,7 +214,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `본인 소유 PR 초안이면 번역 결과와 GitHub URL을 반환한다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: 제목", prBody = "본문")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: 제목", prBody = "본문", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdWithIssueAndUserGithubId(1L, githubId)).willReturn(prDraft)
             given(aiClient.translate("feat: 제목", "본문")).willReturn(AiPrResult("feat: title", "body"))
@@ -224,6 +224,7 @@ class PrDraftServiceImplTest {
             assertThat(result.titleEn).isEqualTo("feat: title")
             assertThat(result.bodyEn).isEqualTo("body")
             assertThat(result.githubUrl).contains("owner/repo")
+            assertThat(result.githubUrl).contains("main...testUser:fix/issue-123")
             assertThat(result.githubUrl).contains("quick_pull=1")
         }
 
@@ -241,7 +242,7 @@ class PrDraftServiceImplTest {
 
         @Test
         fun `본인 소유 PR 초안이면 삭제한다`() {
-            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body")
+            val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
             given(prDraftRepository.findByIdAndUserGithubId(1L, githubId)).willReturn(prDraft)
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -43,7 +43,7 @@ class PrDraftServiceImplTest {
 
     private val githubId = "testUser"
     private val req = CreatePrReq(upstreamRepo = "owner/repo", githubIssueNumber = 1L, baseBranch = "main", headBranch = "fix/issue-123")
-    private val user = User(githubId = githubId)
+    private val user = User(githubId = githubId, name = "testUser")
     private val issue = Issue(repoFullName = "owner/repo", issueNumber = 1L, title = "test issue")
     private val diffContent = "@@ -1 +1 @@\n-old\n+new"
 

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -64,7 +64,7 @@ class PrDraftServiceImplTest {
             given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
             given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn("contributing content")
-            given(prDraftPromptBuilder.build(req, diffContent, "contributing content", emptyList())).willReturn("prompt")
+            given(prDraftPromptBuilder.build(diffContent, "contributing content", emptyList())).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("feat: title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft
@@ -88,7 +88,7 @@ class PrDraftServiceImplTest {
             given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn(null)
             given(gitHubClient.fetchMergedPrs("owner/repo")).willReturn(prs)
-            given(prDraftPromptBuilder.build(req, diffContent, null, prs)).willReturn("prompt")
+            given(prDraftPromptBuilder.build(diffContent, null, prs)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
DiffContent를 Compare API를 통해 가져온다
기존 클라이언트가 diffContent를 직접 입력하는 방식에서 서버가 자동으로 가져오는 방식으로 변경

## 🔗 관련 이슈
- Close #90 

## 🛠️ 주요 변경 사항
- [x] 요청 DTO 변경
``` kotlin
{
	upstreamRepo: string,  // "owner/repo" 형식. ex) "apache/kafka"
	githubIssueNumber: number,
	baseBranch: string,    // upstream 기준 브랜치. ex) "main"
	headBranch: string     // 사용자 포크의 작업 브랜치. ex) "fix/issue-123"
}
```

- [x] url에 브랜치 비교 경로 추가
- [x] compare api 구현 및 내부 응답 dto
- [x] PrDraft entity에 baseBranch, headBranch, forkOwner 추가
        pr을 생성할때 브랜치 정보를 받아오지면 번역 이후 url을 만들때  다시 정보를 얻을 방법이 없습니다. entity에 추가를 안하는 방식으로 하게되면 프론트가 정보를 들고 있어야하므로 api가 번잡해 지는 문제가 있습니다. 그래서 서버가 브랜치정보를 가져다 쓰도록 entity에 추가하는 방식으로 구현하였습니다.
- [x] 관련 test 추가

## 🧪 테스트 결과
<img width="495" height="464" alt="스크린샷 2026-04-29 131227" src="https://github.com/user-attachments/assets/226cea9d-3bc8-4772-bbb1-def8c424e5e2" />

<img width="1074" height="256" alt="스크린샷 2026-04-29 113535" src="https://github.com/user-attachments/assets/fda16981-8231-4b85-93ca-9d8da14eac3e" /> | <img width="1065" height="387" alt="스크린샷 2026-04-29 113835" src="https://github.com/user-attachments/assets/99762d35-2628-4e45-ae07-77677d61e43a" /> | <img width="828" height="898" alt="스크린샷 2026-04-29 113822" src="https://github.com/user-attachments/assets/720e57d8-4d1f-4196-ba8f-6ff2f8e7e087" /> |
|---|---|---|
|diff로 pr 생성|번역 후 생성된 url| 해당 url 페이지|

1. repo를 fork후 파일 하나 생성
2. fork된 레포에서 수정 후 push
3. 이후 pr 생성 실행 (첫번째 사진)
4. 번역 실행 (두번째 사진)
5. url로 들어가면 정상 작동 확인 가능 (세번째 사진)

## 🧐 리뷰어에게
- `main`으로 merge됩니다.
- entity가 변경되어 db를 날렸다가 하시는걸 추천드립니다
- update test가 실패하는건... 왜 그런지 모르겠습니다.. error log 알려주시면 다시 찾아보겠습니다.
