### PR TITLE
[#85][TEST] Issue 관련 테스트 코드 추가, JaCoCo도입

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -1,28 +1,33 @@
 plugins {
-	id 'org.jetbrains.kotlin.jvm' version '2.2.21'
-	id 'org.jetbrains.kotlin.plugin.spring' version '2.2.21'
-	id 'org.jetbrains.kotlin.plugin.jpa' version '2.2.21'
-	id 'org.springframework.boot' version '3.5.14'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.jetbrains.kotlin.jvm' version '2.2.21'
+    id 'org.jetbrains.kotlin.plugin.spring' version '2.2.21'
+    id 'org.jetbrains.kotlin.plugin.jpa' version '2.2.21'
+    id 'org.springframework.boot' version '3.5.14'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.back'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(24)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(24)
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.14"
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:1.1.4"
-	}
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:1.1.4"
+    }
 }
 
 dependencies {
@@ -73,11 +78,39 @@ dependencies {
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll '-Xjsr305=strict', '-Xannotation-default-target=param-property'
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll '-Xjsr305=strict', '-Xannotation-default-target=param-property'
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
+    ignoreFailures = true
+    finalizedBy jacocoTestReport // 테스트 종료 후 리포트 자동 생성
+}
+
+// 4. 리포트 생성 및 제외 설정
+jacocoTestReport {
+    dependsOn test
+    reports {
+        html.required = true
+        xml.required = true
+    }
+
+    // 리포트에서 제외할 클래스들
+    def excludes = [
+            "**/dto/**",
+            "**/*Application*",
+            "**/*Config*",
+            "**/*Response*",
+            "**/*Request*",
+            "**/entity/**",
+            "**/Q*"
+    ]
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: excludes)
+        }))
+    }
 }

--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -86,10 +86,9 @@ kotlin {
 tasks.named('test') {
     useJUnitPlatform()
     ignoreFailures = true
-    finalizedBy jacocoTestReport // 테스트 종료 후 리포트 자동 생성
+    finalizedBy jacocoTestReport
 }
 
-// 4. 리포트 생성 및 제외 설정
 jacocoTestReport {
     dependsOn test
     reports {

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientTest.kt
@@ -1,0 +1,54 @@
+package com.back.omos.domain.issue.ai
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.mockito.kotlin.whenever
+import org.springframework.ai.chat.model.ChatModel
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.mockito.kotlin.mock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * AI 모델(GLM)을 이용한 이슈 추천 로직의 단위 테스트 클래스입니다.
+ * <p>
+ * Mock 된 ChatModel이 반환하는 JSON 형태의 문자열 응답이
+ * 서비스 내부에서 사용하는 객체 리스트로 정확히 역직렬화(Parsing)되는지 검증합니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code IssueGlmClientTest()} <br>
+ * Mockito를 통해 가짜 ChatModel을 주입하고, KotlinModule이 등록된 ObjectMapper를 초기화하여 테스트 환경을 구성합니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * - Mockito: AI 모델 및 인터페이스 모킹<br>
+ * - Jackson (KotlinModule): JSON 데이터 파싱 검증
+ *
+ * @author 유재원
+ * @since 2026-04-28
+ */
+class IssueGlmClientTest {
+    private val chatModel: ChatModel = mock()
+    private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
+    private val client = IssueGlmClientImpl(chatModel, objectMapper)
+
+    @Test
+    fun `AI가 준 JSON 응답이 객체 리스트로 정확히 변환되는지 테스트`() {
+        val fakeJsonResponse = """
+            [
+              { "title": "이슈1", "repoName": "owner/repo1", "reason": "이유1" },
+              { "title": "이슈2", "repoName": "owner/repo2", "reason": "이유2" }
+            ]
+        """.trimIndent()
+
+        whenever(chatModel.call(any<String>())).thenReturn(fakeJsonResponse)
+
+        // when: 클라이언트 호출
+        val results = client.generateRecommendationReasons("Kotlin 스택", emptyList())
+
+        // then: 파싱 결과 확인
+        assertEquals(2, results.size)
+        assertEquals("이슈1", results[0].title)
+        assertEquals("owner/repo2", results[1].repoName)
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/controller/IssueControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/controller/IssueControllerTest.kt
@@ -1,0 +1,160 @@
+package com.back.omos.domain.issue.controller
+
+
+import com.back.omos.domain.issue.dto.RecommendIssueRes
+import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.issue.service.IssueService
+import com.back.omos.domain.issue.service.RecommendService
+import com.back.omos.global.auth.principal.OAuthPrincipal
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.time.LocalDateTime
+
+/**
+ * 이슈(Issue) 관련 API의 엔드포인트 동작을 검증하는 컨트롤러 테스트 클래스입니다.
+ * <p>
+ * MockMvc를 사용하여 실제 서블릿 컨테이너를 구동하지 않고 HTTP 요청 및 응답을 시뮬레이션하며,
+ * 서비스 계층을 Mocking 하여 컨트롤러의 요청 파싱, 권한 처리, 응답 포맷팅 로직을 집중적으로 테스트합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * - {@code WebMvcTest}: IssueController와 관련된 웹 레이어 빈들만 로드하여 가벼운 테스트 환경을 구축합니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code IssueControllerTest()} <br>
+ * Spring Boot의 테스트 컨텍스트 프레임워크에 의해 필요한 Mock 객체들이 자동으로 주입됩니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * - MockMvc: REST API 호출 및 검증 <br>
+ * - Mockito: 서비스 및 리포지토리 레이어의 의존성 제거 <br>
+ * - Spring Security Test: 인증된 사용자(OAuthPrincipal) 및 CSRF 토큰 처리
+ *
+ * @author 유재원
+ * @since 2026-04-29
+ */
+@WebMvcTest(IssueController::class)
+class IssueControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var issueService: IssueService
+
+    @MockitoBean
+    private lateinit var issueRepository: IssueRepository
+
+    @MockitoBean
+    private lateinit var recommendService: RecommendService
+
+    @Test
+    @DisplayName("전체 이슈 조회 성공 테스트")
+    @WithMockUser
+    fun getAllIssuesTest() {
+        // given
+        val mockIssue = Issue(
+            repoFullName = "back-omos/omos-backend",
+            issueNumber = 101L,
+            title = "Test Issue Title"
+        ).apply {
+            content = "이슈 테스트 본문입니다."
+            labels = listOf("bug", "good-first-issue")
+        }
+
+        val mockIssues = listOf(mockIssue)
+        given(issueRepository.findAll()).willReturn(mockIssues)
+
+        // when & then
+        mockMvc.get("/api/v1/issues") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data[0].title") { value("Test Issue Title") }
+            jsonPath("$.data[0].repoFullName") { value("back-omos/omos-backend") }
+        }
+    }
+
+    @Test
+    @DisplayName("깃허브 쿼리로 이슈 크롤링 및 저장 테스트")
+    @WithMockUser
+    fun crawlBySearchTest() {
+        // given
+        val query = "language:kotlin"
+
+        val mockIssues = listOf(
+            Issue(
+                repoFullName = "back-omos/omos-backend",
+                issueNumber = 42L,
+                title = "Crawled Issue"
+            ).apply {
+                content = "크롤링된 이슈 본문입니다."
+            }
+        )
+
+        given(issueService.crawlAndSaveByQuery(query)).willReturn(mockIssues)
+
+        // when & then
+        mockMvc.post("/api/v1/issues/crawl/search") {
+            param("q", query)
+            with(csrf()) // Security POST 요청 시 필수
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data[0].title") { value("Crawled Issue") }
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 맞춤 이슈 추천 테스트")
+    fun getRecommendationTest() {
+        // given
+        val githubId = "jaewon-user"
+
+        val mockPrincipal = OAuthPrincipal(
+            githubId = githubId,
+            attributes = mapOf("login" to githubId)
+        )
+
+        val authentication = UsernamePasswordAuthenticationToken(
+            mockPrincipal,
+            null,
+            mockPrincipal.authorities
+        )
+
+        val mockResponses = listOf(
+            RecommendIssueRes(
+                id = 1L,
+                repoFullName = "back-omos/omos-backend",
+                issueNumber = 123L,
+                title = "AI Recommended Issue",
+                summary = "AI가 분석한 추천 사유 요약입니다.",
+                score = 0.95f,
+                labels = listOf("help wanted"),
+                status = "OPEN"
+            )
+        )
+
+        given(recommendService.getPersonalizedRecommendation(githubId)).willReturn(mockResponses)
+
+        // when & then
+        mockMvc.get("/api/v1/issues/recommend") {
+            with(authentication(authentication))
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data[0].title") { value("AI Recommended Issue") }
+            jsonPath("$.data[0].score") { value(0.95) }
+        }
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/service/IssueServiceTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/service/IssueServiceTest.kt
@@ -1,0 +1,222 @@
+package com.back.omos.domain.issue.service
+
+import com.back.omos.domain.issue.dto.CreateIssueReq
+import com.back.omos.domain.issue.dto.GithubIssueResponse
+import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.github.GithubClient
+import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.global.ai.GeminiEmbeddingModel
+import com.back.omos.global.exception.errorCode.IssueErrorCode
+import com.back.omos.global.exception.exceptions.IssueException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import org.springframework.ai.document.Document
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.util.ReflectionTestUtils
+import java.util.*
+import kotlin.jvm.java
+
+/**
+ * 이슈(Issue) 비즈니스 로직의 핵심 기능을 검증하는 서비스 레이어 테스트 클래스입니다.
+ * <p>
+ * 외부 API 호출, AI 임베딩 모델 연동, DB 접근 로직이 유기적으로 작동하는지 확인하며,
+ * 특히 신규 이슈 크롤링 시의 데이터 변환(Float to Double) 및 중복 체크 로직을 집중적으로 검증합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * - {@code MockitoExtension}: Mockito를 사용하여 외부 의존성(Repository, Client, AI Model)을 격리한 단위 테스트를 수행합니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code IssueServiceTest()} <br>
+ * {@code @BeforeEach} 단계에서 Mock 객체들을 주입하여 테스트 대상인 {@code IssueServiceImpl} 인스턴스를 직접 생성합니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * - Mockito: 외부 API(GitHub) 및 AI 모델(Gemini)의 응답 모킹 <br>
+ * - ReflectionTestUtils: JPA 엔티티의 불변 필드(ID 등)에 테스트용 데이터를 강제 주입 <br>
+ * - Spring AI: Document 및 Embedding 관련 인터페이스 타입 지원
+ *
+ * @author 유재원
+ * @since 2026-04-29
+ */
+
+@ExtendWith(MockitoExtension::class)
+class IssueServiceTest {
+
+    @Mock
+    private lateinit var issueRepository: IssueRepository
+
+    @Mock
+    private lateinit var githubClient: GithubClient
+
+    @Mock
+    private lateinit var embeddingModel: GeminiEmbeddingModel
+
+    private lateinit var issueService: IssueServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        issueService = IssueServiceImpl(issueRepository, githubClient, embeddingModel)
+    }
+
+
+    @Test
+    @DisplayName("이슈 생성 성공")
+    fun createIssueSuccess() {
+        // given
+        val request = CreateIssueReq(
+            repoFullName = "naver/fixture-monkey",
+            issueNumber = 1L,
+            title = "New Issue",
+            status = Issue.IssueStatus.OPEN
+        )
+
+        val mockIssue = request.toEntity()
+        ReflectionTestUtils.setField(mockIssue, "id", 1L)
+
+        given(issueRepository.existsByRepoFullNameAndIssueNumber(any(), any())).willReturn(false)
+        given(issueRepository.save(any<Issue>())).willReturn(mockIssue)
+
+        // when
+        val result = issueService.createIssue(request)
+
+        // then
+        assertNotNull(result)
+        assertEquals(1L, result.id) // DTO에 ID가 잘 담겼는지 확인
+        verify(issueRepository).save(any<Issue>())
+    }
+
+    @Test
+    @DisplayName("이슈 생성 실패 - 중복된 이슈 번호가 존재할 경우 예외 발생")
+    fun createIssueFailAlreadyExist() {
+        // given
+        val request = CreateIssueReq(
+            repoFullName = "org/repo",
+            issueNumber = 1L,
+            title = "Title",
+            status = Issue.IssueStatus.OPEN
+        )
+        given(issueRepository.existsByRepoFullNameAndIssueNumber(any(), any())).willReturn(true)
+
+        // when & then
+        val exception = assertThrows(IssueException::class.java) {
+            issueService.createIssue(request)
+        }
+        assertEquals(IssueErrorCode.ISSUE_ALREADY_EXIST, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("크롤링 및 저장 - 신규 이슈일 경우 URL 파싱 및 AI 임베딩(Vector 변환) 후 저장")
+    fun crawlAndSaveNewIssue() {
+        // given
+        val query = "fixture-monkey"
+
+        val mockGithubResponse = GithubIssueResponse(
+            id = 12345L,
+            number = 99L,
+            title = "Parsing Test Issue",
+            body = "This is body content",
+            htmlUrl = "https://github.com/naver/fixture-monkey/issues/99",
+            repositoryUrl = "https://api.github.com/repos/naver/fixture-monkey",
+            labels = listOf(GithubIssueResponse.LabelResponse(name = "enhancement", color = "blue"))
+        )
+
+        given(githubClient.searchIssues(query)).willReturn(listOf(mockGithubResponse))
+        given(issueRepository.findByRepoFullNameAndIssueNumber(any(), any())).willReturn(null)
+
+        // AI 임베딩 모델 모킹 (FloatArray 반환)
+        val mockFloatVector = FloatArray(3072) { 0.5f }
+        given(embeddingModel.embed(any<Document>())).willReturn(mockFloatVector)
+
+        // 저장 시 전달받은 객체를 그대로 반환하도록 설정
+        given(issueRepository.save(any<Issue>())).willAnswer { invocation ->
+            invocation.getArgument<Issue>(0)
+        }
+        // when
+        val result = issueService.crawlAndSaveByQuery(query)
+
+        // then
+        assertEquals(1, result.size)
+        val savedIssue = result[0]
+
+        assertEquals("naver/fixture-monkey", savedIssue.repoFullName) // URL 파싱 결과 확인
+        assertEquals(99L, savedIssue.issueNumber)
+        assertEquals("Parsing Test Issue", savedIssue.title)
+
+        // FloatArray -> DoubleArray 변환 및 값 검증
+        assertNotNull(savedIssue.issueVector)
+        assertEquals(3072, savedIssue.issueVector?.size)
+        assertEquals(0.5, savedIssue.issueVector!![0], 0.0001)
+
+        verify(embeddingModel).embed(any<Document>())
+        verify(issueRepository).save(any())
+    }
+
+    @Test
+    @DisplayName("크롤링 및 저장 - 이미 존재하는 이슈는 추가 저장 없이 기존 객체 반환")
+    fun crawlAndSaveExistingIssue() {
+        // given
+        val query = "existing"
+        val mockGithubResponse = GithubIssueResponse(
+            id = 111L,
+            number = 1L,
+            title = "Existing",
+            body = "...",
+            htmlUrl = "...",
+            repositoryUrl = "https://api.github.com/repos/org/repo",
+            labels = emptyList()
+        )
+        val existingIssue = Issue(repoFullName = "org/repo", issueNumber = 1L, title = "Already In DB")
+
+        given(githubClient.searchIssues(query)).willReturn(listOf(mockGithubResponse))
+        given(issueRepository.findByRepoFullNameAndIssueNumber("org/repo", 1L)).willReturn(existingIssue)
+
+        // when
+        val result = issueService.crawlAndSaveByQuery(query)
+
+        // then
+        assertEquals(1, result.size)
+        assertEquals("Already In DB", result[0].title)
+
+        verify(embeddingModel, never()).embed(any<Document>()) // AI 호출 안 함
+        verify(issueRepository, never()).save(any()) // 저장 안 함
+    }
+
+    @Test
+    @DisplayName("이슈 상세 조회 성공")
+    fun getIssueSuccess() {
+        // given
+        val issueId = 1L
+        val mockIssue = Issue(repoFullName = "org/repo", issueNumber = 1L, title = "Found")
+        ReflectionTestUtils.setField(mockIssue, "id", issueId)
+
+        given(issueRepository.findById(issueId)).willReturn(Optional.of(mockIssue))
+
+        // when
+        val result = issueService.getIssue(issueId)
+
+        // then
+        assertNotNull(result)
+        assertEquals("Found", result.title)
+    }
+
+    @Test
+    @DisplayName("이슈 상세 조회 실패 - 존재하지 않는 ID")
+    fun getIssueFailNotFound() {
+        // given
+        given(issueRepository.findById(any<Long>())).willReturn(Optional.empty())
+
+        // when & then
+        val exception = assertThrows(IssueException::class.java) {
+            issueService.getIssue(999L)
+        }
+
+        assertEquals(IssueErrorCode.ISSUE_NOT_FOUND, exception.errorCode)
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/service/RecommendServiceTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/service/RecommendServiceTest.kt
@@ -1,0 +1,139 @@
+package com.back.omos.domain.issue.service
+
+import com.back.omos.domain.issue.ai.IssueGlmClient
+import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.issue.dto.AIRecommendationResult
+import com.back.omos.domain.user.entity.User
+import com.back.omos.domain.user.repository.UserRepository
+import com.back.omos.global.exception.exceptions.AuthException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+import java.util.*
+
+/**
+ * 사용자 맞춤형 이슈 추천 비즈니스 로직을 검증하는 서비스 레이어 테스트 클래스입니다.
+ * <p>
+ * 사용자의 기술 스택 및 프로필 벡터를 기반으로 DB에서 유사 이슈 후보군을 추출하고,
+ * 이를 AI(GLM) 모델에 전달하여 최종적인 추천 사유와 함께 정제된 데이터를 반환하는지 확인합니다.
+ * 특히 데이터 불일치 시의 필터링 로직과 사용자 정보 부재 시의 예외 처리를 집중적으로 테스트합니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code RecommendServiceTest()} <br>
+ * Mockito를 통해 Mocking된 {@code IssueRepository}, {@code UserRepository}, {@code IssueGlmClient}를
+ * {@code RecommendServiceImpl}에 주입하여 테스트 환경을 구성합니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * - Mockito (mockito-kotlin): {@code doReturn}, {@code whenever}를 활용한 고차원적인 객체 모킹 <br>
+ * - JUnit 5: {@code assertThrows}, {@code assertEquals} 등을 활용한 로직 결과 및 예외 검증
+ *
+ * @author 유재원
+ * @since 2026-04-29
+ */
+class RecommendServiceTest {
+
+    private val issueRepository: IssueRepository = mock()
+    private val userRepository: UserRepository = mock()
+    private val issueGlmClient: IssueGlmClient = mock()
+
+    private val recommendService = RecommendServiceImpl(
+        issueRepository,
+        userRepository,
+        issueGlmClient
+    )
+
+    @Test
+    @DisplayName("성공: AI가 준 제목과 레포 이름이 DB 후보군과 일치하면 정상적으로 리스트를 반환한다")
+    fun getRecommendation_Success() {
+        // given
+        val githubId = "jaewon-test"
+        val mockUser = mock<User> {
+            on { profileVector } doReturn doubleArrayOf(0.1, 0.2)
+            on { primaryLanguages } doReturn listOf("Kotlin", "Java")
+        }
+
+        val issue1 = createIssue("Fix bug", "owner/repo1")
+        val issue2 = createIssue("Add feature", "owner/repo2")
+        val topIssues = listOf(issue1, issue2)
+
+        whenever(userRepository.findByGithubId(githubId)).thenReturn(Optional.of(mockUser))
+        whenever(issueRepository.findBySimilarity(any(), any())).thenReturn(topIssues)
+
+        // AI가 정확한 정보를 응답했다고 가정
+        val aiResults = listOf(
+            AIRecommendationResult("Fix bug", "owner/repo1", "좋은 버그 수정 이슈입니다."),
+            AIRecommendationResult("Add feature", "owner/repo2", "배울 점이 많은 기능 구현입니다.")
+        )
+        whenever(issueGlmClient.generateRecommendationReasons(any(), any())).thenReturn(aiResults)
+
+        // when
+        val results = recommendService.getPersonalizedRecommendation(githubId)
+
+        // then
+        assertEquals(2, results.size)
+        assertEquals("Fix bug", results[0].title)
+        assertEquals("좋은 버그 수정 이슈입니다.", results[0].summary)
+    }
+
+    @Test
+    @DisplayName("검증: 제목은 같지만 레포 이름이 다르거나, 후보군에 없는 이슈는 mapNotNull에 의해 필터링된다")
+    fun getRecommendation_FilteringMismatch() {
+        // given
+        val githubId = "jaewon-test"
+        val mockUser = mock<User> {
+            on { profileVector } doReturn doubleArrayOf(0.1, 0.2)
+        }
+
+        val issue1 = createIssue("Fix bug", "owner/repo1")
+        val topIssues = listOf(issue1)
+
+        whenever(userRepository.findByGithubId(githubId)).thenReturn(Optional.of(mockUser))
+        whenever(issueRepository.findBySimilarity(any(), any())).thenReturn(topIssues)
+
+        // AI가 엉뚱한 레포 이름을 주거나 아예 없는 제목을 준 경우
+        val aiResults = listOf(
+            AIRecommendationResult("Fix bug", "wrong/repo", "이건 필터링되어야 함"), // 레포 불일치
+            AIRecommendationResult("Unknown Title", "owner/repo1", "이것도 필터링되어야 함") // 제목 불일치
+        )
+        whenever(issueGlmClient.generateRecommendationReasons(any(), any())).thenReturn(aiResults)
+
+        // when
+        val results = recommendService.getPersonalizedRecommendation(githubId)
+
+        // then
+        // 모든 결과가 매칭에 실패했으므로 빈 리스트가 반환되어야 함
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    @DisplayName("예외: 유저의 프로필 벡터가 없으면 AuthException을 던진다")
+    fun getRecommendation_NoVector() {
+        // given
+        val githubId = "jaewon-test"
+        val mockUser = mock<User> {
+            on { profileVector } doReturn null // 벡터가 없음
+        }
+        whenever(userRepository.findByGithubId(githubId)).thenReturn(Optional.of(mockUser))
+
+        // when & then
+        assertThrows<AuthException> {
+            recommendService.getPersonalizedRecommendation(githubId)
+        }
+    }
+
+    // 테스트용 Issue 엔티티 생성을 돕는 헬퍼 메서드
+    private fun createIssue(title: String, repoFullName: String, issueNumber: Long = 1L): Issue {
+        return Issue(
+            repoFullName = repoFullName,
+            issueNumber = issueNumber,
+            title = title,
+            content = "테스트용 이슈 본문입니다.",
+            labels = listOf("bug", "good-first-issue"),
+            issueVector = null,
+            status = Issue.IssueStatus.OPEN
+        )
+    }
+}


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
변경 사항에 대한 간단한 설명을 작성해주세요.
Issue 관련 테스트 코드 추가, JaCoCo도입했습니다.

## 🔗 관련 이슈
- Close #85 

## 🛠️ 주요 변경 사항
- [ ] `build.gradle` 의존성 변경
- [ ] test에 issue 관련 테스트 코드 추가

## 🧪 테스트 결과
테스트 통과 여부나 결과를 적어주세요. (스크린샷 가능)
<img width="721" height="562" alt="image" src="https://github.com/user-attachments/assets/a1b66b74-9d5c-4fd3-952a-d008ca002316" />
현재 JaCoCo를 통한 테스트 커버리지 측정은 이렇게 됩니다.

## 🧐 리뷰어에게
JaCoCo에서 global 하위 폴더들을 감지하지 못하게 빼야할까요?
이거는 테스트 커버리지를 재는게 의미가 있는지 잘 모르겠네요
