### PR TITLE
[#93][FEAT] Pr 다건조회 페이징기능 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/controller/PrDraftController.kt
@@ -4,12 +4,14 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrPageRes
 import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.dto.UpdatePrReq
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.principal.OAuthPrincipal
 import com.back.omos.global.response.CommonResponse
 import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -61,9 +64,11 @@ class PrDraftController(
 
     @GetMapping("/history")
     fun getHistory(
-        @AuthenticationPrincipal principal: OAuthPrincipal
-    ): CommonResponse<List<PrHistoryRes>> {
-        return CommonResponse.success(prDraftService.getHistory(principal.githubId))
+        @AuthenticationPrincipal principal: OAuthPrincipal,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int
+    ): CommonResponse<PrPageRes<PrHistoryRes>> {
+        return CommonResponse.success(prDraftService.getHistory(principal.githubId, PageRequest.of(page, size)))
     }
 
     @PatchMapping("/{id}")

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrPageRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/dto/PrPageRes.kt
@@ -1,0 +1,33 @@
+package com.back.omos.domain.prdraft.dto
+
+import org.springframework.data.domain.Page
+
+/**
+ * PR 초안 목록 페이징 응답 DTO입니다.
+ *
+ * @property content 현재 페이지 데이터 목록
+ * @property totalElements 전체 데이터 수
+ * @property totalPages 전체 페이지 수
+ * @property page 현재 페이지 번호 (0부터 시작)
+ * @property size 페이지당 데이터 수
+ *
+ * @author 5h6vm
+ * @since 2026-04-29
+ */
+data class PrPageRes<T>(
+    val content: List<T>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val page: Int,
+    val size: Int
+) {
+    companion object {
+        fun <T> from(page: Page<T>) = PrPageRes(
+            content = page.content,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            page = page.number,
+            size = page.size
+        )
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/repository/PrDraftRepository.kt
@@ -1,6 +1,8 @@
 package com.back.omos.domain.prdraft.repository
 
 import com.back.omos.domain.prdraft.entity.PrDraft
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -21,16 +23,20 @@ import org.springframework.data.repository.query.Param
 interface PrDraftRepository : JpaRepository<PrDraft, Long> {
 
     /**
-     * 특정 사용자의 PR 초안 목록을 이슈 정보와 함께 생성일 내림차순으로 조회합니다.
+     * 특정 사용자의 PR 초안 목록을 이슈 정보와 함께 생성일 내림차순으로 페이징 조회합니다.
      *
      * <p>
-     * fetch join을 사용하여 issue를 한 번의 쿼리로 함께 조회합니다.
+     * fetch join과 페이징을 함께 사용하기 위해 countQuery를 분리합니다.
      *
      * @param githubId 조회할 사용자의 GitHub ID
-     * @return PR 초안 목록 (최신순, issue 포함)
+     * @param pageable 페이지 정보
+     * @return PR 초안 페이지 (최신순, issue 포함)
      */
-    @Query("SELECT pd FROM PrDraft pd JOIN FETCH pd.issue WHERE pd.user.githubId = :githubId ORDER BY pd.createdAt DESC")
-    fun findAllWithIssueByUserGithubId(@Param("githubId") githubId: String): List<PrDraft>
+    @Query(
+        value = "SELECT pd FROM PrDraft pd JOIN FETCH pd.issue WHERE pd.user.githubId = :githubId ORDER BY pd.createdAt DESC",
+        countQuery = "SELECT COUNT(pd) FROM PrDraft pd WHERE pd.user.githubId = :githubId"
+    )
+    fun findAllWithIssueByUserGithubId(@Param("githubId") githubId: String, pageable: Pageable): Page<PrDraft>
 
     /**
      * PR 초안 ID와 사용자 GitHub ID로 PR 초안을 조회합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftService.kt
@@ -4,8 +4,10 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrPageRes
 import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.dto.UpdatePrReq
+import org.springframework.data.domain.Pageable
 
 /**
  * PR 초안 생성, 조회, 수정, 삭제, 번역 기능을 제공하는 Service 인터페이스입니다.
@@ -41,12 +43,13 @@ interface PrDraftService {
     fun getOne(githubId: String, prDraftId: Long): PrDetailRes
 
     /**
-     * 사용자가 생성한 PR 초안 목록을 최신순으로 조회합니다.
+     * 사용자가 생성한 PR 초안 목록을 최신순으로 페이징 조회합니다.
      *
      * @param githubId 조회할 사용자의 GitHub ID
-     * @return PR 초안 목록 (최신순)
+     * @param pageable 페이지 정보
+     * @return PR 초안 페이지 (최신순)
      */
-    fun getHistory(githubId: String): List<PrHistoryRes>
+    fun getHistory(githubId: String, pageable: Pageable): PrPageRes<PrHistoryRes>
 
     /**
      * PR 초안의 제목과 본문을 수정합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -21,6 +21,7 @@ import com.back.omos.global.exception.exceptions.AuthException
 import com.back.omos.global.exception.exceptions.IssueException
 import com.back.omos.global.exception.exceptions.PrDraftException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -107,6 +108,7 @@ class PrDraftServiceImpl(
      * @return PR 초안 상세 정보 (diffContent 포함)
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */
+    @Transactional(readOnly = true)
     override fun getOne(githubId: String, prDraftId: Long): PrDetailRes {
         val prDraft = prDraftRepository.findByIdWithIssueAndUserGithubId(prDraftId, githubId)
             ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
@@ -119,6 +121,7 @@ class PrDraftServiceImpl(
      * @param githubId 조회할 사용자의 GitHub ID
      * @return PR 초안 목록 (최신순)
      */
+    @Transactional(readOnly = true)
     override fun getHistory(githubId: String, pageable: Pageable): PrPageRes<PrHistoryRes> {
         return PrPageRes.from(
             prDraftRepository.findAllWithIssueByUserGithubId(githubId, pageable)
@@ -135,6 +138,7 @@ class PrDraftServiceImpl(
      * @return 수정된 PR 초안 상세 정보
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */
+    @Transactional
     override fun update(githubId: String, prDraftId: Long, request: UpdatePrReq): PrDetailRes {
         val prDraft = prDraftRepository.findByIdWithIssueAndUserGithubId(prDraftId, githubId)
             ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)
@@ -192,6 +196,7 @@ class PrDraftServiceImpl(
      * @param prDraftId 삭제할 PR 초안 ID
      * @throws PrDraftException 존재하지 않는 PR 초안이거나 본인 소유가 아닌 경우
      */
+    @Transactional
     override fun delete(githubId: String, prDraftId: Long) {
         val prDraft = prDraftRepository.findByIdAndUserGithubId(prDraftId, githubId)
             ?: throw PrDraftException(PrDraftErrorCode.PR_DRAFT_NOT_FOUND)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -5,8 +5,10 @@ import com.back.omos.domain.prdraft.dto.CreatePrReq
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrPageRes
 import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.dto.UpdatePrReq
+import org.springframework.data.domain.Pageable
 import com.back.omos.domain.prdraft.ai.AiClient
 import com.back.omos.domain.prdraft.entity.PrDraft
 import com.back.omos.domain.prdraft.github.GitHubClient
@@ -117,9 +119,11 @@ class PrDraftServiceImpl(
      * @param githubId 조회할 사용자의 GitHub ID
      * @return PR 초안 목록 (최신순)
      */
-    override fun getHistory(githubId: String): List<PrHistoryRes> {
-        return prDraftRepository.findAllWithIssueByUserGithubId(githubId)
-            .map { PrHistoryRes.from(it) }
+    override fun getHistory(githubId: String, pageable: Pageable): PrPageRes<PrHistoryRes> {
+        return PrPageRes.from(
+            prDraftRepository.findAllWithIssueByUserGithubId(githubId, pageable)
+                .map { PrHistoryRes.from(it) }
+        )
     }
 
     /**

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/controller/PrDraftControllerTest.kt
@@ -3,6 +3,7 @@ package com.back.omos.domain.prdraft.controller
 import com.back.omos.domain.prdraft.dto.PrDetailRes
 import com.back.omos.domain.prdraft.dto.PrHistoryRes
 import com.back.omos.domain.prdraft.dto.PrInfoRes
+import com.back.omos.domain.prdraft.dto.PrPageRes
 import com.back.omos.domain.prdraft.dto.PrTranslateRes
 import com.back.omos.domain.prdraft.service.PrDraftService
 import com.back.omos.global.auth.handler.OAuth2FailureHandler
@@ -107,9 +108,15 @@ class PrDraftControllerTest {
     inner class GetHistoryTest {
 
         @Test
-        fun `목록 조회 정상 요청이면 200과 목록을 반환한다`() {
-            given(prDraftService.getHistory(any())).willReturn(
-                listOf(PrHistoryRes(1L, "owner/repo", "test issue", "feat: title", LocalDateTime.now()))
+        fun `목록 조회 정상 요청이면 200과 페이징 목록을 반환한다`() {
+            given(prDraftService.getHistory(any(), any())).willReturn(
+                PrPageRes(
+                    content = listOf(PrHistoryRes(1L, "owner/repo", "test issue", "feat: title", LocalDateTime.now())),
+                    totalElements = 1L,
+                    totalPages = 1,
+                    page = 0,
+                    size = 10
+                )
             )
 
             mockMvc.perform(
@@ -118,9 +125,11 @@ class PrDraftControllerTest {
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.data[0].title").value("feat: title"))
-                .andExpect(jsonPath("$.data[0].repoFullName").value("owner/repo"))
-                .andExpect(jsonPath("$.data[0].issueTitle").value("test issue"))
+                .andExpect(jsonPath("$.data.content[0].title").value("feat: title"))
+                .andExpect(jsonPath("$.data.content[0].repoFullName").value("owner/repo"))
+                .andExpect(jsonPath("$.data.content[0].issueTitle").value("test issue"))
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
         }
 
         @Test

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -26,6 +26,8 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.verify
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.util.ReflectionTestUtils
 import java.util.Optional
 
@@ -133,28 +135,33 @@ class PrDraftServiceImplTest {
     @Nested
     inner class GetHistoryTest {
 
+        private val pageable = PageRequest.of(0, 10)
+
         @Test
         fun `PR 초안 목록을 최신순으로 반환한다`() {
             val prDraft = PrDraft(user = user, issue = issue, diffContent = "diff", prTitle = "feat: title", prBody = "body", baseBranch = "main", headBranch = "fix/issue-123", forkOwner = "testUser")
             ReflectionTestUtils.setField(prDraft, "id", 1L)
-            given(prDraftRepository.findAllWithIssueByUserGithubId(githubId)).willReturn(listOf(prDraft))
+            given(prDraftRepository.findAllWithIssueByUserGithubId(githubId, pageable)).willReturn(PageImpl(listOf(prDraft)))
 
-            val result = service.getHistory(githubId)
+            val result = service.getHistory(githubId, pageable)
 
-            assertThat(result).hasSize(1)
-            assertThat(result[0].id).isEqualTo(1L)
-            assertThat(result[0].repoFullName).isEqualTo("owner/repo")
-            assertThat(result[0].issueTitle).isEqualTo("test issue")
-            assertThat(result[0].title).isEqualTo("feat: title")
+            assertThat(result.content).hasSize(1)
+            assertThat(result.content[0].id).isEqualTo(1L)
+            assertThat(result.content[0].repoFullName).isEqualTo("owner/repo")
+            assertThat(result.content[0].issueTitle).isEqualTo("test issue")
+            assertThat(result.content[0].title).isEqualTo("feat: title")
+            assertThat(result.totalElements).isEqualTo(1L)
+            assertThat(result.totalPages).isEqualTo(1)
         }
 
         @Test
         fun `PR 초안이 없으면 빈 목록을 반환한다`() {
-            given(prDraftRepository.findAllWithIssueByUserGithubId(githubId)).willReturn(emptyList())
+            given(prDraftRepository.findAllWithIssueByUserGithubId(githubId, pageable)).willReturn(PageImpl(emptyList()))
 
-            val result = service.getHistory(githubId)
+            val result = service.getHistory(githubId, pageable)
 
-            assertThat(result).isEmpty()
+            assertThat(result.content).isEmpty()
+            assertThat(result.totalElements).isEqualTo(0L)
         }
     }
 


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
pr 다건조회 페이징 기능 

## 🔗 관련 이슈
- Close #95

## 🛠️ 주요 변경 사항
- [ ] page dto 생성
- [ ] repository page 기능 추가
- [ ] service, controller page 기능 추가
- [ ] test 수정

## 🧪 테스트 결과
<img width="441" height="545" alt="image" src="https://github.com/user-attachments/assets/612f6ef3-e060-4e21-8540-e42db0888836" />

## 🧐 리뷰어에게
`main`으로 병합됩니다.