### PR TITLE
[TEST] Context Analyzer 도메인 단위 테스트 추가

### DIFF
--- a/omos/build.gradle
+++ b/omos/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -29,7 +29,8 @@ import java.time.Duration
  */
 @Component("analysisGitHubClientImpl")
 class GitHubClientImpl(
-    @Value("\${github.token}") private val token: String
+    @Value("\${github.token}") private val token: String,
+    @Value("\${github.api.base-url:https://api.github.com}") private val baseUrl: String = "https://api.github.com"
 ) : GitHubClient {
     private val log = LoggerFactory.getLogger(GitHubClientImpl::class.java)
 
@@ -38,7 +39,7 @@ class GitHubClientImpl(
     }
 
     private val restClient = RestClient.builder()
-        .baseUrl("https://api.github.com")
+        .baseUrl(baseUrl)
         .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $token")
         .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
         .requestFactory(SimpleClientHttpRequestFactory().apply {

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/ai/GlmClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/ai/GlmClientImplTest.kt
@@ -1,0 +1,204 @@
+package com.back.omos.domain.analysis.ai
+
+import com.back.omos.global.exception.exceptions.AnalysisException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.BDDMockito.given
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.springframework.ai.chat.model.ChatModel
+
+/**
+ * GlmClientImpl 단위 테스트
+ *
+ * chatModel은 Mock으로 대체하고, ObjectMapper는 실제 인스턴스를 주입하여
+ * JSON 파싱 로직을 포함한 모든 분기를 검증합니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-29
+ */
+@ExtendWith(MockitoExtension::class)
+@DisplayName("GlmClientImpl 단위 테스트")
+class GlmClientImplTest {
+
+    @Mock
+    private lateinit var chatModel: ChatModel
+
+    // Kotlin data class 역직렬화를 위해 Kotlin 모듈이 등록된 ObjectMapper 사용
+    private val objectMapper = jacksonObjectMapper()
+
+    private lateinit var glmClientImpl: GlmClientImpl
+
+    @BeforeEach
+    fun setUp() {
+        glmClientImpl = GlmClientImpl(chatModel, objectMapper)
+    }
+
+    // ──────────────────────────────────────────
+    // parseFileList() — selectFiles()를 통해 간접 검증
+    // ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("parseFileList()")
+    inner class ParseFileList {
+
+        @Test
+        @DisplayName("정상 JSON 응답을 파일 경로 목록으로 파싱한다")
+        fun `정상 JSON 파싱 성공`() {
+            // given
+            given(chatModel.call(any<String>()))
+                .willReturn("""{"files": ["src/a.kt", "src/b.kt"]}""")
+
+            // when
+            val result = glmClientImpl.selectFiles("Fix bug", null, listOf("src/a.kt", "src/b.kt"))
+
+            // then
+            assertEquals(listOf("src/a.kt", "src/b.kt"), result)
+        }
+
+        @Test
+        @DisplayName("마크다운 코드블록이 포함된 응답도 정상 파싱한다")
+        fun `마크다운 코드블록 응답 파싱 성공`() {
+            // given: ```json ... ``` 래핑된 응답
+            val response = "```json\n{\"files\": [\"src/a.kt\"]}\n```"
+            given(chatModel.call(any<String>())).willReturn(response)
+
+            // when
+            val result = glmClientImpl.selectFiles("Fix bug", null, listOf("src/a.kt"))
+
+            // then
+            assertEquals(listOf("src/a.kt"), result)
+        }
+
+        @Test
+        @DisplayName("'files' 키가 없는 JSON 응답이면 AnalysisException을 던진다")
+        fun `files 키 없으면 예외`() {
+            // given: files 키 없는 올바른 JSON
+            given(chatModel.call(any<String>())).willReturn("""{"other": []}""")
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.selectFiles("Fix bug", null, emptyList())
+            }
+        }
+
+        @Test
+        @DisplayName("JSON 형식이 깨진 응답이면 AnalysisException을 던진다")
+        fun `JSON 형식 오류시 예외`() {
+            // given: JSON이 아닌 문자열
+            given(chatModel.call(any<String>())).willReturn("not json at all")
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.selectFiles("Fix bug", null, emptyList())
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────
+    // selectFiles() 테스트
+    // ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("selectFiles()")
+    inner class SelectFiles {
+
+        @Test
+        @DisplayName("chatModel.call()이 null을 반환하면 AnalysisException을 던진다")
+        fun `chatModel null 반환시 예외`() {
+            // given
+            given(chatModel.call(any<String>())).willReturn(null)
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.selectFiles("Fix bug", null, emptyList())
+            }
+        }
+
+        @Test
+        @DisplayName("chatModel.call()이 RuntimeException을 던지면 AnalysisException으로 래핑한다")
+        fun `chatModel RuntimeException시 AnalysisException 래핑`() {
+            // given: 네트워크 오류 등 런타임 예외 시뮬레이션
+            given(chatModel.call(any<String>())).willThrow(RuntimeException("API connection error"))
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.selectFiles("Fix bug", null, emptyList())
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────
+    // analyze() 테스트
+    // ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("analyze()")
+    inner class Analyze {
+
+        @Test
+        @DisplayName("chatModel.call()이 null을 반환하면 AnalysisException을 던진다")
+        fun `chatModel null 반환시 예외`() {
+            // given
+            given(chatModel.call(any<String>())).willReturn(null)
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.analyze("Fix bug", null, emptyList(), emptyMap())
+            }
+        }
+
+        @Test
+        @DisplayName("chatModel.call()이 RuntimeException을 던지면 AnalysisException으로 래핑한다")
+        fun `chatModel RuntimeException시 AnalysisException 래핑`() {
+            // given
+            given(chatModel.call(any<String>())).willThrow(RuntimeException("API connection error"))
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.analyze("Fix bug", null, emptyList(), emptyMap())
+            }
+        }
+
+        @Test
+        @DisplayName("유효한 JSON 응답을 GlmAnalysisRes로 파싱하여 반환한다")
+        fun `유효한 JSON 응답 파싱 성공`() {
+            // given
+            val json = """
+                {
+                    "guideline": "서비스 계층에서 null 체크 추가",
+                    "pseudoCode": "UserService.findById() → Optional.orElseThrow()",
+                    "sideEffects": "기존 null 반환에 의존하던 코드 영향 가능"
+                }
+            """.trimIndent()
+            given(chatModel.call(any<String>())).willReturn(json)
+
+            // when
+            val result = glmClientImpl.analyze("Fix NullPointerException", "본문", listOf("bug"), emptyMap())
+
+            // then
+            assertEquals("서비스 계층에서 null 체크 추가", result.guideline)
+            assertEquals("UserService.findById() → Optional.orElseThrow()", result.pseudoCode)
+            assertEquals("기존 null 반환에 의존하던 코드 영향 가능", result.sideEffects)
+        }
+
+        @Test
+        @DisplayName("GlmAnalysisRes로 파싱할 수 없는 JSON 응답이면 AnalysisException을 던진다")
+        fun `파싱 불가 JSON 응답시 예외`() {
+            // given: 필수 필드가 누락된 JSON (GlmAnalysisRes 역직렬화 실패)
+            given(chatModel.call(any<String>())).willReturn("broken json")
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                glmClientImpl.analyze("Fix bug", null, emptyList(), emptyMap())
+            }
+        }
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/github/GitHubClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/github/GitHubClientImplTest.kt
@@ -1,0 +1,238 @@
+package com.back.omos.domain.analysis.github
+
+import com.back.omos.global.exception.exceptions.AnalysisException
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
+import java.util.Base64
+
+/**
+ * GitHubClientImpl 단위 테스트
+ *
+ * MockWebServer를 사용하여 실제 HTTP 서버를 로컬에 띄우고
+ * 응답 시나리오별로 GitHubClientImpl 동작을 검증합니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-04-29
+ */
+@ActiveProfiles("test")
+@DisplayName("GitHubClientImpl 단위 테스트")
+class GitHubClientImplTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var gitHubClient: GitHubClientImpl
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        gitHubClient = GitHubClientImpl(
+            token = "test-token",
+            baseUrl = "http://localhost:${mockWebServer.port}"
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    // ──────────────────────────────────────────
+    // fetchTree() 테스트
+    // ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("fetchTree()")
+    inner class FetchTree {
+
+        @Test
+        @DisplayName("truncated=true 응답 시 AnalysisException을 던진다")
+        fun `truncated true 응답시 예외`() {
+            // given: 대형 레포에서 GitHub가 결과를 잘라낸 경우
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setBody("""{"tree": [{"path": "src/Foo.kt", "type": "blob"}], "truncated": true}""")
+            )
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                gitHubClient.fetchTree("owner", "repo")
+            }
+        }
+
+        @Test
+        @DisplayName("정상 응답 시 blob 타입 파일 경로만 반환한다")
+        fun `정상 응답시 blob 경로 목록 반환`() {
+            // given: blob(파일)과 tree(디렉토리)가 혼재한 응답
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(
+                        """
+                        {
+                            "tree": [
+                                {"path": "src/main/Foo.kt", "type": "blob"},
+                                {"path": "src/main", "type": "tree"},
+                                {"path": "src/main/Bar.kt", "type": "blob"}
+                            ],
+                            "truncated": false
+                        }
+                        """.trimIndent()
+                    )
+            )
+
+            // when
+            val result = gitHubClient.fetchTree("owner", "repo")
+
+            // then: tree 타입은 제외하고 blob만 반환
+            assertEquals(listOf("src/main/Foo.kt", "src/main/Bar.kt"), result)
+        }
+
+        @Test
+        @DisplayName("HTTP 오류 응답 시 AnalysisException을 던진다")
+        fun `HTTP 오류 응답시 예외`() {
+            // given: 403 Forbidden (Rate Limit 초과 등)
+            mockWebServer.enqueue(MockResponse().setResponseCode(403))
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                gitHubClient.fetchTree("owner", "repo")
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────
+    // fetchFileContent() 테스트
+    // ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("fetchFileContent()")
+    inner class FetchFileContent {
+
+        @Test
+        @DisplayName("404 응답 시 null을 반환한다")
+        fun `404 응답시 null 반환`() {
+            // given: 파일이 존재하지 않는 경우
+            mockWebServer.enqueue(MockResponse().setResponseCode(404))
+
+            // when
+            val result = gitHubClient.fetchFileContent("owner", "repo", "src/NotExist.kt")
+
+            // then
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("404 외 HTTP 오류(500 등) 시 로그를 남기고 null을 반환한다")
+        fun `500 응답시 null 반환`() {
+            // given: 서버 내부 오류
+            mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+            // when
+            val result = gitHubClient.fetchFileContent("owner", "repo", "src/Foo.kt")
+
+            // then: 예외가 전파되지 않고 null 반환
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("정상 응답 시 Base64 디코딩된 파일 내용을 반환한다")
+        fun `정상 응답시 디코딩된 파일 내용 반환`() {
+            // given: GitHub API는 파일 내용을 Base64로 인코딩하여 반환
+            val originalContent = "fun main() { println(\"Hello, World!\") }"
+            val encoded = Base64.getEncoder().encodeToString(originalContent.toByteArray())
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setBody("""{"content": "$encoded"}""")
+            )
+
+            // when
+            val result = gitHubClient.fetchFileContent("owner", "repo", "src/Main.kt")
+
+            // then
+            assertEquals(originalContent, result)
+        }
+
+        @Test
+        @DisplayName("content 필드가 null인 응답 시 null을 반환한다")
+        fun `content null 응답시 null 반환`() {
+            // given: 빈 파일이나 바이너리 파일의 경우 content가 null
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setBody("""{"content": null}""")
+            )
+
+            // when
+            val result = gitHubClient.fetchFileContent("owner", "repo", "src/Empty.kt")
+
+            // then
+            assertNull(result)
+        }
+    }
+
+    // ──────────────────────────────────────────
+    // fetchIssue() 테스트
+    // ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("fetchIssue()")
+    inner class FetchIssue {
+
+        @Test
+        @DisplayName("정상 응답 시 GitHubIssueRes를 반환한다")
+        fun `정상 응답시 이슈 정보 반환`() {
+            // given
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(
+                        """
+                        {
+                            "number": 42,
+                            "title": "Fix NullPointerException",
+                            "body": "이슈 본문",
+                            "labels": [{"name": "bug"}, {"name": "good first issue"}]
+                        }
+                        """.trimIndent()
+                    )
+            )
+
+            // when
+            val result = gitHubClient.fetchIssue("owner", "repo", 42)
+
+            // then
+            assertEquals(42, result.number)
+            assertEquals("Fix NullPointerException", result.title)
+            assertEquals("이슈 본문", result.body)
+            assertEquals(listOf("bug", "good first issue"), result.labels.map { it.name })
+        }
+
+        @Test
+        @DisplayName("HTTP 오류 응답 시 AnalysisException을 던진다")
+        fun `HTTP 오류 응답시 예외`() {
+            // given: 404 (이슈 없음) 또는 기타 오류
+            mockWebServer.enqueue(MockResponse().setResponseCode(404))
+
+            // when & then
+            assertThrows(AnalysisException::class.java) {
+                gitHubClient.fetchIssue("owner", "repo", 999)
+            }
+        }
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -25,49 +25,34 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
-import org.mockito.Mockito.lenient
 import org.mockito.Mock
+import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.springframework.test.context.ActiveProfiles
 import java.util.Optional
 
-/**
- * ContextAnalyzerServiceImpl 단위 테스트
- *
- * 외부 의존성(GitHub API, DB)을 Mock으로 대체하여
- * 서비스 로직만 독립적으로 검증합니다.
- *
- * @author Jaewon Ryu
- * @since 2026-04-24
- */
 @ExtendWith(MockitoExtension::class)
 @ActiveProfiles("test")
 class ContextAnalyzerServiceImplTest {
 
-    @Mock
-    private lateinit var analysisResultRepository: AnalysisResultRepository
-
-    @Mock
-    private lateinit var userAnalysisRequestRepository: UserAnalysisRequestRepository
-
-    @Mock
-    private lateinit var issueRepository: IssueRepository
-
-    @Mock
-    private lateinit var userRepository: UserRepository
-
-    @Mock
-    private lateinit var gitHubClient: GitHubClient
-
-    @Mock
-    private lateinit var glmClient: GlmClient
-
-    @Mock
-    private lateinit var mockUser: User
+    @Mock private lateinit var analysisResultRepository: AnalysisResultRepository
+    @Mock private lateinit var userAnalysisRequestRepository: UserAnalysisRequestRepository
+    @Mock private lateinit var issueRepository: IssueRepository
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var gitHubClient: GitHubClient
+    @Mock private lateinit var glmClient: GlmClient
+    @Mock private lateinit var mockUser: User
 
     private lateinit var contextAnalyzerService: ContextAnalyzerServiceImpl
+
+    companion object {
+        private const val GITHUB_ID = "test-user"
+        private const val USER_ID = 1L
+        private const val ISSUE_ID = 1L
+    }
 
     @BeforeEach
     fun setUp() {
@@ -82,16 +67,6 @@ class ContextAnalyzerServiceImplTest {
             objectMapper = ObjectMapper()
         )
     }
-
-    companion object {
-        private const val GITHUB_ID = "test-user"
-        private const val USER_ID = 1L
-        private const val ISSUE_ID = 1L
-    }
-
-    // ──────────────────────────────────────────
-    // 테스트용 픽스처 (공통으로 쓰는 더미 데이터)
-    // ──────────────────────────────────────────
 
     private val mockIssue = Issue(
         repoFullName = "spring-projects/spring-boot",
@@ -116,10 +91,6 @@ class ContextAnalyzerServiceImplTest {
         sideEffects = "TODO: GLM 연동 후 실제 부작용 분석"
     )
 
-    // ──────────────────────────────────────────
-    // getGuide() 테스트
-    // ──────────────────────────────────────────
-
     @Nested
     @DisplayName("getGuide()")
     inner class GetGuide {
@@ -127,41 +98,33 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("사용자 캐시 HIT - 동일 이슈에 재요청하면 GitHub API 호출 없이 즉시 반환한다")
         fun `사용자 캐시 HIT시 즉시 반환`() {
-            // given
             val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(completedRequest)
 
-            // when
             val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
 
-            // then
             assertNotNull(result)
             assertEquals("TODO: GLM 연동 후 실제 가이드 생성", result.guideline)
             then(gitHubClient).shouldHaveNoInteractions()
-            then(userAnalysisRequestRepository).should().findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID)
         }
 
         @Test
         @DisplayName("이슈 캐시 HIT - 다른 사용자의 분석 결과가 있으면 재사용하고 요청 이력을 저장한다")
         fun `이슈 캐시 HIT시 즉시 반환`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(0L)
             given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(mockAnalysisResult)
 
-            // when
             val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
 
-            // then
             assertNotNull(result)
-            assertEquals(listOf("src/main/kotlin/com/example/UserService.kt"), result.filePaths)
             assertEquals("TODO: GLM 연동 후 실제 가이드 생성", result.guideline)
             then(gitHubClient).shouldHaveNoInteractions()
             then(userAnalysisRequestRepository).should().save(any())
@@ -170,16 +133,14 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("캐시 MISS - 분석 결과가 없으면 GitHub API 호출 후 저장한다")
         fun `캐시 MISS시 GitHub API 호출`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(0L)
             given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
-            given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42))
-                .willReturn(mockIssueInfo)
+            given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(mockIssueInfo)
             given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
                 .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
             given(glmClient.selectFiles(any(), anyOrNull(), any()))
@@ -187,17 +148,11 @@ class ContextAnalyzerServiceImplTest {
             given(gitHubClient.fetchFileContent("spring-projects", "spring-boot", "src/main/kotlin/com/example/UserService.kt"))
                 .willReturn("fun userService() { ... }")
             given(glmClient.analyze(any(), anyOrNull(), any(), any()))
-                .willReturn(GlmAnalysisRes(
-                    guideline = "가이드라인",
-                    pseudoCode = "의사코드",
-                    sideEffects = "부작용"
-                ))
+                .willReturn(GlmAnalysisRes(guideline = "가이드라인", pseudoCode = "의사코드", sideEffects = "부작용"))
             given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
 
-            // when
             val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
 
-            // then
             assertNotNull(result)
             then(gitHubClient).should().fetchIssue("spring-projects", "spring-boot", 42)
             then(gitHubClient).should().fetchTree("spring-projects", "spring-boot")
@@ -209,10 +164,8 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("이슈가 없으면 AnalysisException을 던진다")
         fun `이슈 없으면 예외 던짐`() {
-            // given
             given(issueRepository.findById(999L)).willReturn(Optional.empty())
 
-            // when & then
             assertThrows<AnalysisException> {
                 contextAnalyzerService.getGuide(999L, GITHUB_ID)
             }
@@ -221,11 +174,9 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("사용자가 없으면 AuthException을 던진다")
         fun `사용자 없으면 예외 던짐`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.empty())
 
-            // when & then
             assertThrows<AuthException> {
                 contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
             }
@@ -234,24 +185,89 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("일일 분석 요청 횟수 초과 시 AnalysisException을 던진다")
         fun `횟수 초과 시 예외 던짐`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(5L)
 
-            // when & then
             assertThrows<AnalysisException> {
                 contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
             }
         }
-    }
 
-    // ──────────────────────────────────────────
-    // getPseudoCode() 테스트
-    // ──────────────────────────────────────────
+        @Test
+        @DisplayName("repoFullName이 'owner/repo' 형식이 아니면 AnalysisException을 던진다")
+        fun `repoFullName 형식 오류시 예외`() {
+            val badIssue = Issue(
+                repoFullName = "invalid-format",
+                issueNumber = 42L,
+                title = "Fix NullPointerException",
+                content = "이슈 본문",
+                status = Issue.IssueStatus.OPEN
+            )
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(badIssue))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(0L)
+            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
+
+            assertThrows<AnalysisException> {
+                contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+            }
+            then(gitHubClient).shouldHaveNoInteractions()
+        }
+
+        @Test
+        @DisplayName("GLM이 빈 파일 목록을 반환하면 빈 맵으로 analyze()를 호출한다")
+        fun `GLM 빈 파일 목록 반환시 analyze 빈맵 호출`() {
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(0L)
+            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
+            given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(mockIssueInfo)
+            given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
+                .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
+            given(glmClient.selectFiles(any(), anyOrNull(), any())).willReturn(emptyList())
+            given(glmClient.analyze(any(), anyOrNull(), any(), eq(emptyMap())))
+                .willReturn(GlmAnalysisRes(guideline = "가이드", pseudoCode = "코드", sideEffects = "없음"))
+            given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
+
+            contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+
+            then(glmClient).should().analyze(any(), anyOrNull(), any(), eq(emptyMap()))
+        }
+
+        @Test
+        @DisplayName("GLM이 후보 목록에 없는 경로를 반환하면 필터링 후 빈 맵으로 analyze()를 호출한다")
+        fun `GLM 비후보 경로 반환시 필터링 후 analyze 빈맵 호출`() {
+            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
+                .willReturn(null)
+            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                .willReturn(0L)
+            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
+            given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(mockIssueInfo)
+            given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
+                .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
+            given(glmClient.selectFiles(any(), anyOrNull(), any()))
+                .willReturn(listOf("src/other/NotInCandidates.kt"))
+            given(glmClient.analyze(any(), anyOrNull(), any(), eq(emptyMap())))
+                .willReturn(GlmAnalysisRes(guideline = "가이드", pseudoCode = "코드", sideEffects = "없음"))
+            given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
+
+            contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+
+            then(glmClient).should().analyze(any(), anyOrNull(), any(), eq(emptyMap()))
+        }
+    }
 
     @Nested
     @DisplayName("getPseudoCode()")
@@ -260,17 +276,14 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("사용자 캐시 HIT - 동일 이슈에 재요청하면 GitHub API 호출 없이 즉시 반환한다")
         fun `사용자 캐시 HIT시 즉시 반환`() {
-            // given
             val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(completedRequest)
 
-            // when
             val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
-            // then
             assertNotNull(result)
             assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
             then(gitHubClient).shouldHaveNoInteractions()
@@ -279,19 +292,16 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("이슈 캐시 HIT - 다른 사용자의 분석 결과가 있으면 재사용하고 요청 이력을 저장한다")
         fun `이슈 캐시 HIT시 즉시 반환`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(0L)
             given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(mockAnalysisResult)
 
-            // when
             val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
-            // then
             assertNotNull(result)
             assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
             then(gitHubClient).shouldHaveNoInteractions()
@@ -301,10 +311,8 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("이슈가 없으면 AnalysisException을 던진다")
         fun `이슈 없으면 예외 던짐`() {
-            // given
             given(issueRepository.findById(999L)).willReturn(Optional.empty())
 
-            // when & then
             assertThrows<AnalysisException> {
                 contextAnalyzerService.getPseudoCode(999L, GITHUB_ID)
             }
@@ -313,11 +321,9 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("사용자가 없으면 AuthException을 던진다")
         fun `사용자 없으면 예외 던짐`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.empty())
 
-            // when & then
             assertThrows<AuthException> {
                 contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
             }
@@ -326,15 +332,13 @@ class ContextAnalyzerServiceImplTest {
         @Test
         @DisplayName("일일 분석 요청 횟수 초과 시 AnalysisException을 던진다")
         fun `횟수 초과 시 예외 던짐`() {
-            // given
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(USER_ID, ISSUE_ID))
+            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
                 .willReturn(null)
             given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
                 .willReturn(5L)
 
-            // when & then
             assertThrows<AnalysisException> {
                 contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
             }


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
현재 ContextAnalyzerServiceImpl 기본 테스트만 존재하는 상태라
핵심 로직에 대한 단위 테스트들을 추가했습니다.

## 🔗 관련 이슈
- Close #92

## 🛠️ 주요 변경 사항
**ContextAnalyzerServiceImplTest** 엣지 케이스 추가
- repoFullName 형식 오류 시 AnalysisException 발생 + GitHub API 미호출 검증
- GLM이 빈 파일 목록 반환 시 빈 맵으로 analyze() 호출 검증
- GLM이 후보 외 경로 반환 시 필터링 후 빈 맵으로 analyze() 호출 검증
- UserAnalysisRequest 도입에 따른 기존 테스트 전면 수정
  - userRepository, userAnalysisRequestRepository Mock 추가
  - 사용자 캐시 HIT / 이슈 캐시 HIT / 캐시 MISS 케이스 분리
  - 사용자 없음(AuthException), 횟수 초과(AnalysisException) 케이스 추가

**GlmClientImplTest** 신규 작성 (10개)
- ParseFileList: 정상 JSON / 마크다운 코드블록 / files 키 없음 / 깨진 JSON
- SelectFiles: null 반환 / RuntimeException 래핑
- Analyze: null / RuntimeException / 유효 JSON 성공 / 파싱 실패

**GitHubClientImplTest** 신규 작성 (11개, MockWebServer 기반)
- FetchTree: truncated=true 예외 / 정상(blob만 반환) / HTTP 오류 예외
- FetchFileContent: 404 null / 500 null / 정상 Base64 디코딩 / content null
- FetchIssue: 정상 / HTTP 오류 예외

**GitHubClientImpl** 프로덕션 코드 수정
- baseUrl을 `@Value("${github.api.base-url:https://api.github.com}")`로 외부화
- MockWebServer 테스트를 위한 주입 포인트 확보
- 기본값 유지로 프로덕션 동작에는 영향 없음

**build.gradle**
- MockWebServer 의존성 추가 (`com.squareup.okhttp3:mockwebserver:4.12.0`)
- GitHubClientImpl HTTP 응답을 실제 서버 없이 검증하기 위해 도입
- 
## 🧪 테스트 결과
총 24개 테스트 전체 통과
<img width="884" height="1062" alt="image" src="https://github.com/user-attachments/assets/bb344dfc-c078-4b45-b369-1a132635f8ab" />

## 🧐 리뷰어에게

MockWebServer 도입을 위해 GitHubClientImpl의 baseUrl을 하드코딩에서 `@Value`로 변경했습니다.

UserAnalysisRequest 도입(#86 머지)으로 서비스 구조가 변경되어 다시 수정했습니다.