### PR TITLE
[#99][FEAT] 추천 이슈 이력 조회 기능 추가

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/controller/IssueController.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.issue.controller
 
+import com.back.omos.domain.issue.dto.RecommendIssueHistoryRes
 import com.back.omos.domain.issue.dto.RecommendIssueRes
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
@@ -86,6 +87,7 @@ class IssueController(
      * <p>
      * 인증된 사용자의 GitHub ID를 기반으로 프로필 벡터를 조회하며,
      * 벡터 유사도 검색과 AI 분석(RAG)을 거쳐 최적의 이슈 3개를 선정해 반환합니다.
+     * 추천 결과는 이력으로 저장되어 [getRecommendationHistory]를 통해 재조회할 수 있습니다.
      *
      * @param principal 인증된 사용자의 세션 정보 ([OAuthPrincipal])
      * @return AI가 생성한 상세 추천 사유를 포함한 [RecommendIssueRes]
@@ -97,5 +99,23 @@ class IssueController(
     ): CommonResponse<List<RecommendIssueRes>> {
         val responses = recommendService.getPersonalizedRecommendation(principal.githubId)
         return CommonResponse.success(responses)
+    }
+
+    /**
+     * 사용자가 이전에 추천받은 이슈 목록을 반환합니다.
+     * <p>
+     * 서비스 재방문 시 기존 추천 이력을 확인할 수 있으며, 최근 추천 순으로 정렬됩니다.
+     * 동일 이슈가 재추천된 경우 가장 최근 추천 일시를 기준으로 정렬됩니다.
+     *
+     * @param principal 인증된 사용자의 세션 정보 ([OAuthPrincipal])
+     * @return 추천 이력 목록 (최근 추천 순), 이력이 없으면 빈 리스트 반환
+     * @author MintyU
+     * @since 2026-04-29
+     */
+    @GetMapping("/recommend/history")
+    fun getRecommendationHistory(
+        @AuthenticationPrincipal principal: OAuthPrincipal
+    ): CommonResponse<List<RecommendIssueHistoryRes>> {
+        return CommonResponse.success(recommendService.getUserRecommendationHistory(principal.githubId))
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/dto/RecommendIssueHistoryRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/dto/RecommendIssueHistoryRes.kt
@@ -1,0 +1,61 @@
+package com.back.omos.domain.issue.dto
+
+import com.back.omos.domain.analysis.entity.UserAnalysisRequest
+import com.back.omos.domain.issue.entity.UserRecommendedIssue
+
+/**
+ * 사용자의 이슈 추천 이력 응답 DTO입니다.
+ *
+ * [RecommendIssueRes]의 기본 필드에 분석 여부 정보를 추가로 포함합니다.
+ * [isAnalyzed]가 true인 경우 [analysisResultId]를 통해 분석 결과를 조회할 수 있습니다.
+ *
+ * @property id 이슈의 시스템 내부 식별자
+ * @property repoFullName 이슈가 속한 레포지토리의 전체 이름 (예: owner/repo)
+ * @property issueNumber 레포지토리 내에서의 이슈 번호
+ * @property title 이슈 제목
+ * @property summary AI가 생성한 추천 사유
+ * @property score 추천 점수 (0.0 ~ 1.0)
+ * @property labels 이슈에 부여된 라벨 목록
+ * @property status 이슈 상태 (OPEN/CLOSED)
+ * @property isAnalyzed 해당 이슈에 대해 사용자가 분석을 완료했는지 여부
+ * @property analysisResultId 완료된 분석 결과의 식별자, [isAnalyzed]가 false이면 null
+ *
+ * @author MintyU
+ * @since 2026-04-29
+ */
+data class RecommendIssueHistoryRes(
+    val id: Long,
+    val repoFullName: String,
+    val issueNumber: Long,
+    val title: String,
+    val summary: String,
+    val score: Float,
+    val labels: List<String>?,
+    val status: String,
+    val isAnalyzed: Boolean,
+    val analysisResultId: Long?
+) {
+    companion object {
+
+        /**
+         * [UserRecommendedIssue]와 해당 이슈의 분석 요청 정보로 DTO를 생성합니다.
+         *
+         * @param recommended 추천 이력 엔티티
+         * @param analysisRequest 해당 이슈에 대한 사용자의 분석 요청, 없으면 null
+         */
+        fun from(recommended: UserRecommendedIssue, analysisRequest: UserAnalysisRequest?): RecommendIssueHistoryRes {
+            return RecommendIssueHistoryRes(
+                id = recommended.issue.id ?: 0L,
+                repoFullName = recommended.issue.repoFullName,
+                issueNumber = recommended.issue.issueNumber,
+                title = recommended.issue.title,
+                summary = recommended.summary ?: "요약 정보 없음",
+                score = 0.0f,
+                labels = recommended.issue.labels,
+                status = recommended.issue.status.name,
+                isAnalyzed = analysisRequest != null,
+                analysisResultId = analysisRequest?.analysisResult?.id
+            )
+        }
+    }
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/entity/UserRecommendedIssue.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/entity/UserRecommendedIssue.kt
@@ -1,0 +1,63 @@
+package com.back.omos.domain.issue.entity
+
+import com.back.omos.domain.user.entity.User
+import com.back.omos.global.jpa.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+/**
+ * 사용자에게 추천된 이슈 이력을 저장하는 엔티티입니다.
+ *
+ * 사용자가 추천을 받을 때마다 추천된 이슈와 AI가 생성한 추천 사유를 기록합니다.
+ * 동일 사용자-이슈 조합은 유니크 제약으로 하나의 레코드만 유지되며,
+ * 재추천 시에는 [summary]가 최신 내용으로 갱신됩니다.
+ * [BaseEntity.updatedAt]이 자동 갱신되므로 가장 최근 추천 순으로 정렬할 수 있습니다.
+ *
+ * [BaseEntity]를 상속받아 다음 필드들을 자동으로 관리합니다:
+ * - `id`: 시스템 내부 식별자 (Long, PK)
+ * - `createdAt`: 최초 추천 일시
+ * - `updatedAt`: 마지막 추천 일시 (재추천 시 갱신)
+ *
+ * @author MintyU
+ * @since 2026-04-29
+ * @see Issue
+ * @see User
+ */
+@Entity
+@Table(
+    name = "user_recommended_issues",
+    uniqueConstraints = [UniqueConstraint(
+        name = "uk_user_recommended_issue_user_issue",
+        columnNames = ["user_id", "issue_id"]
+    )]
+)
+class UserRecommendedIssue(
+
+    /**
+     * 추천을 받은 사용자입니다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    /**
+     * 추천된 이슈입니다.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id", nullable = false)
+    val issue: Issue,
+
+    /**
+     * AI가 생성한 이슈 추천 사유입니다.
+     *
+     * 재추천 시 최신 사유로 갱신됩니다.
+     */
+    @Column(columnDefinition = "TEXT")
+    var summary: String? = null
+
+) : BaseEntity()

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/repository/UserRecommendedIssueRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/repository/UserRecommendedIssueRepository.kt
@@ -1,0 +1,38 @@
+package com.back.omos.domain.issue.repository
+
+import com.back.omos.domain.issue.entity.UserRecommendedIssue
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * [UserRecommendedIssue] 엔티티에 대한 데이터 액세스 인터페이스입니다.
+ *
+ * 기본적인 CRUD 연산은 [JpaRepository]에서 제공하며,
+ * 추천 이력 조회 및 upsert를 위한 배치 조회 메서드를 추가로 정의합니다.
+ *
+ * @author MintyU
+ * @since 2026-04-29
+ */
+interface UserRecommendedIssueRepository : JpaRepository<UserRecommendedIssue, Long> {
+
+    /**
+     * 특정 사용자의 추천 이력을 최근 추천 순으로 조회합니다.
+     *
+     * [UserRecommendedIssue.updatedAt]을 기준으로 내림차순 정렬하므로
+     * 재추천된 이슈는 갱신된 일시 기준으로 상위에 노출됩니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @return 해당 사용자의 전체 추천 이력 (최근 추천 순)
+     */
+    fun findAllByUserIdOrderByUpdatedAtDesc(userId: Long): List<UserRecommendedIssue>
+
+    /**
+     * 특정 사용자의 추천 이력 중 지정한 이슈 ID 목록에 해당하는 레코드를 조회합니다.
+     *
+     * 추천 결과 저장 시 기존 레코드 유무를 한 번의 쿼리로 확인하기 위해 사용됩니다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param issueIds 조회 대상 이슈 ID 목록
+     * @return 해당 이슈들에 대한 기존 추천 이력 목록
+     */
+    fun findAllByUserIdAndIssueIdIn(userId: Long, issueIds: List<Long>): List<UserRecommendedIssue>
+}

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendService.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendService.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.issue.service
 
+import com.back.omos.domain.issue.dto.RecommendIssueHistoryRes
 import com.back.omos.domain.issue.dto.RecommendIssueRes
 
 /**
@@ -21,8 +22,23 @@ interface RecommendService {
      * 2. 검색된 이슈 후보들과 유저 스택 정보를 조합한 컨텍스트 구성 (Augmentation)
      * 3. AI 모델(GLM)을 통한 최종 선정 및 맞춤형 추천 사유 생성 (Generation)
      *
+     * 추천 결과는 [getUserRecommendationHistory]를 통해 이후에도 조회할 수 있도록 저장됩니다.
+     * 동일 이슈가 재추천된 경우 기존 레코드의 추천 사유를 최신 내용으로 갱신합니다.
+     *
      * @param githubId 추천을 진행할 사용자의 GitHub 고유 식별자
      * @return AI가 선정한 최적의 이슈 정보와 상세 추천 사유를 포함한 List<RecommendIssueRes>
      */
     fun getPersonalizedRecommendation(githubId: String): List<RecommendIssueRes>
+
+    /**
+     * 사용자가 이전에 추천받은 이슈 목록을 최근 추천 순으로 반환합니다.
+     *
+     * 서비스 재방문 시 기존 추천 이력을 다시 확인할 수 있도록 제공됩니다.
+     *
+     * @param githubId 조회할 사용자의 GitHub 고유 식별자
+     * @return 추천 이력 목록 (최근 추천 순), 이력이 없으면 빈 리스트 반환
+     * @author MintyU
+     * @since 2026-04-29
+     */
+    fun getUserRecommendationHistory(githubId: String): List<RecommendIssueHistoryRes>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
@@ -1,8 +1,14 @@
 package com.back.omos.domain.issue.service
 
+import com.back.omos.domain.analysis.repository.UserAnalysisRequestRepository
 import com.back.omos.domain.issue.ai.IssueGlmClient
+import com.back.omos.domain.issue.dto.RecommendIssueHistoryRes
 import com.back.omos.domain.issue.dto.RecommendIssueRes
+import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.domain.issue.entity.UserRecommendedIssue
 import com.back.omos.domain.issue.repository.IssueRepository
+import com.back.omos.domain.issue.repository.UserRecommendedIssueRepository
+import com.back.omos.domain.user.entity.User
 import com.back.omos.domain.user.repository.UserRepository
 import com.back.omos.global.exception.errorCode.AuthErrorCode
 import com.back.omos.global.exception.errorCode.IssueErrorCode
@@ -21,10 +27,12 @@ import org.springframework.transaction.annotation.Transactional
 class RecommendServiceImpl(
     private val issueRepository: IssueRepository,
     private val userRepository: UserRepository,
-    private val issueGlmClient: IssueGlmClient
+    private val issueGlmClient: IssueGlmClient,
+    private val userRecommendedIssueRepository: UserRecommendedIssueRepository,
+    private val userAnalysisRequestRepository: UserAnalysisRequestRepository
 ) : RecommendService {
 
-    @Transactional(readOnly = true)
+    @Transactional
     override fun getPersonalizedRecommendation(githubId: String): List<RecommendIssueRes> {
 
         // 1. 유저 조회
@@ -52,22 +60,72 @@ class RecommendServiceImpl(
             candidateIssues = topIssues
         )
 
-        // 6. 결과 반환
-        return aiRecommendationReasons.mapNotNull { aiResult ->
-            // 제목과 레포지토리 이름이 모두 일치하는 이슈를 찾음
+        // 6. AI 결과와 이슈 매칭
+        val recommendations = aiRecommendationReasons.mapNotNull { aiResult ->
             val matchedIssue = topIssues.find {
                 it.title == aiResult.title && it.repoFullName == aiResult.repoName
-            }
+            } ?: return@mapNotNull null
 
-            // 매칭되는 이슈를 못 찾으면 null처리
-            if (matchedIssue == null) {
-                return@mapNotNull null
-            }
+            matchedIssue to aiResult.reason
+        }
 
-            // DTO로 변환
-            RecommendIssueRes.from(matchedIssue).copy(
-                summary = aiResult.reason
-            )
+        // 7. 추천 이력 저장 (upsert)
+        saveRecommendationHistory(user, recommendations)
+
+        // 8. 결과 반환
+        return recommendations.map { (issue, reason) ->
+            RecommendIssueRes.from(issue).copy(summary = reason)
+        }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getUserRecommendationHistory(githubId: String): List<RecommendIssueHistoryRes> {
+        val user = userRepository.findByGithubId(githubId)
+            .orElseThrow { AuthException(AuthErrorCode.USER_NOT_FOUND, "GitHub ID [$githubId]에 해당하는 유저를 찾을 수 없습니다.") }
+
+        val history = userRecommendedIssueRepository.findAllByUserIdOrderByUpdatedAtDesc(user.id!!)
+
+        if (history.isEmpty()) return emptyList()
+
+        // 추천 이력의 이슈 ID 목록으로 분석 완료 여부를 한 번에 조회
+        val issueIds = history.mapNotNull { it.issue.id }
+        val analyzedMap = userAnalysisRequestRepository
+            .findAllByUserIdAndAnalysisResultIssueIdIn(user.id!!, issueIds)
+            .associateBy { it.analysisResult!!.issue.id!! }
+
+        return history.map { recommended ->
+            val analysisRequest = recommended.issue.id?.let { analyzedMap[it] }
+            RecommendIssueHistoryRes.from(recommended, analysisRequest)
+        }.sortedByDescending { it.isAnalyzed }
+    }
+
+    /**
+     * 추천 결과를 이력으로 저장합니다. 이미 추천된 이슈는 요약을 최신 내용으로 갱신합니다.
+     *
+     * 기존 레코드를 한 번의 IN 쿼리로 일괄 조회한 뒤 메모리에서 upsert를 처리하여
+     * N+1 문제를 방지합니다.
+     *
+     * @param user 추천을 받은 사용자
+     * @param recommendations 추천된 이슈와 AI 생성 사유의 쌍 목록
+     * @author MintyU
+     * @since 2026-04-29
+     */
+    private fun saveRecommendationHistory(user: User, recommendations: List<Pair<Issue, String>>) {
+        val userId = user.id ?: return
+        val issueIds = recommendations.mapNotNull { (issue, _) -> issue.id }
+
+        val existingMap = userRecommendedIssueRepository
+            .findAllByUserIdAndIssueIdIn(userId, issueIds)
+            .associateBy { it.issue.id!! }
+
+        recommendations.forEach { (issue, summary) ->
+            val issueId = issue.id ?: return@forEach
+            val existing = existingMap[issueId]
+            if (existing != null) {
+                existing.summary = summary
+            } else {
+                userRecommendedIssueRepository.save(UserRecommendedIssue(user = user, issue = issue, summary = summary))
+            }
         }
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/service/RecommendServiceImpl.kt
@@ -112,13 +112,14 @@ class RecommendServiceImpl(
      */
     private fun saveRecommendationHistory(user: User, recommendations: List<Pair<Issue, String>>) {
         val userId = user.id ?: return
-        val issueIds = recommendations.mapNotNull { (issue, _) -> issue.id }
+        val deduped = recommendations.distinctBy { (issue, _) -> issue.id }
+        val issueIds = deduped.mapNotNull { (issue, _) -> issue.id }
 
         val existingMap = userRecommendedIssueRepository
             .findAllByUserIdAndIssueIdIn(userId, issueIds)
             .associateBy { it.issue.id!! }
 
-        recommendations.forEach { (issue, summary) ->
+        deduped.forEach { (issue, summary) ->
             val issueId = issue.id ?: return@forEach
             val existing = existingMap[issueId]
             if (existing != null) {


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
추천 받았던 이슈들의 이력을 조회할 수 있도록 변경했습니다.

## 🔗 관련 이슈
- Close #99 

## 🛠️ 주요 변경 사항
- [ ] 사용자가 추천 받았던 이슈들의 목록을 따로 저장할 수 있도록 구현했습니다.
- [ ] 이슈 목록을 다시 불러올 수 있도록 구현했습니다.
- [ ] 해당 이슈가 분석이 완료된 이슈인지 확인할 수 있도록 필드를 추가했습니다.
