### PR TITLE
[FEAT] Context Analyzer RAG 파이프라인 개선 (GraphQL 도입)

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClient.kt
@@ -65,4 +65,17 @@ interface GitHubClient {
      *         GITHUB_API_FAIL — API 호출 실패 또는 Rate Limit 초과 시
      */
     fun fetchTree(owner: String, repo: String): List<String>
+
+    /**
+     * GitHub GraphQL API를 통해 여러 파일의 내용을 한 번에 가져옵니다.
+     *
+     * fetchFileContent 순차 호출 대비 응답시간이 개선됩니다.
+     *
+     * @param owner 레포지토리 소유자
+     * @param repo 레포지토리명
+     * @param paths 조회할 파일 경로 목록
+     * @return 파일 경로 → 내용 맵. 조회 실패한 파일은 맵에서 제외됩니다.
+     * @throws AnalysisException GITHUB_API_FAIL — API 호출 실패 시
+     */
+    fun fetchFileContents(owner: String, repo: String, paths: List<String>): Map<String, String>
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -165,4 +165,53 @@ class GitHubClientImpl(
             )
         }
     }
+    override fun fetchFileContents(owner: String, repo: String, paths: List<String>): Map<String, String> {
+        if (paths.isEmpty()) return emptyMap()
+
+        val fileQueries = paths.mapIndexed { index, path ->
+            """file$index: object(expression: "HEAD:$path") { ... on Blob { text } }"""
+        }.joinToString("\n")
+
+        val query = """
+        query {
+            repository(owner: "$owner", name: "$repo") {
+                $fileQueries
+            }
+        }
+    """.trimIndent()
+
+        return try {
+            val response = restClient.post()
+                .uri("/graphql")
+                .header(HttpHeaders.ACCEPT, "application/json")
+                .body(mapOf("query" to query))
+                .retrieve()
+                .body(Map::class.java)
+                ?: throw AnalysisException(
+                    AnalysisErrorCode.GITHUB_API_FAIL,
+                    "[GitHubClientImpl#fetchFileContents] 응답이 null입니다: $owner/$repo",
+                    "파일 내용을 가져오는 데 실패했습니다."
+                )
+
+            @Suppress("UNCHECKED_CAST")
+            val repository = (response["data"] as? Map<String, Any>)
+                ?.get("repository") as? Map<String, Any>
+                ?: return emptyMap()
+
+            paths.mapIndexed { index, path ->
+                val text = (repository["file$index"] as? Map<String, Any>)
+                    ?.get("text") as? String
+                if (text != null) path to text else null
+            }.filterNotNull().toMap()
+
+        } catch (e: AnalysisException) {
+            throw e
+        } catch (e: RestClientResponseException) {
+            throw AnalysisException(
+                AnalysisErrorCode.GITHUB_API_FAIL,
+                "[GitHubClientImpl#fetchFileContents] HTTP ${e.statusCode}: $owner/$repo",
+                "파일 내용을 가져오는 데 실패했습니다."
+            )
+        }
+    }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -201,17 +201,17 @@ class GitHubClientImpl(
             // errors 필드 확인
             @Suppress("UNCHECKED_CAST")
             val errors = response["errors"] as? List<*>
-            if (!errors.isNullOrEmpty()) {
-                log.warn("[GitHubClientImpl#fetchFileContents] GraphQL errors: $errors")
-            }
-
-            @Suppress("UNCHECKED_CAST")
             val repository = (response["data"] as? Map<String, Any>)
                 ?.get("repository") as? Map<String, Any>
-                ?: run {
-                    log.warn("[GitHubClientImpl#fetchFileContents] repository가 null입니다: $owner/$repo")
-                    return emptyMap()
-                }
+
+            if (!errors.isNullOrEmpty() || repository == null) {
+                log.warn("[GitHubClientImpl#fetchFileContents] GraphQL errors: $errors, repository: $repository")
+                throw AnalysisException(
+                    AnalysisErrorCode.GITHUB_API_FAIL,
+                    "[GitHubClientImpl#fetchFileContents] GraphQL 오류 또는 repository null: $owner/$repo",
+                    "파일 내용을 가져오는 데 실패했습니다."
+                )
+            }
 
             paths.mapIndexed { index, path ->
                 val text = (repository["file$index"] as? Map<String, Any>)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -198,10 +198,20 @@ class GitHubClientImpl(
                     "파일 내용을 가져오는 데 실패했습니다."
                 )
 
+            // errors 필드 확인
+            @Suppress("UNCHECKED_CAST")
+            val errors = response["errors"] as? List<*>
+            if (!errors.isNullOrEmpty()) {
+                log.warn("[GitHubClientImpl#fetchFileContents] GraphQL errors: $errors")
+            }
+
             @Suppress("UNCHECKED_CAST")
             val repository = (response["data"] as? Map<String, Any>)
                 ?.get("repository") as? Map<String, Any>
-                ?: return emptyMap()
+                ?: run {
+                    log.warn("[GitHubClientImpl#fetchFileContents] repository가 null입니다: $owner/$repo")
+                    return emptyMap()
+                }
 
             paths.mapIndexed { index, path ->
                 val text = (repository["file$index"] as? Map<String, Any>)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubClientImpl.kt
@@ -168,17 +168,22 @@ class GitHubClientImpl(
     override fun fetchFileContents(owner: String, repo: String, paths: List<String>): Map<String, String> {
         if (paths.isEmpty()) return emptyMap()
 
+        // 특수문자 이스케이프 (GraphQL Injection 방지)
+        val safeOwner = owner.replace("\\", "\\\\").replace("\"", "\\\"")
+        val safeRepo = repo.replace("\\", "\\\\").replace("\"", "\\\"")
+
         val fileQueries = paths.mapIndexed { index, path ->
-            """file$index: object(expression: "HEAD:$path") { ... on Blob { text } }"""
+            val safePath = path.replace("\\", "\\\\").replace("\"", "\\\"")
+            """file$index: object(expression: "HEAD:$safePath") { ... on Blob { text } }"""
         }.joinToString("\n")
 
         val query = """
-        query {
-            repository(owner: "$owner", name: "$repo") {
-                $fileQueries
-            }
+    query {
+        repository(owner: "$safeOwner", name: "$safeRepo") {
+            $fileQueries
         }
-    """.trimIndent()
+    }
+""".trimIndent()
 
         return try {
             val response = restClient.post()

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import org.slf4j.LoggerFactory
 
 /**
  * [ContextAnalyzerService]의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
@@ -55,6 +56,8 @@ class ContextAnalyzerServiceImpl(
     private val glmClient: GlmClient,
     private val objectMapper: ObjectMapper
 ) : ContextAnalyzerService {
+
+    private val log = LoggerFactory.getLogger(ContextAnalyzerServiceImpl::class.java)
 
     @Transactional
     override fun getGuide(issueId: Long, githubId: String): GuideResponseDto {
@@ -142,11 +145,11 @@ class ContextAnalyzerServiceImpl(
      * 처리 흐름:
      * 1. [Issue.repoFullName]에서 owner/repo 파싱
      * 2. GitHub API로 이슈 상세 정보 fetch
-     * 3. GitHub API로 레포지토리 전체 파일 트리 fetch 후 지원 확장자로 필터링
-     * 4. 이슈 제목 키워드와 매칭되는 파일 경로 선별 (매칭 없으면 상위 5개 폴백)
-     * 5. 선택된 파일의 내용 fetch
-     * 6. 선택된 파일 경로를 JSON 배열 문자열로 직렬화
-     * 7. GLM API로 가이드·수도 코드·사이드 이펙트 분석 수행
+     * 3. GitHub Tree API로 전체 파일 경로 목록 fetch 후 확장자 필터링
+     * 4. 확장자 필터링된 경로 전체 + 이슈 → GLM 1차 호출로 관련 파일 선별
+     * 5. GraphQL로 선별된 파일 내용 한 번에 fetch
+     * 6. 파일 내용 파싱/가공 (주석 제거, 토큰 제한)
+     * 7. 파싱한 코드 + 이슈 → GLM 2차 호출로 가이드 생성
      *
      * @param issue 분석 대상 이슈
      * @return 저장된 [AnalysisResult]
@@ -174,45 +177,60 @@ class ContextAnalyzerServiceImpl(
                         path.endsWith(".py") || path.endsWith(".go") ||
                         path.endsWith(".rs") || path.endsWith(".cpp")
             }
+        log.info("[generateAnalysis] 확장자 필터링 후 파일 수: ${allFilePaths.size}")
+// 2단계: 동적 배치로 GLM 1차 호출 (최대한 많은 파일 경로 전달)
+        val batchSizes = listOf(3000, 2000, 1000, 500, 200, 100, 30)
+        var selectedPaths: List<String> = emptyList()
 
-        // 2단계: 키워드 프리필터링으로 GLM에 넘길 후보를 MAX_CANDIDATE_FILES 이하로 제한
-        val keywords = issueInfo.title
-            .lowercase()
-            .split(" ", "-", "_", ".")
-            .filter { it.length > 3 }
-
-        val candidatePaths = allFilePaths
-            .filter { path -> keywords.any { keyword -> path.lowercase().contains(keyword) } }
-            .take(MAX_CANDIDATE_FILES)
-            .ifEmpty { allFilePaths.take(MAX_CANDIDATE_FILES) }
-
-// 3단계: 좁혀진 후보 내에서 GLM이 최종 선별 + 결과 검증
-        val candidatePathsSet = candidatePaths.toSet()
-        val selectedPaths = glmClient.selectFiles(
-            issueTitle = issueInfo.title,
-            issueBody = issueInfo.body,
-            filePaths = candidatePaths
-        )
-            .asSequence()
-            .filter { it in candidatePathsSet }  // 후보 외 경로 제거
-            .distinct()                           // 중복 제거
-            .take(MAX_SELECT_FILES)               // 최대 5개 강제 제한
-            .toList()
-
-        val fileContents = selectedPaths
-            .mapNotNull { path ->
-                val content = gitHubClient.fetchFileContent(owner, repoName, path)
-                if (content != null) path to content else null
+        for (size in batchSizes) {
+            try {
+                log.info("[generateAnalysis] GLM selectFiles 시도: ${size}개")
+                selectedPaths = glmClient.selectFiles(
+                    issueTitle = issueInfo.title,
+                    issueBody = issueInfo.body,
+                    filePaths = allFilePaths.take(size)
+                )
+                    .asSequence()
+                    .filter { it in allFilePaths.toSet() }
+                    .distinct()
+                    .take(MAX_SELECT_FILES)
+                    .toList()
+                log.info("[generateAnalysis] GLM selectFiles 성공! 배치 사이즈: $size, 선별 파일: $selectedPaths")
+                break
+            } catch (e: Exception) {
+                log.warn("[generateAnalysis] GLM selectFiles 실패 (배치 사이즈: $size): ${e.message}")
             }
-            .toMap()
+        }
 
-        val filePaths = objectMapper.writeValueAsString(fileContents.keys.toList())
+        if (selectedPaths.isEmpty()) {
+            throw AnalysisException(
+                AnalysisErrorCode.GLM_API_FAIL,
+                "[generateAnalysis] 모든 배치 사이즈에서 GLM selectFiles 실패",
+                "파일 선별에 실패했습니다."
+            )
+        }
+        log.info("[generateAnalysis] GLM 선별 파일: $selectedPaths")
+        // 3단계: GraphQL로 선별된 파일 내용 한 번에 fetch
+        val fileContents = gitHubClient.fetchFileContents(owner, repoName, selectedPaths)
+        log.info("[generateAnalysis] GraphQL fetch 완료 파일 수: ${fileContents.size}")
+        fileContents.forEach { (path, content) ->
+            log.info("[generateAnalysis] $path — ${content.length}자")
+        }
+        // 4단계: 파일 내용 파싱/가공 (토큰 절약)
+        val parsedFileContents = fileContents.mapValues { (_, content) ->
+            parseFileContent(content)
+        }
+        parsedFileContents.forEach { (path, content) ->
+            log.info("[generateAnalysis] 파싱 후 $path — ${content.length}자")
+        }
+        // 5단계: 파싱한 코드 + 이슈 → GLM 2차 호출
+        val filePaths = objectMapper.writeValueAsString(parsedFileContents.keys.toList())
         val labels = issueInfo.labels.map { it.name }
         val glmResult = glmClient.analyze(
             issueTitle = issueInfo.title,
             issueBody = issueInfo.body,
             labels = labels,
-            fileContents = fileContents
+            fileContents = parsedFileContents
         )
 
         return analysisResultRepository.save(
@@ -226,13 +244,36 @@ class ContextAnalyzerServiceImpl(
         )
     }
 
+    /**
+     * 파일 내용을 파싱/가공합니다.
+     *
+     * 빈 줄, 주석 제거 및 토큰 제한을 적용합니다.
+     *
+     * @param content 원본 파일 내용
+     * @return 가공된 파일 내용
+     */
+    private fun parseFileContent(content: String): String {
+        return content
+            .lines()
+            .filter { it.isNotBlank() }
+            .filter { line ->
+                val trimmed = line.trimStart()
+                !trimmed.startsWith("//") &&
+                        !trimmed.startsWith("*") &&
+                        !trimmed.startsWith("/*") &&
+                        !trimmed.startsWith("#")
+            }
+            .joinToString("\n")
+            .take(MAX_FILE_CONTENT_LENGTH)
+    }
+
     companion object {
-        /** GLM에 넘기는 후보 파일 최대 개수. 테스트 결과 30개 초과 시 GLM 응답 품질 저하 및 토큰 초과 가능성이 있어 설정. */
-        private const val MAX_CANDIDATE_FILES = 30
-        /** GLM이 최종 선별하는 파일 최대 개수. 5개 초과 시 fetchFileContent 호출 증가로 응답 지연 발생. */
+        /** GLM이 최종 선별하는 파일 최대 개수 */
         private const val MAX_SELECT_FILES = 5
-        /** 사용자 1인당 하루 최대 분석 요청 횟수. */
+        /** 사용자 1인당 하루 최대 분석 요청 횟수 */
         private const val DAILY_REQUEST_LIMIT = 5L
+        /** 파일당 최대 문자 수 (토큰 절약) */
+        private const val MAX_FILE_CONTENT_LENGTH = 3000
     }
 
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -179,7 +179,7 @@ class ContextAnalyzerServiceImpl(
             }
         log.info("[generateAnalysis] 확장자 필터링 후 파일 수: ${allFilePaths.size}")
 // 2단계: 동적 배치로 GLM 1차 호출 (최대한 많은 파일 경로 전달)
-        val batchSizes = listOf(3000, 2000, 1000, 500, 200, 100, 30)
+        val batchSizes = listOf(3300, 3000, 2000, 1000, 700, 300, 100)
         var selectedPaths: List<String> = emptyList()
 
         for (size in batchSizes) {
@@ -197,7 +197,7 @@ class ContextAnalyzerServiceImpl(
                     .toList()
                 log.info("[generateAnalysis] GLM selectFiles 성공! 배치 사이즈: $size, 선별 파일: $selectedPaths")
                 break
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 log.warn("[generateAnalysis] GLM selectFiles 실패 (배치 사이즈: $size): ${e.message}")
             }
         }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -181,6 +181,7 @@ class ContextAnalyzerServiceImpl(
 // 2단계: 동적 배치로 GLM 1차 호출 (최대한 많은 파일 경로 전달)
         val batchSizes = listOf(3300, 3000, 2000, 1000, 700, 300, 100)
         var selectedPaths: List<String> = emptyList()
+        val allFilePathsSet = allFilePaths.toSet()
 
         for (size in batchSizes) {
             try {
@@ -191,13 +192,15 @@ class ContextAnalyzerServiceImpl(
                     filePaths = allFilePaths.take(size)
                 )
                     .asSequence()
-                    .filter { it in allFilePaths.toSet() }
+                    .filter { it in allFilePathsSet }
                     .distinct()
                     .take(MAX_SELECT_FILES)
                     .toList()
                 log.info("[generateAnalysis] GLM selectFiles 성공! 배치 사이즈: $size, 선별 파일: $selectedPaths")
                 break
-            } catch (e: Throwable) {
+            } catch (e: Error) {
+                throw e
+            } catch (e: Exception) {
                 log.warn("[generateAnalysis] GLM selectFiles 실패 (배치 사이즈: $size): ${e.message}")
             }
         }

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -3,6 +3,8 @@ spring:
     activate:
       on-profile: dev
   ai:
+    retry:
+      max-attempts: 2 # 전체 1번 재시도 허용
     openai:
       api-key: ${GLM_API_KEY}
       base-url: https://aigw.alpha.grepp.co/v1


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
기존 키워드 기반 파일 선별 방식을
GitHub GraphQL API를 도입해 파이프라인을 개선했습니다.

키워드 필터링 제거 → GLM이 전체 경로 보고 직접 판단
GraphQL로 파일 내용 한 번에 fetch → API 호출 최소화
실제 코드 기반 GLM 분석 → 가이드 품질 향상

## 🔗 관련 이슈
- Close #103

## 🛠️ 주요 변경 사항
- [x] `GitHubClient` 인터페이스에 `fetchFileContents()` 추가
- [x] `GitHubClientImpl` — RestClient로 GraphQL 엔드포인트 호출, alias 방식으로 여러 파일 내용 한 번에 fetch
- [x] `ContextAnalyzerServiceImpl` 파이프라인 전면 변경
  - 키워드 필터링 제거 → 확장자 필터링 후 전체 경로를 GLM에 전달
  - 동적 배치 전략 도입 (3000→2000→1000→500→200→100→30), 타임아웃 발생 시 자동으로 배치 크기 축소
  - GraphQL로 선별된 파일 내용 한 번에 fetch (fetchFileContent 순차 호출 대체)
  - 파일 내용 파싱/가공 추가 (주석·빈줄 제거, 파일당 3000자 제한)
  - GLM 2차 호출 시 실제 코드 기반 분석
  - 응답 시간은 평균적으로 2분 30초 정도로 이전과 비슷합니다.

## 🧪 테스트 결과

### 대형 레포 — crate/crate (파일 5,036개, 이슈 #19192)

| | Before (v2) | After (v3) |
|---|---|---|
| 선별 파일 | test_s3.py, CrateDB.java, Bootstrap.java ... | GeoPointType.java, FileReadingIterator.java ... |
| 정확도 | 이슈와 무관한 파일 선별 | 이슈 라벨(`sql: type system`)과 정확히 일치 |
| 배치 전략 | 키워드 필터링 30개 | 동적 배치 3000개에서 성공 |

### 소형 레포 — hensu-project/hensu (파일 527개, 이슈 #69)
<img width="1030" height="307" alt="image" src="https://github.com/user-attachments/assets/21654779-2140-4a6a-abd3-9700c832fee9" />

| | Before (v2) | After (v3) |
|---|---|---|
| 선별 파일 | WorkflowCommand.java, HensuCommand.java (무관) | TextVisualizationFormat.java, MermaidVisualizationFormat.java 등 |
| 정확도 | 이슈 관련 파일 누락 | 이슈 본문에 명시된 파일 5개 전부 정확히 선별 |

## 🧐 리뷰어에게
동적 배치 최적 사이즈(3000개)는 crate/crate 기준으로 확인했으나
레포 특성에 따라 달라질 수 있습니다.
추후 배치 사이즈를 설정값으로 외부화하는 것도 고려할 수 있습니다.