### PR TITLE
[#101][FEAT] langfuse 도입

### DIFF
--- a/omos/docker-compose.yml
+++ b/omos/docker-compose.yml
@@ -1,15 +1,31 @@
 services:
+  langfuse-db:
+    image: postgres:16
+    container_name: omos-langfuse-db
+    restart: always
+    environment:
+      POSTGRES_DB: langfuse
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - ./data/langfuse-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d langfuse"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   langfuse:
     image: langfuse/langfuse:2
     container_name: omos-langfuse
     restart: always
     depends_on:
-      db:
+      langfuse-db:
         condition: service_healthy
     ports:
       - "3001:3000"
     environment:
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@langfuse-db:5432/langfuse
       NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET}
       SALT: ${LANGFUSE_SALT}
       NEXTAUTH_URL: http://localhost:3001

--- a/omos/docker-compose.yml
+++ b/omos/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  langfuse:
+    image: langfuse/langfuse:2
+    container_name: omos-langfuse
+    restart: always
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "3001:3000"
+    environment:
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET}
+      SALT: ${LANGFUSE_SALT}
+      NEXTAUTH_URL: http://localhost:3001
+      TELEMETRY_ENABLED: "false"
+
   db:
     image: pgvector/pgvector:pg16
     container_name: omos-db

--- a/omos/docs/langfuse.md
+++ b/omos/docs/langfuse.md
@@ -1,0 +1,47 @@
+# Langfuse 설정 가이드
+
+PR 초안 생성 AI 호출의 응답시간·토큰 사용량·품질 점수를 추적하기 위해 Langfuse를 사용합니다.
+
+## 로컬 실행
+
+```bash
+docker-compose up -d
+```
+
+Langfuse UI: http://localhost:3001
+
+> `DB_USER`, `DB_PASSWORD`는 기존 앱 DB와 공유합니다.  
+> `LANGFUSE_NEXTAUTH_SECRET`, `LANGFUSE_SALT`는 아무 랜덤 문자열이면 됩니다. (`openssl rand -base64 32`로 생성 가능)
+
+## 키 발급
+
+1. http://localhost:3001 에서 회원가입 후 프로젝트 생성
+2. **Settings → API Keys → Create new API key**
+3. 발급된 키를 환경변수에 추가
+
+```env
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+# LANGFUSE_HOST는 기본값이 http://localhost:3001 이므로 로컬에선 생략 가능
+```
+
+키가 없어도 앱은 정상 동작합니다. 키가 없으면 AI 호출 기록만 건너뜁니다.
+
+## 추적 항목
+
+| 항목 | 설명 |
+|---|---|
+| `pr-draft-vN` | PR 초안 생성 — 응답시간, 토큰 수, 프롬프트/응답 원문 |
+| `pr-translate-vN` | 번역 — 응답시간, 토큰 수 |
+| `quality` score | LLM-as-judge가 채점한 0~10점 품질 점수 (PR 초안 생성에만 적용) |
+
+## 프롬프트 버전 관리
+
+프롬프트를 수정할 때 반드시 두 곳의 버전을 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
+
+| 파일 | 상수 |
+|---|---|
+| `PrDraftPromptBuilder.kt` | `PROMPT_VERSION` |
+| `SpringAiClient.kt` | `GENERATION_PR_DRAFT` |
+
+예: `v2` → `v3`으로 올릴 때 두 상수를 같이 변경합니다.

--- a/omos/docs/langfuse.md
+++ b/omos/docs/langfuse.md
@@ -1,6 +1,6 @@
 # Langfuse 설정 가이드
 
-PR 초안 생성 AI 호출의 응답시간·토큰 사용량·품질 점수를 추적하기 위해 Langfuse를 사용합니다.
+AI 호출의 응답시간·토큰 사용량·품질 점수를 추적하기 위해 Langfuse를 사용합니다.
 
 ## 로컬 실행
 
@@ -28,6 +28,8 @@ LANGFUSE_SECRET_KEY=sk-lf-...
 키가 없어도 앱은 정상 동작합니다. 키가 없으면 AI 호출 기록만 건너뜁니다.
 
 ## 추적 항목
+
+아래는 현재 PR 파트 기준입니다. 각 파트에서 연동하면 항목이 추가됩니다.
 
 | 항목 | 설명 |
 |---|---|
@@ -107,11 +109,17 @@ if (traceId != null) {
 
 ## 프롬프트 버전 관리
 
-프롬프트를 수정할 때 반드시 두 곳의 버전을 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
+프롬프트를 수정할 때 `GENERATION_NAME` 상수의 버전을 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
 
-| 파일 | 상수 |
-|---|---|
-| `PrDraftPromptBuilder.kt` | `PROMPT_VERSION` |
-| `SpringAiClient.kt` | `GENERATION_PR_DRAFT` |
+**네이밍 컨벤션:** `{기능명}-v{N}`
 
-예: `v2` → `v3`으로 올릴 때 두 상수를 같이 변경합니다.
+PR 파트의 경우 `SpringAiClient.kt`에서 이렇게 관리합니다:
+
+```kotlin
+companion object {
+    private const val GENERATION_PR_DRAFT = "pr-draft-v2"  // 프롬프트 수정 시 v3, v4... 으로 올릴 것
+    private const val GENERATION_TRANSLATE = "pr-translate-v1"
+}
+```
+
+버전을 올리지 않으면 Langfuse에서 이전 버전과 현재 버전의 데이터가 섞여 비교가 어렵습니다.

--- a/omos/docs/langfuse.md
+++ b/omos/docs/langfuse.md
@@ -35,6 +35,76 @@ LANGFUSE_SECRET_KEY=sk-lf-...
 | `pr-translate-vN` | 번역 — 응답시간, 토큰 수 |
 | `quality` score | LLM-as-judge가 채점한 0~10점 품질 점수 (PR 초안 생성에만 적용) |
 
+## 다른 AI 파트에서 Langfuse 연동하기
+
+`LangfuseClient`는 전역 빈으로 등록되어 있어서 어디서든 주입받아 사용할 수 있습니다.
+
+### 기본 사용법 — AI 호출 기록
+
+```kotlin
+@Component
+class MyAiClient(
+    private val chatModel: ChatModel,
+    private val langfuseClient: LangfuseClient
+) {
+    companion object {
+        // 프롬프트를 수정할 때마다 버전을 올려야 Langfuse에서 버전별 비교가 가능합니다.
+        private const val GENERATION_NAME = "my-feature-v1"
+    }
+
+    fun callAi(prompt: String): String {
+        val startTime = Instant.now()
+        val response = chatModel.call(prompt)
+        val endTime = Instant.now()
+
+        langfuseClient.recordGeneration(
+            name = GENERATION_NAME,
+            input = prompt,
+            output = response,
+            startTime = startTime,
+            endTime = endTime,
+        )
+
+        return response
+    }
+}
+```
+
+### 토큰 수도 같이 기록하고 싶다면
+
+`ChatModel.call(Prompt(...))`으로 호출하면 usage 메타데이터에서 토큰 수를 꺼낼 수 있습니다.
+
+```kotlin
+val chatResponse = chatModel.call(Prompt(prompt))
+val usage = chatResponse.metadata.usage
+
+langfuseClient.recordGeneration(
+    name = GENERATION_NAME,
+    input = prompt,
+    output = chatResponse.result.output.text ?: "",
+    startTime = startTime,
+    endTime = endTime,
+    inputTokens = usage?.promptTokens?.toInt(),
+    outputTokens = usage?.completionTokens?.toInt(),
+)
+```
+
+### 품질 점수도 기록하고 싶다면
+
+`recordGeneration()`이 반환하는 `traceId`로 점수를 붙일 수 있습니다.
+
+```kotlin
+val traceId = langfuseClient.recordGeneration(...)
+
+if (traceId != null) {
+    langfuseClient.recordScore(traceId, score = 8.5, reason = "채점 근거")
+}
+```
+
+> Langfuse 키가 설정되지 않은 환경에서는 `recordGeneration()`이 `null`을 반환하고 기록을 건너뜁니다. 메인 로직에는 영향이 없습니다.
+
+---
+
 ## 프롬프트 버전 관리
 
 프롬프트를 수정할 때 반드시 두 곳의 버전을 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -96,12 +96,12 @@ class SpringAiClient(
                     {"score": 8.5, "reason": "채점 근거 한 줄"}
                 """.trimIndent()
 
-                val judgeResponse = chatModel.call(judgePrompt) ?: return@Thread
+                val judgeResponse = chatModel.call(judgePrompt) ?: return@submit
 
                 // JSON에서 score와 reason 추출
-                val json = extractJson(judgeResponse) ?: return@Thread
+                val json = extractJson(judgeResponse) ?: return@submit
                 val node = objectMapper.readTree(json)
-                val score = node.get("score")?.asDouble() ?: return@Thread
+                val score = node.get("score")?.asDouble() ?: return@submit
                 val reason = node.get("reason")?.asText() ?: ""
 
                 langfuseClient.recordScore(traceId, score, reason)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -42,7 +42,7 @@ class SpringAiClient(
 
     companion object {
         // 프롬프트 내용을 변경할 때 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        private const val GENERATION_PR_DRAFT = "pr-draft-v1"
+        private const val GENERATION_PR_DRAFT = "pr-draft-v2"
         private const val GENERATION_TRANSLATE = "pr-translate-v1"
     }
 

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -6,6 +6,7 @@ import com.back.omos.global.exception.exceptions.AiException
 import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KotlinLogging
 import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
 import java.time.Instant
@@ -46,6 +47,69 @@ class SpringAiClient(
     }
 
     /**
+     * 생성된 PR 초안의 품질을 LLM-as-judge 방식으로 채점합니다.
+     *
+     * <p>
+     * 원본 프롬프트(diff 포함)와 생성 결과를 AI에게 다시 전달하여
+     * 0~10점 점수와 채점 근거를 JSON으로 반환받습니다.
+     * 채점 결과는 Langfuse의 해당 trace에 score로 기록됩니다.
+     *
+     * <p><b>비동기 처리:</b><br>
+     * AI 호출은 별도 스레드에서 실행되어 PR 생성 응답 시간에 영향을 주지 않습니다.
+     *
+     * @param traceId 점수를 붙일 Langfuse trace ID
+     * @param originalPrompt PR 생성에 사용된 원본 프롬프트
+     * @param generatedTitle AI가 생성한 PR 제목
+     * @param generatedBody AI가 생성한 PR 본문
+     */
+    private fun evaluateAsync(
+        traceId: String,
+        originalPrompt: String,
+        generatedTitle: String,
+        generatedBody: String
+    ) {
+        Thread {
+            try {
+                val judgePrompt = """
+                    아래 PR 초안이 diff 내용을 얼마나 잘 반영했는지 평가해줘.
+
+                    [원본 프롬프트 (diff 포함)]
+                    $originalPrompt
+
+                    [생성된 PR 제목]
+                    $generatedTitle
+
+                    [생성된 PR 본문]
+                    $generatedBody
+
+                    [평가 기준]
+                    - 제목이 변경 내용을 정확히 요약하는가 (0~3점)
+                    - 본문이 변경 이유와 맥락을 충분히 설명하는가 (0~3점)
+                    - conventional commits 형식을 따르는가 (0~2점)
+                    - 불필요하거나 부정확한 내용이 없는가 (0~2점)
+
+                    반드시 아래 JSON 형식으로만 응답해.
+                    {"score": 8.5, "reason": "채점 근거 한 줄"}
+                """.trimIndent()
+
+                val judgeResponse = chatModel.call(judgePrompt) ?: return@Thread
+
+                // JSON에서 score와 reason 추출
+                val json = extractJson(judgeResponse) ?: return@Thread
+                val node = objectMapper.readTree(json)
+                val score = node.get("score")?.asDouble() ?: return@Thread
+                val reason = node.get("reason")?.asText() ?: ""
+
+                langfuseClient.recordScore(traceId, score, reason)
+                logger.debug { "LLM judge 채점 완료: score=$score" }
+            } catch (e: Exception) {
+                // 채점 실패는 메인 흐름에 영향을 주지 않음
+                logger.warn { "LLM judge 채점 실패 (무시됨): ${e.message}" }
+            }
+        }.start()
+    }
+
+    /**
      * 전달받은 프롬프트를 GLM에 전달하여 PR 초안을 생성합니다.
      *
      * <p>
@@ -57,21 +121,35 @@ class SpringAiClient(
      */
     override fun generatePrDraft(prompt: String): AiPrResult {
         val startTime = Instant.now()
-        val response = chatModel.call(prompt)
-            .takeIf { it.isNotBlank() }
-            ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+        val chatResponse = chatModel.call(Prompt(prompt))
         val endTime = Instant.now()
 
-        // 응답시간·프롬프트·결과를 Langfuse에 비동기 기록 (실패해도 메인 흐름에 영향 없음)
-        langfuseClient.recordGeneration(
+        val response = chatResponse.result.output.text
+            ?.takeIf { it.isNotBlank() }
+            ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+
+        // 토큰 수는 GLM API 응답에 포함된 usage 메타데이터에서 추출
+        val usage = chatResponse.metadata.usage
+
+        // 응답시간·토큰 수·프롬프트·결과를 Langfuse에 비동기 기록 (실패해도 메인 흐름에 영향 없음)
+        val traceId = langfuseClient.recordGeneration(
             name = GENERATION_PR_DRAFT,
             input = prompt,
             output = response,
             startTime = startTime,
-            endTime = endTime
+            endTime = endTime,
+            inputTokens = usage?.promptTokens?.toInt(),
+            outputTokens = usage?.completionTokens?.toInt()
         )
 
-        return parseResponse(response)
+        val result = parseResponse(response)
+
+        // traceId가 있을 때만 LLM judge 채점 (비동기, 응답 시간에 영향 없음)
+        if (traceId != null) {
+            evaluateAsync(traceId, prompt, result.title, result.body)
+        }
+
+        return result
     }
 
     /**
@@ -102,18 +180,24 @@ class SpringAiClient(
         """.trimIndent()
 
         val startTime = Instant.now()
-        val response = chatModel.call(prompt)
-            .takeIf { it.isNotBlank() }
-            ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+        val chatResponse = chatModel.call(Prompt(prompt))
         val endTime = Instant.now()
 
-        // 응답시간·프롬프트·결과를 Langfuse에 비동기 기록 (실패해도 메인 흐름에 영향 없음)
+        val response = chatResponse.result.output.text
+            ?.takeIf { it.isNotBlank() }
+            ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+
+        val usage = chatResponse.metadata.usage
+
+        // 응답시간·토큰 수·프롬프트·결과를 Langfuse에 비동기 기록 (실패해도 메인 흐름에 영향 없음)
         langfuseClient.recordGeneration(
             name = GENERATION_TRANSLATE,
             input = prompt,
             output = response,
             startTime = startTime,
-            endTime = endTime
+            endTime = endTime,
+            inputTokens = usage?.promptTokens?.toInt(),
+            outputTokens = usage?.completionTokens?.toInt()
         )
 
         return parseResponse(response)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.prdraft.ai
 
+import com.back.omos.global.ai.LangfuseClient
 import com.back.omos.global.exception.errorCode.AiErrorCode
 import com.back.omos.global.exception.exceptions.AiException
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -7,6 +8,7 @@ import mu.KotlinLogging
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
+import java.time.Instant
 
 /**
  * Spring AI를 사용하여 GLM 모델을 호출하는 실제 AI 구현체입니다.
@@ -19,35 +21,64 @@ import java.security.MessageDigest
  * AI 응답에 마크다운 코드 블록이 포함될 수 있어,
  * 정규식으로 JSON 객체를 추출한 뒤 역직렬화합니다.
  *
+ * <p><b>성능 기록:</b><br>
+ * 각 AI 호출의 프롬프트·응답·응답시간을 {@link LangfuseClient}를 통해 비동기로 기록합니다.
+ * Langfuse 미설정 시 기록을 건너뛰므로 기능에는 영향을 주지 않습니다.
+ *
  * @author 5h6vm
  * @since 2026-04-24
  * @see AiClient
+ * @see LangfuseClient
  */
 @Component
 class SpringAiClient(
     private val chatModel: ChatModel,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val langfuseClient: LangfuseClient
 ) : AiClient {
 
     private val logger = KotlinLogging.logger {}
 
+    companion object {
+        // 프롬프트 내용을 변경할 때 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
+        private const val GENERATION_PR_DRAFT = "pr-draft-v1"
+        private const val GENERATION_TRANSLATE = "pr-translate-v1"
+    }
+
     /**
      * 전달받은 프롬프트를 GLM에 전달하여 PR 초안을 생성합니다.
+     *
+     * <p>
+     * 호출 전후로 시각을 측정하여 응답시간을 포함한 기록을 Langfuse에 비동기로 전송합니다.
      *
      * @param prompt AI에게 전달할 PR 생성 프롬프트
      * @return AI가 생성한 PR 제목 및 본문
      * @throws AiException AI 응답이 비어 있거나 JSON 파싱에 실패한 경우
      */
     override fun generatePrDraft(prompt: String): AiPrResult {
+        val startTime = Instant.now()
         val response = chatModel.call(prompt)
             .takeIf { it.isNotBlank() }
             ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+        val endTime = Instant.now()
+
+        // 응답시간·프롬프트·결과를 Langfuse에 비동기 기록 (실패해도 메인 흐름에 영향 없음)
+        langfuseClient.recordGeneration(
+            name = GENERATION_PR_DRAFT,
+            input = prompt,
+            output = response,
+            startTime = startTime,
+            endTime = endTime
+        )
 
         return parseResponse(response)
     }
 
     /**
      * 한국어 PR 제목과 본문을 영어로 번역합니다.
+     *
+     * <p>
+     * 호출 전후로 시각을 측정하여 응답시간을 포함한 기록을 Langfuse에 비동기로 전송합니다.
      *
      * @param title 번역할 PR 제목 (한국어)
      * @param body 번역할 PR 본문 (한국어)
@@ -70,9 +101,20 @@ class SpringAiClient(
             $body
         """.trimIndent()
 
+        val startTime = Instant.now()
         val response = chatModel.call(prompt)
             .takeIf { it.isNotBlank() }
             ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
+        val endTime = Instant.now()
+
+        // 응답시간·프롬프트·결과를 Langfuse에 비동기 기록 (실패해도 메인 흐름에 영향 없음)
+        langfuseClient.recordGeneration(
+            name = GENERATION_TRANSLATE,
+            input = prompt,
+            output = response,
+            startTime = startTime,
+            endTime = endTime
+        )
 
         return parseResponse(response)
     }

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -10,6 +10,7 @@ import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
 import java.time.Instant
+import java.util.concurrent.Executors
 
 /**
  * Spring AI를 사용하여 GLM 모델을 호출하는 실제 AI 구현체입니다.
@@ -44,6 +45,9 @@ class SpringAiClient(
         // 프롬프트 내용을 변경할 때 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
         private const val GENERATION_PR_DRAFT = "pr-draft-v2"
         private const val GENERATION_TRANSLATE = "pr-translate-v1"
+
+        // LLM judge 채점 전용 풀 — 동시 채점 수를 제한해 스레드 고갈 방지
+        private val judgeExecutor = Executors.newFixedThreadPool(4)
     }
 
     /**
@@ -68,7 +72,7 @@ class SpringAiClient(
         generatedTitle: String,
         generatedBody: String
     ) {
-        Thread {
+        judgeExecutor.submit {
             try {
                 val judgePrompt = """
                     아래 PR 초안이 diff 내용을 얼마나 잘 반영했는지 평가해줘.
@@ -106,7 +110,7 @@ class SpringAiClient(
                 // 채점 실패는 메인 흐름에 영향을 주지 않음
                 logger.warn { "LLM judge 채점 실패 (무시됨): ${e.message}" }
             }
-        }.start()
+        }
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -42,7 +42,7 @@ class PrDraftPromptBuilder {
 
     companion object {
         // 프롬프트 내용을 변경할 때 이 버전도 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        const val PROMPT_VERSION = "v1"
+        const val PROMPT_VERSION = "v2"
     }
 
 
@@ -65,12 +65,20 @@ class PrDraftPromptBuilder {
         }
 
         return """
-            당신은 오픈소스 프로젝트의 PR 초안 작성 도우미입니다.
-            아래 diff를 바탕으로 PR 제목과 본문을 작성하세요.
+            [System Message]
+            당신은 오픈소스 커뮤니티의 소통을 돕는 테크니컬 라이터입니다.
+            수정된 코드와 맥락을 결합하여, 메인테이너가 한눈에 이해할 수 있는 전문적인 Pull Request 본문을 작성합니다.
             반드시 제목과 본문 모두 한국어로 작성하세요.
+
+            [Input]
             $contextSection
-            [Diff]
+            - 변경된 코드 내역:
             $diffContent
+
+            [Instruction]
+            1. 제목은 feat:, fix:, refactor:, chore:, docs:, test: 중 하나의 커밋 컨벤션을 따르고 50자 이내로 작성하세요.
+            2. 본문은 '변경 이유(Why)', '수정 내용(What)', '테스트 방법(How to Test)'의 3단 구조로 작성하세요.
+            3. 불필요한 미사여구는 배제하고, 엔지니어링 관점에서 간결하고 명확한 어조를 유지하세요.
 
             반드시 아래 JSON 형식으로만 응답하세요.
             {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -40,6 +40,11 @@ class PrDraftPromptBuilder {
     private val defaultTemplate = ClassPathResource("templates/pr-default-template.md")
         .inputStream.bufferedReader().readText()
 
+    companion object {
+        // 프롬프트 내용을 변경할 때 이 버전도 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
+        const val PROMPT_VERSION = "v1"
+    }
+
 
     /**
      * PR 초안 생성을 위한 프롬프트 문자열을 구성합니다.

--- a/omos/src/main/kotlin/com/back/omos/global/ai/LangfuseClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/ai/LangfuseClient.kt
@@ -72,6 +72,8 @@ class LangfuseClient(
      * @param output AI가 반환한 응답 원문
      * @param startTime AI 호출 시작 시각
      * @param endTime AI 호출 완료 시각
+     * @param inputTokens 프롬프트 토큰 수 (GLM API 응답에서 추출, null이면 기록 생략)
+     * @param outputTokens 응답 토큰 수 (GLM API 응답에서 추출, null이면 기록 생략)
      * @param metadata 프롬프트 버전·컨텍스트 타입 등 추가 기록 정보
      */
     fun recordGeneration(
@@ -80,12 +82,16 @@ class LangfuseClient(
         output: String,
         startTime: Instant,
         endTime: Instant,
+        inputTokens: Int? = null,
+        outputTokens: Int? = null,
         metadata: Map<String, Any> = emptyMap()
-    ) {
+    ): String? {
         // Langfuse가 설정되지 않은 환경에서는 기록 생략
-        val client = webClient ?: return
+        val client = webClient ?: return null
 
-        val body = buildIngestionBody(name, input, output, startTime, endTime, metadata)
+        // traceId를 미리 생성해 반환함으로써 호출부에서 score를 붙일 수 있게 함
+        val traceId = UUID.randomUUID().toString()
+        val body = buildIngestionBody(traceId, name, input, output, startTime, endTime, inputTokens, outputTokens, metadata)
 
         // fire-and-forget: 전송 실패가 메인 요청에 영향을 주지 않도록 subscribe만 걸고 반환
         client.post()
@@ -93,10 +99,49 @@ class LangfuseClient(
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(body)
             .retrieve()
-            .bodyToMono(Void::class.java)
+            .bodyToMono(String::class.java)
             .subscribe(
-                { },
+                { res -> logger.debug { "Langfuse 기록 성공: $res" } },
                 { e -> logger.warn { "Langfuse 기록 실패 (무시됨): ${e.message}" } }
+            )
+
+        return traceId
+    }
+
+    /**
+     * 특정 trace에 품질 점수를 기록합니다.
+     *
+     * <p>
+     * LLM-as-judge가 채점한 결과를 Langfuse scores API로 전송합니다.
+     * Langfuse UI의 해당 trace에 점수와 채점 근거가 표시됩니다.
+     *
+     * <p><b>비동기 처리:</b><br>
+     * fire-and-forget 방식으로 처리되어 메인 흐름에 영향을 주지 않습니다.
+     *
+     * @param traceId 점수를 붙일 trace ID ([recordGeneration]의 반환값)
+     * @param score 품질 점수 (0.0 ~ 10.0)
+     * @param reason 채점 근거
+     */
+    fun recordScore(traceId: String, score: Double, reason: String) {
+        val client = webClient ?: return
+
+        val body = mapOf(
+            "traceId" to traceId,
+            "name" to "quality",
+            "value" to score,
+            "comment" to reason
+        )
+
+        // fire-and-forget: 점수 전송 실패가 메인 요청에 영향을 주지 않도록 함
+        client.post()
+            .uri("/api/public/scores")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .subscribe(
+                { res -> logger.debug { "Langfuse 점수 기록 성공: $res" } },
+                { e -> logger.warn { "Langfuse 점수 기록 실패 (무시됨): ${e.message}" } }
             )
     }
 
@@ -104,44 +149,97 @@ class LangfuseClient(
      * Langfuse 인제스션 API에 전송할 요청 바디를 구성합니다.
      *
      * <p>
-     * generation-create 이벤트 하나를 batch로 감싸 반환합니다.
-     * traceId와 generationId는 각각 UUID로 새로 발급합니다.
+     * trace-create와 generation-create 두 이벤트를 하나의 batch로 묶어 반환합니다.
+     * Langfuse UI에서 generation은 trace 하위에 속해야 표시되므로
+     * 두 이벤트가 같은 traceId를 공유합니다.
      *
      * @param name generation 이름
      * @param input 프롬프트 원문
      * @param output AI 응답 원문
      * @param startTime 호출 시작 시각
      * @param endTime 호출 완료 시각
+     * @param inputTokens 프롬프트 토큰 수 (null이면 usage 필드 생략)
+     * @param outputTokens 응답 토큰 수 (null이면 usage 필드 생략)
      * @param metadata 추가 기록 정보
      * @return Langfuse 인제스션 API 요청 바디
      */
     private fun buildIngestionBody(
+        traceId: String,
         name: String,
         input: String,
         output: String,
         startTime: Instant,
         endTime: Instant,
+        inputTokens: Int?,
+        outputTokens: Int?,
         metadata: Map<String, Any>
     ): Map<String, Any> {
-        return mapOf(
-            "batch" to listOf(
+
+        return mapOf("batch" to listOf(
+                // trace를 먼저 생성해야 generation이 그 아래에 표시됨
+                mapOf(
+                    "id" to UUID.randomUUID().toString(),
+                    "type" to "trace-create",
+                    "timestamp" to startTime.toString(),
+                    "body" to mapOf(
+                        "id" to traceId,
+                        "name" to name,
+                        "timestamp" to startTime.toString(),
+                        "metadata" to metadata
+                    )
+                ),
                 mapOf(
                     "id" to UUID.randomUUID().toString(),
                     "type" to "generation-create",
                     "timestamp" to startTime.toString(),
-                    "body" to mapOf(
-                        "id" to UUID.randomUUID().toString(),
-                        "traceId" to UUID.randomUUID().toString(),
-                        "name" to name,
-                        "startTime" to startTime.toString(),
-                        "endTime" to endTime.toString(),
-                        "model" to "glm-4.5",
-                        "input" to input,
-                        "output" to output,
-                        "metadata" to metadata
-                    )
+                    "body" to buildGenerationBody(traceId, name, input, output, startTime, endTime, inputTokens, outputTokens, metadata)
                 )
             )
         )
+    }
+
+    /**
+     * generation-create 이벤트의 body를 구성합니다.
+     *
+     * <p>
+     * inputTokens·outputTokens가 null이 아닌 경우에만 usage 필드를 포함합니다.
+     * GLM API가 토큰 정보를 반환하지 않는 경우 usage 없이 기록합니다.
+     *
+     * @return generation body 맵
+     */
+    private fun buildGenerationBody(
+        traceId: String,
+        name: String,
+        input: String,
+        output: String,
+        startTime: Instant,
+        endTime: Instant,
+        inputTokens: Int?,
+        outputTokens: Int?,
+        metadata: Map<String, Any>
+    ): Map<String, Any> {
+        val body = mutableMapOf<String, Any>(
+            "id" to UUID.randomUUID().toString(),
+            "traceId" to traceId,
+            "name" to name,
+            "startTime" to startTime.toString(),
+            "endTime" to endTime.toString(),
+            "model" to "glm-4.5",
+            "input" to input,
+            "output" to output,
+            "metadata" to metadata
+        )
+
+        // 토큰 정보가 있을 때만 usage 필드 추가 (GLM API가 미제공 시 생략)
+        if (inputTokens != null || outputTokens != null) {
+            body["usage"] = mapOf(
+                "input" to (inputTokens ?: 0),
+                "output" to (outputTokens ?: 0),
+                "total" to ((inputTokens ?: 0) + (outputTokens ?: 0)),
+                "unit" to "TOKENS"
+            )
+        }
+
+        return body
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/global/ai/LangfuseClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/global/ai/LangfuseClient.kt
@@ -1,0 +1,147 @@
+package com.back.omos.global.ai
+
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+/**
+ * Langfuse에 AI 호출 결과를 비동기로 기록하는 클라이언트입니다.
+ *
+ * <p>
+ * AI 호출마다 프롬프트·응답·응답시간·메타데이터를 Langfuse 인제스션 API로 전송하여
+ * 프롬프트 버전별 성능 변화를 대시보드에서 추적할 수 있도록 합니다.
+ *
+ * <p><b>설정:</b><br>
+ * {@code langfuse.host}, {@code langfuse.public-key}, {@code langfuse.secret-key} 중
+ * 하나라도 비어 있으면 WebClient를 생성하지 않고 기록을 전부 건너뜁니다.
+ * 덕분에 Langfuse 미설정 환경에서도 애플리케이션이 정상 동작합니다.
+ *
+ * <p><b>장애 격리:</b><br>
+ * 전송은 fire-and-forget 방식으로 처리됩니다.
+ * Langfuse 서버가 다운되거나 네트워크 오류가 발생해도 경고 로그만 남기고
+ * 메인 요청 흐름에는 영향을 주지 않습니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-30
+ */
+@Component
+class LangfuseClient(
+    @Value("\${langfuse.host:}") private val host: String,
+    @Value("\${langfuse.public-key:}") private val publicKey: String,
+    @Value("\${langfuse.secret-key:}") private val secretKey: String
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    // host·publicKey·secretKey가 모두 설정된 경우에만 WebClient를 초기화
+    private val webClient: WebClient? by lazy {
+        if (host.isBlank() || publicKey.isBlank() || secretKey.isBlank()) {
+            logger.info { "Langfuse 설정이 없어 AI 호출 기록을 건너뜁니다." }
+            null
+        } else {
+            WebClient.builder()
+                .baseUrl(host)
+                .defaultHeader(
+                    "Authorization",
+                    // Langfuse는 Basic Auth 방식으로 인증 (publicKey:secretKey를 Base64 인코딩)
+                    "Basic " + Base64.getEncoder().encodeToString("$publicKey:$secretKey".toByteArray())
+                )
+                .build()
+        }
+    }
+
+    /**
+     * AI 호출 한 건을 Langfuse generation으로 기록합니다.
+     *
+     * <p>
+     * Langfuse 인제스션 API({@code POST /api/public/ingestion})의 batch 형식으로
+     * generation-create 이벤트를 전송합니다.
+     * WebClient가 초기화되지 않은 경우(미설정) 즉시 반환합니다.
+     *
+     * <p><b>비동기 처리:</b><br>
+     * {@code subscribe()}로 fire-and-forget 방식으로 전송하므로 호출 스레드를 블로킹하지 않습니다.
+     * 전송 실패 시 에러 콜백에서 경고 로그를 남기고 종료합니다.
+     *
+     * @param name generation 이름 (예: "pr-draft-v1", "pr-translate-v1")
+     * @param input AI에 전달한 프롬프트 원문
+     * @param output AI가 반환한 응답 원문
+     * @param startTime AI 호출 시작 시각
+     * @param endTime AI 호출 완료 시각
+     * @param metadata 프롬프트 버전·컨텍스트 타입 등 추가 기록 정보
+     */
+    fun recordGeneration(
+        name: String,
+        input: String,
+        output: String,
+        startTime: Instant,
+        endTime: Instant,
+        metadata: Map<String, Any> = emptyMap()
+    ) {
+        // Langfuse가 설정되지 않은 환경에서는 기록 생략
+        val client = webClient ?: return
+
+        val body = buildIngestionBody(name, input, output, startTime, endTime, metadata)
+
+        // fire-and-forget: 전송 실패가 메인 요청에 영향을 주지 않도록 subscribe만 걸고 반환
+        client.post()
+            .uri("/api/public/ingestion")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(Void::class.java)
+            .subscribe(
+                { },
+                { e -> logger.warn { "Langfuse 기록 실패 (무시됨): ${e.message}" } }
+            )
+    }
+
+    /**
+     * Langfuse 인제스션 API에 전송할 요청 바디를 구성합니다.
+     *
+     * <p>
+     * generation-create 이벤트 하나를 batch로 감싸 반환합니다.
+     * traceId와 generationId는 각각 UUID로 새로 발급합니다.
+     *
+     * @param name generation 이름
+     * @param input 프롬프트 원문
+     * @param output AI 응답 원문
+     * @param startTime 호출 시작 시각
+     * @param endTime 호출 완료 시각
+     * @param metadata 추가 기록 정보
+     * @return Langfuse 인제스션 API 요청 바디
+     */
+    private fun buildIngestionBody(
+        name: String,
+        input: String,
+        output: String,
+        startTime: Instant,
+        endTime: Instant,
+        metadata: Map<String, Any>
+    ): Map<String, Any> {
+        return mapOf(
+            "batch" to listOf(
+                mapOf(
+                    "id" to UUID.randomUUID().toString(),
+                    "type" to "generation-create",
+                    "timestamp" to startTime.toString(),
+                    "body" to mapOf(
+                        "id" to UUID.randomUUID().toString(),
+                        "traceId" to UUID.randomUUID().toString(),
+                        "name" to name,
+                        "startTime" to startTime.toString(),
+                        "endTime" to endTime.toString(),
+                        "model" to "glm-4.5",
+                        "input" to input,
+                        "output" to output,
+                        "metadata" to metadata
+                    )
+                )
+            )
+        )
+    }
+}

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -63,6 +63,12 @@ app:
   oauth2:
     redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth/callback}
 
+# Langfuse 설정 (localhost:3001에서 프로젝트 생성 후 발급받은 키로 교체)
+langfuse:
+  host: ${LANGFUSE_HOST:http://localhost:3001}
+  public-key: ${LANGFUSE_PUBLIC_KEY:}
+  secret-key: ${LANGFUSE_SECRET_KEY:}
+
 # 로깅 레벨
 logging:
   level:

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -73,4 +73,5 @@ langfuse:
 logging:
   level:
     root: INFO
-    com.back.omos: DEBUG # 프로젝트 패키지 로그 레벨
+    com.back.omos: DEBUG
+    com.back.omos.global.ai.LangfuseClient: DEBUG # 프로젝트 패키지 로그 레벨

--- a/omos/src/main/resources/application-dev.yaml
+++ b/omos/src/main/resources/application-dev.yaml
@@ -74,4 +74,3 @@ logging:
   level:
     root: INFO
     com.back.omos: DEBUG
-    com.back.omos.global.ai.LangfuseClient: DEBUG # 프로젝트 패키지 로그 레벨

--- a/omos/src/main/resources/application-test.yaml
+++ b/omos/src/main/resources/application-test.yaml
@@ -54,3 +54,8 @@ app:
 github:
   token: ${GITHUB_TOKEN:test-token}
 
+langfuse:
+  host: ${LANGFUSE_HOST:http://localhost:3001}
+  public-key: ${LANGFUSE_PUBLIC_KEY:}
+  secret-key: ${LANGFUSE_SECRET_KEY:}
+

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Qualifier
  * @author 5h6vm
  * @since 2026-04-30
  */
-//@Disabled("프롬프트 평가용 수동 실행 테스트 — 필요할 때만 @Disabled 제거하고 실행")
+@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
 @SpringBootTest
 @ActiveProfiles("test")
 class PrDraftPromptEvalTest {

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 //@Disabled("프롬프트 평가용 수동 실행 테스트 — 필요할 때만 @Disabled 제거하고 실행")
 @SpringBootTest
 @ActiveProfiles("test")
-class PromptEvalTest {
+class PrDraftPromptEvalTest {
 
     @Autowired
     private lateinit var aiClient: SpringAiClient

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Qualifier
  * @author 5h6vm
  * @since 2026-04-30
  */
-@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
+//@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
 @SpringBootTest
 @ActiveProfiles("test")
 class PrDraftPromptEvalTest {

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Qualifier
  * @author 5h6vm
  * @since 2026-04-30
  */
-//@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
+@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
 @SpringBootTest
 @ActiveProfiles("test")
 class PrDraftPromptEvalTest {

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PromptEvalTest.kt
@@ -1,0 +1,260 @@
+package com.back.omos.domain.prdraft.ai
+
+import com.back.omos.domain.prdraft.service.PrDraftPromptBuilder
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.io.File
+import org.springframework.beans.factory.annotation.Qualifier
+
+/**
+ * 프롬프트 버전별 성능을 비교하기 위한 평가 테스트입니다.
+ *
+ * <p>
+ * 고정된 diff 샘플 5종으로 AI를 호출하고, 결과를 Langfuse에 자동 기록합니다.
+ * 프롬프트를 수정할 때마다 이 테스트를 실행하여 버전 간 score/latency를 비교하세요.
+ *
+ * <p><b>실행 방법:</b><br>
+ * {@code @Disabled}를 제거하거나 IntelliJ에서 해당 테스트를 직접 실행합니다.
+ * 실행 후 localhost:3001 → Traces에서 결과를 확인합니다.
+ *
+ * <p><b>주의:</b><br>
+ * 실제 GLM API와 Langfuse를 호출하므로 dev 환경에서만 실행해야 합니다.
+ * 프롬프트 버전을 바꾸면 {@link PrDraftPromptBuilder#PROMPT_VERSION}과
+ * {@link SpringAiClient}의 {@code GENERATION_PR_DRAFT} 상수도 함께 올려야 합니다.
+ *
+ * @author 5h6vm
+ * @since 2026-04-30
+ */
+//@Disabled("프롬프트 평가용 수동 실행 테스트 — 필요할 때만 @Disabled 제거하고 실행")
+@SpringBootTest
+@ActiveProfiles("test")
+class PromptEvalTest {
+
+    @Autowired
+    private lateinit var aiClient: SpringAiClient
+
+    @Autowired
+    private lateinit var promptBuilder: PrDraftPromptBuilder
+
+    /**
+     * 5종의 고정 diff 샘플로 프롬프트를 평가합니다.
+     *
+     * <p>
+     * 각 샘플은 실제 오픈소스 기여 시나리오를 반영합니다.
+     * 결과는 Langfuse에 자동 기록되며, score·latency·토큰 수를 확인할 수 있습니다.
+     */
+    @Test
+    fun `고정 샘플 5종으로 프롬프트 평가`() {
+        EVAL_SAMPLES.forEachIndexed { index, sample ->
+            println("\n===== 샘플 ${index + 1}: ${sample.description} =====")
+
+            try {
+                val prompt = promptBuilder.build(
+                    diffContent = sample.diff,
+                    contributing = null,
+                    prs = emptyList()
+                )
+
+                val result = aiClient.generatePrDraft(prompt)
+
+                println("제목: ${result.title}")
+                println("본문 미리보기: ${result.body.take(100)}...")
+            } catch (e: Exception) {
+                println("샘플 ${index + 1} 실패 (건너뜀): ${e.message}")
+            }
+
+            // 연속 호출 시 rate limit 방지
+            if (index < EVAL_SAMPLES.lastIndex) Thread.sleep(10_000)
+        }
+
+        // Langfuse fire-and-forget 전송 + LLM judge 채점(별도 스레드) 완료 대기
+        // judge 호출은 GLM 응답까지 최대 30초 소요될 수 있고 샘플 5개가 동시 진행되므로 60초 대기
+        Thread.sleep(60_000)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 고정 평가 샘플 (같은 샘플로 버전 간 비교해야 의미 있음 — 임의로 수정 금지)
+    // ──────────────────────────────────────────────────────────────────────────
+    companion object {
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun loadDotEnv(registry: DynamicPropertyRegistry) {
+            val envFile = File(".env").takeIf { it.exists() }
+                ?: File("../.env").takeIf { it.exists() }
+                ?: return
+
+            envFile.readLines().forEach { line ->
+                val trimmed = line.trim()
+                if (trimmed.isNotEmpty() && !trimmed.startsWith('#')) {
+                    val idx = trimmed.indexOf('=')
+                    if (idx > 0) {
+                        val key = trimmed.substring(0, idx).trim()
+                        val value = trimmed.substring(idx + 1).trim()
+                        registry.add(key) { value }
+                    }
+                }
+            }
+        }
+        data class EvalSample(val description: String, val diff: String)
+
+        val EVAL_SAMPLES = listOf(
+
+            // 샘플 1: 단순 버그 수정 (null 안전성)
+            EvalSample(
+                description = "null 안전성 버그 수정",
+                diff = """
+                    diff --git a/src/main/kotlin/com/example/service/UserService.kt b/src/main/kotlin/com/example/service/UserService.kt
+                    index a1b2c3d..e4f5g6h 100644
+                    --- a/src/main/kotlin/com/example/service/UserService.kt
+                    +++ b/src/main/kotlin/com/example/service/UserService.kt
+                    @@ -24,7 +24,9 @@ class UserService(
+                         fun getUserProfile(userId: Long): UserProfileRes {
+                             val user = userRepository.findById(userId)
+                    -            .orElseThrow { RuntimeException("User not found") }
+                    +            .orElseThrow { UserNotFoundException("존재하지 않는 사용자입니다: userId=${'$'}userId") }
+                    -        return UserProfileRes(user.name, user.email)
+                    +        return UserProfileRes(
+                    +            name = user.name ?: "Unknown",
+                    +            email = user.email ?: ""
+                    +        )
+                         }
+                    }
+                """.trimIndent()
+            ),
+
+            // 샘플 2: 신규 기능 (페이지네이션 추가)
+            EvalSample(
+                description = "목록 조회 API에 페이지네이션 추가",
+                diff = """
+                    diff --git a/src/main/kotlin/com/example/controller/PostController.kt b/src/main/kotlin/com/example/controller/PostController.kt
+                    index b2c3d4e..f5g6h7i 100644
+                    --- a/src/main/kotlin/com/example/controller/PostController.kt
+                    +++ b/src/main/kotlin/com/example/controller/PostController.kt
+                    @@ -12,8 +12,12 @@ class PostController(private val postService: PostService) {
+                    -    @GetMapping
+                    -    fun getPosts(): ResponseEntity<List<PostRes>> {
+                    -        return ResponseEntity.ok(postService.getPosts())
+                    +    @GetMapping
+                    +    fun getPosts(
+                    +        @RequestParam(defaultValue = "0") page: Int,
+                    +        @RequestParam(defaultValue = "20") size: Int
+                    +    ): ResponseEntity<Page<PostRes>> {
+                    +        val pageable = PageRequest.of(page, size, Sort.by("createdAt").descending())
+                    +        return ResponseEntity.ok(postService.getPosts(pageable))
+                         }
+                    diff --git a/src/main/kotlin/com/example/service/PostService.kt b/src/main/kotlin/com/example/service/PostService.kt
+                    @@ -8,6 +8,6 @@ class PostService(private val postRepository: PostRepository) {
+                    -    fun getPosts(): List<PostRes> =
+                    -        postRepository.findAll().map { PostRes.from(it) }
+                    +    fun getPosts(pageable: Pageable): Page<PostRes> =
+                    +        postRepository.findAll(pageable).map { PostRes.from(it) }
+                    }
+                """.trimIndent()
+            ),
+
+            // 샘플 3: 리팩토링 (중복 코드 추출)
+            EvalSample(
+                description = "공통 검증 로직 메서드 추출 리팩토링",
+                diff = """
+                    diff --git a/src/main/kotlin/com/example/service/OrderService.kt b/src/main/kotlin/com/example/service/OrderService.kt
+                    index c3d4e5f..g6h7i8j 100644
+                    --- a/src/main/kotlin/com/example/service/OrderService.kt
+                    +++ b/src/main/kotlin/com/example/service/OrderService.kt
+                    @@ -15,20 +15,16 @@ class OrderService(private val orderRepository: OrderRepository) {
+                         fun cancelOrder(userId: Long, orderId: Long) {
+                    -        val order = orderRepository.findById(orderId)
+                    -            .orElseThrow { OrderNotFoundException(orderId) }
+                    -        if (order.userId != userId) throw ForbiddenException()
+                    +        val order = getOrderOrThrow(userId, orderId)
+                             order.cancel()
+                             orderRepository.save(order)
+                         }
+
+                         fun getOrderDetail(userId: Long, orderId: Long): OrderDetailRes {
+                    -        val order = orderRepository.findById(orderId)
+                    -            .orElseThrow { OrderNotFoundException(orderId) }
+                    -        if (order.userId != userId) throw ForbiddenException()
+                    +        val order = getOrderOrThrow(userId, orderId)
+                             return OrderDetailRes.from(order)
+                         }
+                    +
+                    +    private fun getOrderOrThrow(userId: Long, orderId: Long): Order {
+                    +        val order = orderRepository.findById(orderId)
+                    +            .orElseThrow { OrderNotFoundException(orderId) }
+                    +        if (order.userId != userId) throw ForbiddenException()
+                    +        return order
+                    +    }
+                    }
+                """.trimIndent()
+            ),
+
+            // 샘플 4: 성능 개선 (캐싱 적용)
+            EvalSample(
+                description = "레포지토리 정보 조회에 캐싱 적용",
+                diff = """
+                    diff --git a/src/main/kotlin/com/example/service/RepoService.kt b/src/main/kotlin/com/example/service/RepoService.kt
+                    index d4e5f6g..h7i8j9k 100644
+                    --- a/src/main/kotlin/com/example/service/RepoService.kt
+                    +++ b/src/main/kotlin/com/example/service/RepoService.kt
+                    @@ -1,10 +1,13 @@
+                    +import org.springframework.cache.annotation.Cacheable
+                    +import org.springframework.cache.annotation.CacheEvict
+                    +
+                     @Service
+                    +@EnableCaching
+                     class RepoService(private val repoRepository: RepoRepository) {
+
+                    +    @Cacheable(value = ["repoInfo"], key = "#repoId")
+                         fun getRepoInfo(repoId: Long): RepoInfoRes {
+                             return repoRepository.findById(repoId)
+                                 .map { RepoInfoRes.from(it) }
+                                 .orElseThrow { RepoNotFoundException(repoId) }
+                         }
+                    +
+                    +    @CacheEvict(value = ["repoInfo"], key = "#repoId")
+                    +    fun invalidateCache(repoId: Long) = Unit
+                     }
+                """.trimIndent()
+            ),
+
+            // 샘플 5: 보안 수정 (입력값 검증 추가)
+            EvalSample(
+                description = "API 요청 입력값 검증 추가",
+                diff = """
+                    diff --git a/src/main/kotlin/com/example/dto/CreateCommentReq.kt b/src/main/kotlin/com/example/dto/CreateCommentReq.kt
+                    index e5f6g7h..i8j9k0l 100644
+                    --- a/src/main/kotlin/com/example/dto/CreateCommentReq.kt
+                    +++ b/src/main/kotlin/com/example/dto/CreateCommentReq.kt
+                    @@ -1,7 +1,12 @@
+                    +import jakarta.validation.constraints.NotBlank
+                    +import jakarta.validation.constraints.Size
+                    +
+                     data class CreateCommentReq(
+                    -    val content: String,
+                    -    val postId: Long
+                    +    @field:NotBlank(message = "댓글 내용은 필수입니다.")
+                    +    @field:Size(min = 1, max = 500, message = "댓글은 1자 이상 500자 이하여야 합니다.")
+                    +    val content: String,
+                    +
+                    +    @field:Positive(message = "게시글 ID는 양수여야 합니다.")
+                    +    val postId: Long
+                     )
+                    diff --git a/src/main/kotlin/com/example/controller/CommentController.kt b/src/main/kotlin/com/example/controller/CommentController.kt
+                    @@ -8,6 +8,7 @@ class CommentController(private val commentService: CommentService) {
+                         @PostMapping
+                         fun createComment(
+                    +        @Valid
+                             @RequestBody request: CreateCommentReq
+                         ): ResponseEntity<CommentRes> {
+                             return ResponseEntity.ok(commentService.create(request))
+                """.trimIndent()
+            )
+        )
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClientTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClientTest.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.prdraft.ai
 
+import com.back.omos.global.ai.LangfuseClient
 import com.back.omos.global.exception.errorCode.AiErrorCode
 import com.back.omos.global.exception.exceptions.AiException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -12,19 +13,43 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.metadata.ChatResponseMetadata
 import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.chat.prompt.Prompt
 
 @ExtendWith(MockitoExtension::class)
 class SpringAiClientTest {
 
     @Mock private lateinit var chatModel: ChatModel
+    @Mock private lateinit var langfuseClient: LangfuseClient
 
     private lateinit var client: SpringAiClient
 
     @BeforeEach
     fun setUp() {
-        client = SpringAiClient(chatModel, jacksonObjectMapper())
+        client = SpringAiClient(chatModel, jacksonObjectMapper(), langfuseClient)
+        // Langfuse 미설정 환경처럼 동작 (score 기록 불필요)
+        given(langfuseClient.recordGeneration(any(), any(), any(), any(), any(), any(), any(), any())).willReturn(null)
+    }
+
+    private fun mockChatResponse(text: String): ChatResponse {
+        val message = org.mockito.Mockito.mock(AssistantMessage::class.java).also {
+            given(it.text).willReturn(text)
+        }
+        val generation = org.mockito.Mockito.mock(Generation::class.java).also {
+            given(it.output).willReturn(message)
+        }
+        val metadata = org.mockito.Mockito.mock(ChatResponseMetadata::class.java).also {
+            given(it.usage).willReturn(null)
+        }
+        return org.mockito.Mockito.mock(ChatResponse::class.java).also {
+            given(it.result).willReturn(generation)
+            given(it.metadata).willReturn(metadata)
+        }
     }
 
     @Nested
@@ -32,7 +57,8 @@ class SpringAiClientTest {
 
         @Test
         fun `정상 JSON 응답을 파싱한다`() {
-            given(chatModel.call(anyString())).willReturn("""{"title":"feat: test","body":"test body"}""")
+            given(chatModel.call(any(Prompt::class.java)))
+                .willReturn(mockChatResponse("""{"title":"feat: test","body":"test body"}"""))
 
             val result = client.generatePrDraft("prompt")
 
@@ -42,8 +68,8 @@ class SpringAiClientTest {
 
         @Test
         fun `마크다운 코드펜스로 감싸진 응답을 파싱한다`() {
-            val response = "```json\n{\"title\":\"feat: test\",\"body\":\"test body\"}\n```"
-            given(chatModel.call(anyString())).willReturn(response)
+            given(chatModel.call(any(Prompt::class.java)))
+                .willReturn(mockChatResponse("```json\n{\"title\":\"feat: test\",\"body\":\"test body\"}\n```"))
 
             val result = client.generatePrDraft("prompt")
 
@@ -56,7 +82,8 @@ class SpringAiClientTest {
 
         @Test
         fun `빈 응답이면 AI_RESPONSE_EMPTY 예외를 던진다`() {
-            given(chatModel.call(anyString())).willReturn("   ")
+            given(chatModel.call(any(Prompt::class.java)))
+                .willReturn(mockChatResponse("   "))
 
             assertThatThrownBy { client.generatePrDraft("prompt") }
                 .isInstanceOf(AiException::class.java)
@@ -66,7 +93,8 @@ class SpringAiClientTest {
 
         @Test
         fun `JSON 파싱 실패 시 AI_RESPONSE_PARSE_FAILED 예외를 던진다`() {
-            given(chatModel.call(anyString())).willReturn("not a json response at all")
+            given(chatModel.call(any(Prompt::class.java)))
+                .willReturn(mockChatResponse("not a json response at all"))
 
             assertThatThrownBy { client.generatePrDraft("prompt") }
                 .isInstanceOf(AiException::class.java)

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClientTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClientTest.kt
@@ -13,15 +13,18 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.springframework.ai.chat.messages.AssistantMessage
-import org.springframework.ai.chat.metadata.ChatResponseMetadata
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.model.Generation
 import org.springframework.ai.chat.prompt.Prompt
 
 @ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SpringAiClientTest {
 
     @Mock private lateinit var chatModel: ChatModel
@@ -33,23 +36,11 @@ class SpringAiClientTest {
     fun setUp() {
         client = SpringAiClient(chatModel, jacksonObjectMapper(), langfuseClient)
         // Langfuse 미설정 환경처럼 동작 (score 기록 불필요)
-        given(langfuseClient.recordGeneration(any(), any(), any(), any(), any(), any(), any(), any())).willReturn(null)
+        given(langfuseClient.recordGeneration(any(), any(), any(), any(), any(), anyOrNull(), anyOrNull(), any())).willReturn(null)
     }
 
     private fun mockChatResponse(text: String): ChatResponse {
-        val message = org.mockito.Mockito.mock(AssistantMessage::class.java).also {
-            given(it.text).willReturn(text)
-        }
-        val generation = org.mockito.Mockito.mock(Generation::class.java).also {
-            given(it.output).willReturn(message)
-        }
-        val metadata = org.mockito.Mockito.mock(ChatResponseMetadata::class.java).also {
-            given(it.usage).willReturn(null)
-        }
-        return org.mockito.Mockito.mock(ChatResponse::class.java).also {
-            given(it.result).willReturn(generation)
-            given(it.metadata).willReturn(metadata)
-        }
+        return ChatResponse(listOf(Generation(AssistantMessage(text))))
     }
 
     @Nested
@@ -57,7 +48,7 @@ class SpringAiClientTest {
 
         @Test
         fun `정상 JSON 응답을 파싱한다`() {
-            given(chatModel.call(any(Prompt::class.java)))
+            given(chatModel.call(any<Prompt>()))
                 .willReturn(mockChatResponse("""{"title":"feat: test","body":"test body"}"""))
 
             val result = client.generatePrDraft("prompt")
@@ -68,7 +59,7 @@ class SpringAiClientTest {
 
         @Test
         fun `마크다운 코드펜스로 감싸진 응답을 파싱한다`() {
-            given(chatModel.call(any(Prompt::class.java)))
+            given(chatModel.call(any<Prompt>()))
                 .willReturn(mockChatResponse("```json\n{\"title\":\"feat: test\",\"body\":\"test body\"}\n```"))
 
             val result = client.generatePrDraft("prompt")
@@ -82,7 +73,7 @@ class SpringAiClientTest {
 
         @Test
         fun `빈 응답이면 AI_RESPONSE_EMPTY 예외를 던진다`() {
-            given(chatModel.call(any(Prompt::class.java)))
+            given(chatModel.call(any<Prompt>()))
                 .willReturn(mockChatResponse("   "))
 
             assertThatThrownBy { client.generatePrDraft("prompt") }
@@ -93,7 +84,7 @@ class SpringAiClientTest {
 
         @Test
         fun `JSON 파싱 실패 시 AI_RESPONSE_PARSE_FAILED 예외를 던진다`() {
-            given(chatModel.call(any(Prompt::class.java)))
+            given(chatModel.call(any<Prompt>()))
                 .willReturn(mockChatResponse("not a json response at all"))
 
             assertThatThrownBy { client.generatePrDraft("prompt") }


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
langfuse로 프롬프트 별 기록 저장

## 🔗 관련 이슈
- Close #101 

## 🛠️ 주요 변경 사항
- [ ] docs/langfuse.md : 생성, 로컬 실행, 키발급, ai 연동, 프롬프트 버전 관리 가이드
- [ ] docker-compse : langfuse, DB 컨테이너 구성
- [ ] global/ai/LangfuseClient : ai 결과를 langfuse에 비동기 기록하는 클라이언트
- [ ] test/.../domain/prdratf/ai/PrDraftPromptEvalTest : 샘플 평가 테스트
- [ ] domain/prdraft/ai/SpringAiClient : langfuse 연동 추가, LLM-as-judge 품질 채점
- [ ] .yaml : 설정 추가
- [ ] test 수정

## 🧪 테스트 결과
<img width="1907" height="711" alt="image" src="https://github.com/user-attachments/assets/4430c05a-58f8-4525-a710-1e557643151a" />

## 🧐 리뷰어에게
저도.. 일단 만들고 본거라.. 내용에 대해 자세히는 모릅니다.. 클로드가 더 잘 알거에요..
