### PR TITLE
[FEAT] 이슈 수정 시 분석 결과 캐시 갱신 구현

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubIssueRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubIssueRes.kt
@@ -3,6 +3,7 @@ package com.back.omos.domain.analysis.github
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 /**
  * GitHub Issues API 응답을 담는 DTO입니다.
@@ -52,5 +53,5 @@ data class GitHubIssueRes(
      * GitHub API 응답의 updated_at 필드와 매핑됩니다.
      */
     @JsonProperty("updated_at")
-    val updatedAt: LocalDateTime?
+    val updatedAt: OffsetDateTime?
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubIssueRes.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/github/GitHubIssueRes.kt
@@ -1,6 +1,8 @@
 package com.back.omos.domain.analysis.github
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDateTime
 
 /**
  * GitHub Issues API 응답을 담는 DTO입니다.
@@ -42,5 +44,13 @@ data class GitHubIssueRes(
      * 이슈에 부여된 라벨 목록입니다.
      * GitHub 응답의 labels 배열을 GitHubLabel 리스트로 매핑합니다.
      */
-    val labels: List<GitHubLabel>
+    val labels: List<GitHubLabel>,
+
+    /**
+     * 이슈 최종 수정 시각입니다.
+     * 캐시 유효성 검사 시 분석 결과의 createdAt과 비교합니다.
+     * GitHub API 응답의 updated_at 필드와 매핑됩니다.
+     */
+    @JsonProperty("updated_at")
+    val updatedAt: LocalDateTime?
 )

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
@@ -51,4 +51,14 @@ interface UserAnalysisRequestRepository : JpaRepository<UserAnalysisRequest, Lon
      * @return 해당 이슈들에 대한 완료된 분석 요청 목록
      */
     fun findAllByUserIdAndAnalysisResultIssueIdIn(userId: Long, issueIds: List<Long>): List<UserAnalysisRequest>
+
+    /**
+     * 특정 분석 결과를 참조하는 모든 사용자 분석 요청을 삭제합니다.
+     *
+     * 캐시 무효화 시 기존 [AnalysisResult]를 삭제하기 전에 호출하여
+     * [UserAnalysisRequest] 고아 레코드 발생을 방지합니다.
+     *
+     * @param analysisResultId 삭제할 분석 결과의 ID
+     */
+    fun deleteAllByAnalysisResultId(analysisResultId: Long)
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/repository/UserAnalysisRequestRepository.kt
@@ -1,7 +1,11 @@
 package com.back.omos.domain.analysis.repository
 
+import com.back.omos.domain.analysis.entity.AnalysisResult
 import com.back.omos.domain.analysis.entity.UserAnalysisRequest
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 /**
@@ -53,12 +57,15 @@ interface UserAnalysisRequestRepository : JpaRepository<UserAnalysisRequest, Lon
     fun findAllByUserIdAndAnalysisResultIssueIdIn(userId: Long, issueIds: List<Long>): List<UserAnalysisRequest>
 
     /**
-     * 특정 분석 결과를 참조하는 모든 사용자 분석 요청을 삭제합니다.
+     * 특정 분석 결과를 참조하는 모든 사용자 분석 요청을 새 분석 결과로 업데이트합니다.
      *
-     * 캐시 무효화 시 기존 [AnalysisResult]를 삭제하기 전에 호출하여
-     * [UserAnalysisRequest] 고아 레코드 발생을 방지합니다.
+     * 캐시 무효화 시 기존 [UserAnalysisRequest]의 이력과 일일 제한 카운트를 보존하면서
+     * 새 [AnalysisResult]로 연결을 갱신합니다.
      *
-     * @param analysisResultId 삭제할 분석 결과의 ID
+     * @param oldResultId 기존 분석 결과 ID
+     * @param newResult 새 분석 결과
      */
-    fun deleteAllByAnalysisResultId(analysisResultId: Long)
+    @Modifying
+    @Query("UPDATE UserAnalysisRequest u SET u.analysisResult = :newResult WHERE u.analysisResult.id = :oldId")
+    fun updateAnalysisResult(@Param("oldId") oldId: Long, @Param("newResult") newResult: AnalysisResult)
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -217,7 +217,13 @@ class ContextAnalyzerServiceImpl(
                 path.endsWith(".ts") || path.endsWith(".js") ||
                         path.endsWith(".kt") || path.endsWith(".java") ||
                         path.endsWith(".py") || path.endsWith(".go") ||
-                        path.endsWith(".rs") || path.endsWith(".cpp")
+                        path.endsWith(".rs") || path.endsWith(".cpp") ||
+                        path.endsWith(".json") || path.endsWith(".yaml") ||
+                        path.endsWith(".yml") || path.endsWith(".md") ||
+                        path.endsWith(".html") || path.endsWith(".css") ||
+                        path.endsWith(".scss") || path.endsWith(".xml") ||
+                        path.endsWith(".toml") || path.endsWith(".gradle") ||
+                        path.endsWith(".properties")
             }
         log.info("[generateAnalysis] 확장자 필터링 후 파일 수: ${allFilePaths.size}")
 // 2단계: 동적 배치로 GLM 1차 호출 (최대한 많은 파일 경로 전달)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -15,6 +15,7 @@ import com.back.omos.global.exception.errorCode.AnalysisErrorCode
 import com.back.omos.global.exception.errorCode.AuthErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
 import com.back.omos.global.exception.exceptions.AuthException
+import com.back.omos.domain.analysis.github.GitHubIssueRes
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier
@@ -72,8 +73,9 @@ class ContextAnalyzerServiceImpl(
     /**
      * 분석 결과를 반환합니다.
      *
-     * 사용자별 캐시 확인 → 일일 횟수 제한 검사 → 이슈별 캐시 확인(재사용) → 신규 생성 순으로 처리합니다.
-     * 새로운 요청이 발생할 경우 [UserAnalysisRequest]를 저장하여 이력을 기록합니다.
+     * 사용자별 캐시 확인 → 일일 횟수 제한 검사 → 이슈별 캐시 확인(재사용/갱신) → 신규 생성 순으로 처리합니다.
+     * 캐시된 분석 결과가 [CACHE_VALIDITY_DAYS]일 이상 경과한 경우 GitHub API로 이슈 수정 여부를 확인하고,
+     * 수정된 경우 캐시를 무효화하고 재생성합니다.
      *
      * @param issueId 분석할 이슈의 식별자
      * @param githubId 요청한 사용자의 GitHub ID
@@ -88,6 +90,17 @@ class ContextAnalyzerServiceImpl(
                     "해당 이슈를 찾을 수 없습니다."
                 )
             }
+
+        // repoFullName 파싱을 상단으로 올림 (캐시 갱신 체크에 필요)
+        val parts = issue.repoFullName.split("/")
+        if (parts.size != 2) {
+            throw AnalysisException(
+                AnalysisErrorCode.GITHUB_API_FAIL,
+                "[ContextAnalyzerServiceImpl#resolveOrCreateAnalysis] repoFullName 형식이 올바르지 않습니다: ${issue.repoFullName}",
+                "레포지토리 정보가 올바르지 않습니다."
+            )
+        }
+        val (owner, repoName) = parts
 
         val user = userRepository.findByGithubIdWithLock(githubId)
             .orElseThrow {
@@ -114,8 +127,33 @@ class ContextAnalyzerServiceImpl(
             )
         }
 
-        // 이슈에 대한 분석 결과가 이미 존재하면 재사용, 없으면 신규 생성
-        val analysisResult = analysisResultRepository.findByIssueId(issueId) ?: generateAnalysis(issue)
+        // 이슈별 캐시 확인 + 갱신 체크
+        val cached = analysisResultRepository.findByIssueId(issueId)
+        val cacheThreshold = now.minusDays(CACHE_VALIDITY_DAYS)
+
+        val analysisResult = if (cached != null) {
+            if (cached.createdAt.isBefore(cacheThreshold)) {
+                // 캐시가 3일 이상 경과 → GitHub API로 이슈 수정 여부 확인
+                log.info("[resolveOrCreateAnalysis] 캐시 유효기간 초과, 이슈 수정 여부 확인: issueId=$issueId")
+                val latestIssue = gitHubClient.fetchIssue(owner, repoName, issue.issueNumber.toInt())
+
+                if (isIssueModifiedAfterAnalysis(latestIssue, cached)) {
+                    // 이슈 수정됨 → 캐시 무효화 후 재생성
+                    log.info("[resolveOrCreateAnalysis] 이슈 수정 감지, 캐시 무효화: issueId=$issueId")
+                    analysisResultRepository.delete(cached)
+                    analysisResultRepository.flush()
+                    generateAnalysis(issue)
+                } else {
+                    // 이슈 수정 안 됨 → 기존 캐시 반환
+                    cached
+                }
+            } else {
+                // 3일 이내 캐시 → 그대로 반환
+                cached
+            }
+        } else {
+            generateAnalysis(issue)
+        }
 
         // 사용자 분석 요청 이력 저장
         userAnalysisRequestRepository.save(
@@ -128,15 +166,15 @@ class ContextAnalyzerServiceImpl(
     /**
      * 이슈가 분석 이후 수정되었는지 판단합니다.
      *
-     * TODO: [getGuide], [getPseudoCode]의 캐시 갱신 조건으로 연결 필요.
-     *       현재 이 메서드는 호출되지 않으므로 캐시 무효화가 동작하지 않습니다.
+     * 캐시된 분석 결과의 createdAt과 GitHub API에서 가져온 이슈의 updatedAt을 비교합니다.
+     * [resolveOrCreateAnalysis]에서 캐시 유효기간([CACHE_VALIDITY_DAYS]일) 초과 시 호출됩니다.
      *
-     * @param issue 캐시 유효성을 검사할 이슈
+     * @param latestIssue GitHub API에서 가져온 최신 이슈 정보
      * @param result 비교 대상인 기존 분석 결과
-     * @return 이슈의 [Issue.updatedAt]이 분석 결과의 [AnalysisResult.createdAt]보다 늦으면 true
+     * @return 이슈의 updatedAt이 분석 결과의 createdAt보다 늦으면 true
      */
-    private fun isIssueModifiedAfterAnalysis(issue: Issue, result: AnalysisResult): Boolean {
-        return issue.updatedAt.isAfter(result.createdAt)
+    private fun isIssueModifiedAfterAnalysis(latestIssue: GitHubIssueRes, result: AnalysisResult): Boolean {
+        return latestIssue.updatedAt?.isAfter(result.createdAt) ?: false
     }
 
     /**
@@ -277,6 +315,8 @@ class ContextAnalyzerServiceImpl(
         private const val DAILY_REQUEST_LIMIT = 5L
         /** 파일당 최대 문자 수 (토큰 절약) */
         private const val MAX_FILE_CONTENT_LENGTH = 3000
+        /** 캐시 유효기간 (일). 이 기간이 지나면 GitHub API로 이슈 수정 여부를 확인. */
+        private const val CACHE_VALIDITY_DAYS = 3L
     }
 
     private fun toGuideDto(result: AnalysisResult): GuideResponseDto {

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -140,6 +140,7 @@ class ContextAnalyzerServiceImpl(
                 if (isIssueModifiedAfterAnalysis(latestIssue, cached)) {
                     // 이슈 수정됨 → 캐시 무효화 후 재생성
                     log.info("[resolveOrCreateAnalysis] 이슈 수정 감지, 캐시 무효화: issueId=$issueId")
+                    userAnalysisRequestRepository.deleteAllByAnalysisResultId(cached.id!!)
                     analysisResultRepository.delete(cached)
                     analysisResultRepository.flush()
                     generateAnalysis(issue, owner, repoName)

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import org.slf4j.LoggerFactory
+import java.time.ZoneId
 
 /**
  * [ContextAnalyzerService]의 핵심 비즈니스 로직을 담당하는 서비스 구현체입니다.
@@ -184,7 +185,10 @@ class ContextAnalyzerServiceImpl(
      * @return 이슈의 updatedAt이 분석 결과의 createdAt보다 늦으면 true
      */
     private fun isIssueModifiedAfterAnalysis(latestIssue: GitHubIssueRes, result: AnalysisResult): Boolean {
-        return latestIssue.updatedAt?.isAfter(result.createdAt) ?: false
+        val updatedAt = latestIssue.updatedAt ?: return false
+        // OffsetDateTime을 서버 시간대 기준 LocalDateTime으로 변환해서 비교
+        val updatedAtLocal = updatedAt.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()
+        return updatedAtLocal.isAfter(result.createdAt)
     }
 
     /**

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -142,7 +142,7 @@ class ContextAnalyzerServiceImpl(
                     log.info("[resolveOrCreateAnalysis] 이슈 수정 감지, 캐시 무효화: issueId=$issueId")
                     analysisResultRepository.delete(cached)
                     analysisResultRepository.flush()
-                    generateAnalysis(issue)
+                    generateAnalysis(issue, owner, repoName)
                 } else {
                     // 이슈 수정 안 됨 → 기존 캐시 반환
                     cached
@@ -152,7 +152,7 @@ class ContextAnalyzerServiceImpl(
                 cached
             }
         } else {
-            generateAnalysis(issue)
+            generateAnalysis(issue, owner, repoName)
         }
 
         // 사용자 분석 요청 이력 저장
@@ -181,29 +181,19 @@ class ContextAnalyzerServiceImpl(
      * GitHub API로 관련 소스코드를 수집하고 GLM API로 분석 결과를 생성한 뒤 저장합니다.
      *
      * 처리 흐름:
-     * 1. [Issue.repoFullName]에서 owner/repo 파싱
-     * 2. GitHub API로 이슈 상세 정보 fetch
-     * 3. GitHub Tree API로 전체 파일 경로 목록 fetch 후 확장자 필터링
-     * 4. 확장자 필터링된 경로 전체 + 이슈 → GLM 1차 호출로 관련 파일 선별
-     * 5. GraphQL로 선별된 파일 내용 한 번에 fetch
-     * 6. 파일 내용 파싱/가공 (주석 제거, 토큰 제한)
-     * 7. 파싱한 코드 + 이슈 → GLM 2차 호출로 가이드 생성
+     * 1. GitHub API로 이슈 상세 정보 fetch
+     * 2. GitHub Tree API로 전체 파일 경로 목록 fetch 후 확장자 필터링
+     * 3. 확장자 필터링된 경로 전체 + 이슈 → GLM 1차 호출로 관련 파일 선별 (동적 배치)
+     * 4. GraphQL로 선별된 파일 내용 한 번에 fetch
+     * 5. 파일 내용 파싱/가공 (주석 제거, 토큰 제한)
+     * 6. 파싱한 코드 + 이슈 → GLM 2차 호출로 가이드 생성
      *
      * @param issue 분석 대상 이슈
      * @return 저장된 [AnalysisResult]
      * @throws AnalysisException [Issue.repoFullName] 형식이 `owner/repo`가 아닌 경우,
      *                           또는 GitHub/GLM API 호출에 실패하는 경우
      */
-    private fun generateAnalysis(issue: Issue): AnalysisResult {
-        val parts = issue.repoFullName.split("/")
-        if (parts.size != 2) {
-            throw AnalysisException(
-                AnalysisErrorCode.GITHUB_API_FAIL,
-                "[ContextAnalyzerServiceImpl#generateAnalysis] repoFullName 형식이 올바르지 않습니다: ${issue.repoFullName}",
-                "레포지토리 정보가 올바르지 않습니다."
-            )
-        }
-        val (owner, repoName) = parts
+    private fun generateAnalysis(issue: Issue, owner: String, repoName: String): AnalysisResult {
 
         val issueInfo = gitHubClient.fetchIssue(owner, repoName, issue.issueNumber.toInt())
 

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -33,9 +33,10 @@ import org.slf4j.LoggerFactory
  * [AnalysisResultRepository]에 해당 이슈의 분석 결과가 존재하면 즉시 반환합니다.
  * 분석 결과가 없는 경우에만 GitHub API와 GLM API를 통해 새 분석 결과를 생성하고 저장합니다.
  *
- * <p><b>캐시 갱신 (미구현 — TODO):</b><br>
+ * <p><b>캐시 갱신:</b><br>
  * [isIssueModifiedAfterAnalysis]를 통해 이슈의 updatedAt과 분석 결과의 createdAt을 비교,
- * 이슈가 분석 이후 수정된 경우 가이드를 재생성하는 로직이 설계되어 있으나 아직 적용되지 않았습니다.
+ * 캐시 유효기간([CACHE_VALIDITY_DAYS]일) 초과 시 GitHub API로 이슈 수정 여부를 확인합니다.
+ * 수정된 경우 새 분석 결과를 생성하고 기존 [UserAnalysisRequest]는 새 결과로 업데이트합니다.
  *
  * <p><b>외부 모듈:</b><br>
  * GitHub API — 관련 소스코드 수집<br>
@@ -138,12 +139,20 @@ class ContextAnalyzerServiceImpl(
                 val latestIssue = gitHubClient.fetchIssue(owner, repoName, issue.issueNumber.toInt())
 
                 if (isIssueModifiedAfterAnalysis(latestIssue, cached)) {
-                    // 이슈 수정됨 → 캐시 무효화 후 재생성
+                    // 이슈 수정됨 → 새 결과 생성 후 기존 요청 업데이트 (이력 보존)
                     log.info("[resolveOrCreateAnalysis] 이슈 수정 감지, 캐시 무효화: issueId=$issueId")
-                    userAnalysisRequestRepository.deleteAllByAnalysisResultId(cached.id!!)
+
+                    // 1. 새 분석 결과 먼저 생성
+                    val newResult = generateAnalysis(issue, owner, repoName)
+
+                    // 2. 기존 UserAnalysisRequest를 새 결과로 업데이트 (daily count 보존)
+                    userAnalysisRequestRepository.updateAnalysisResult(cached.id!!, newResult)
+
+                    // 3. 기존 캐시 삭제
                     analysisResultRepository.delete(cached)
                     analysisResultRepository.flush()
-                    generateAnalysis(issue, owner, repoName)
+
+                    newResult
                 } else {
                     // 이슈 수정 안 됨 → 기존 캐시 반환
                     cached

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.analysis.service
 
+import org.mockito.Mockito.doNothing
 import com.back.omos.domain.analysis.ai.GlmAnalysisRes
 import com.back.omos.domain.analysis.ai.GlmClient
 import com.back.omos.domain.analysis.entity.AnalysisResult
@@ -245,6 +246,7 @@ class ContextAnalyzerServiceImplTest {
                 contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
             }
         }
+    }
 
         @Nested
         @DisplayName("getPseudoCode()")
@@ -362,7 +364,7 @@ class ContextAnalyzerServiceImplTest {
                 given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(recentResult)
                 given(userAnalysisRequestRepository.save(any())).willReturn(any())
 
-                val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+                val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
                 assertNotNull(result)
                 // fetchIssue 호출 안 됨
@@ -380,6 +382,7 @@ class ContextAnalyzerServiceImplTest {
                     sideEffects = "오래된 부작용"
                 )
                 ReflectionTestUtils.setField(oldResult, "createdAt", LocalDateTime.now().minusDays(4))
+                ReflectionTestUtils.setField(oldResult, "id", 999L)
 
                 val latestIssueInfo = GitHubIssueRes(
                     number = 42,
@@ -404,10 +407,10 @@ class ContextAnalyzerServiceImplTest {
                 given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(latestIssueInfo)
                 given(userAnalysisRequestRepository.save(any())).willReturn(any())
 
-                val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+                val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
                 assertNotNull(result)
-                assertEquals("오래된 가이드", result.guideline)
+                assertEquals("오래된 코드", result.pseudoCode)
                 then(analysisResultRepository).shouldHaveNoMoreInteractions()
             }
 
@@ -422,6 +425,7 @@ class ContextAnalyzerServiceImplTest {
                     sideEffects = "오래된 부작용"
                 )
                 ReflectionTestUtils.setField(oldResult, "createdAt", LocalDateTime.now().minusDays(4))
+                ReflectionTestUtils.setField(oldResult, "id", 999L)
 
                 val latestIssueInfo = GitHubIssueRes(
                     number = 42,
@@ -454,13 +458,15 @@ class ContextAnalyzerServiceImplTest {
                     .willReturn(GlmAnalysisRes(guideline = "새 가이드", pseudoCode = "새 코드", sideEffects = "새 부작용"))
                 given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
 
-                contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+                // 캐시 삭제 검증 전에 stub 추가
+                doNothing().`when`(userAnalysisRequestRepository).deleteAllByAnalysisResultId(any())
+                contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
-                // 캐시 삭제 검증
+                // 캐시 삭제 검증에도 추가
+                then(userAnalysisRequestRepository).should().deleteAllByAnalysisResultId(any())
                 then(analysisResultRepository).should().delete(oldResult)
                 then(analysisResultRepository).should().flush()
                 then(analysisResultRepository).should().save(any())
             }
         }
     }
-}

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -8,6 +8,7 @@ import com.back.omos.domain.analysis.github.GitHubClient
 import com.back.omos.domain.analysis.github.GitHubIssueRes
 import com.back.omos.domain.analysis.repository.AnalysisResultRepository
 import com.back.omos.domain.analysis.repository.UserAnalysisRequestRepository
+import org.springframework.test.util.ReflectionTestUtils
 import com.back.omos.domain.issue.entity.Issue
 import com.back.omos.domain.issue.repository.IssueRepository
 import com.back.omos.domain.user.entity.User
@@ -33,18 +34,26 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.springframework.test.context.ActiveProfiles
 import java.util.Optional
+import java.time.LocalDateTime
 
 @ExtendWith(MockitoExtension::class)
 @ActiveProfiles("test")
 class ContextAnalyzerServiceImplTest {
 
-    @Mock private lateinit var analysisResultRepository: AnalysisResultRepository
-    @Mock private lateinit var userAnalysisRequestRepository: UserAnalysisRequestRepository
-    @Mock private lateinit var issueRepository: IssueRepository
-    @Mock private lateinit var userRepository: UserRepository
-    @Mock private lateinit var gitHubClient: GitHubClient
-    @Mock private lateinit var glmClient: GlmClient
-    @Mock private lateinit var mockUser: User
+    @Mock
+    private lateinit var analysisResultRepository: AnalysisResultRepository
+    @Mock
+    private lateinit var userAnalysisRequestRepository: UserAnalysisRequestRepository
+    @Mock
+    private lateinit var issueRepository: IssueRepository
+    @Mock
+    private lateinit var userRepository: UserRepository
+    @Mock
+    private lateinit var gitHubClient: GitHubClient
+    @Mock
+    private lateinit var glmClient: GlmClient
+    @Mock
+    private lateinit var mockUser: User
 
     private lateinit var contextAnalyzerService: ContextAnalyzerServiceImpl
 
@@ -80,7 +89,8 @@ class ContextAnalyzerServiceImplTest {
         number = 42,
         title = "Fix NullPointerException",
         body = "이슈 본문",
-        labels = emptyList()
+        labels = emptyList(),
+        updatedAt = null
     )
 
     private val mockAnalysisResult = AnalysisResult(
@@ -145,8 +155,8 @@ class ContextAnalyzerServiceImplTest {
                 .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
             given(glmClient.selectFiles(any(), anyOrNull(), any()))
                 .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
-            given(gitHubClient.fetchFileContent("spring-projects", "spring-boot", "src/main/kotlin/com/example/UserService.kt"))
-                .willReturn("fun userService() { ... }")
+            given(gitHubClient.fetchFileContents(eq("spring-projects"), eq("spring-boot"), any()))
+                .willReturn(mapOf("src/main/kotlin/com/example/UserService.kt" to "fun userService() { ... }"))
             given(glmClient.analyze(any(), anyOrNull(), any(), any()))
                 .willReturn(GlmAnalysisRes(guideline = "가이드라인", pseudoCode = "의사코드", sideEffects = "부작용"))
             given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
@@ -208,12 +218,7 @@ class ContextAnalyzerServiceImplTest {
                 status = Issue.IssueStatus.OPEN
             )
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(badIssue))
-            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
-                .willReturn(null)
-            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
-                .willReturn(0L)
-            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
+            // 나머지 stub 다 제거!
 
             assertThrows<AnalysisException> {
                 contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
@@ -222,8 +227,8 @@ class ContextAnalyzerServiceImplTest {
         }
 
         @Test
-        @DisplayName("GLM이 빈 파일 목록을 반환하면 빈 맵으로 analyze()를 호출한다")
-        fun `GLM 빈 파일 목록 반환시 analyze 빈맵 호출`() {
+        @DisplayName("GLM이 모든 배치에서 빈 파일 목록을 반환하면 AnalysisException을 던진다")
+        fun `GLM 빈 파일 목록 반환시 예외 던짐`() {
             given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
             given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
             given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
@@ -235,112 +240,226 @@ class ContextAnalyzerServiceImplTest {
             given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
                 .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
             given(glmClient.selectFiles(any(), anyOrNull(), any())).willReturn(emptyList())
-            given(glmClient.analyze(any(), anyOrNull(), any(), eq(emptyMap())))
-                .willReturn(GlmAnalysisRes(guideline = "가이드", pseudoCode = "코드", sideEffects = "없음"))
-            given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
-
-            contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
-
-            then(glmClient).should().analyze(any(), anyOrNull(), any(), eq(emptyMap()))
-        }
-
-        @Test
-        @DisplayName("GLM이 후보 목록에 없는 경로를 반환하면 필터링 후 빈 맵으로 analyze()를 호출한다")
-        fun `GLM 비후보 경로 반환시 필터링 후 analyze 빈맵 호출`() {
-            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
-                .willReturn(null)
-            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
-                .willReturn(0L)
-            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(null)
-            given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(mockIssueInfo)
-            given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
-                .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
-            given(glmClient.selectFiles(any(), anyOrNull(), any()))
-                .willReturn(listOf("src/other/NotInCandidates.kt"))
-            given(glmClient.analyze(any(), anyOrNull(), any(), eq(emptyMap())))
-                .willReturn(GlmAnalysisRes(guideline = "가이드", pseudoCode = "코드", sideEffects = "없음"))
-            given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
-
-            contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
-
-            then(glmClient).should().analyze(any(), anyOrNull(), any(), eq(emptyMap()))
-        }
-    }
-
-    @Nested
-    @DisplayName("getPseudoCode()")
-    inner class GetPseudoCode {
-
-        @Test
-        @DisplayName("사용자 캐시 HIT - 동일 이슈에 재요청하면 GitHub API 호출 없이 즉시 반환한다")
-        fun `사용자 캐시 HIT시 즉시 반환`() {
-            val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
-            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
-                .willReturn(completedRequest)
-
-            val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
-
-            assertNotNull(result)
-            assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
-            then(gitHubClient).shouldHaveNoInteractions()
-        }
-
-        @Test
-        @DisplayName("이슈 캐시 HIT - 다른 사용자의 분석 결과가 있으면 재사용하고 요청 이력을 저장한다")
-        fun `이슈 캐시 HIT시 즉시 반환`() {
-            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
-                .willReturn(null)
-            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
-                .willReturn(0L)
-            given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(mockAnalysisResult)
-
-            val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
-
-            assertNotNull(result)
-            assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
-            then(gitHubClient).shouldHaveNoInteractions()
-            then(userAnalysisRequestRepository).should().save(any())
-        }
-
-        @Test
-        @DisplayName("이슈가 없으면 AnalysisException을 던진다")
-        fun `이슈 없으면 예외 던짐`() {
-            given(issueRepository.findById(999L)).willReturn(Optional.empty())
 
             assertThrows<AnalysisException> {
-                contextAnalyzerService.getPseudoCode(999L, GITHUB_ID)
+                contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
             }
         }
 
-        @Test
-        @DisplayName("사용자가 없으면 AuthException을 던진다")
-        fun `사용자 없으면 예외 던짐`() {
-            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.empty())
+        @Nested
+        @DisplayName("getPseudoCode()")
+        inner class GetPseudoCode {
 
-            assertThrows<AuthException> {
-                contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+            @Test
+            @DisplayName("사용자 캐시 HIT - 동일 이슈에 재요청하면 GitHub API 호출 없이 즉시 반환한다")
+            fun `사용자 캐시 HIT시 즉시 반환`() {
+                val completedRequest = UserAnalysisRequest(user = mockUser).apply { complete(mockAnalysisResult) }
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+                given(
+                    userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(
+                        eq(USER_ID),
+                        eq(ISSUE_ID)
+                    )
+                )
+                    .willReturn(completedRequest)
+
+                val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+
+                assertNotNull(result)
+                assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
+                then(gitHubClient).shouldHaveNoInteractions()
             }
-        }
 
-        @Test
-        @DisplayName("일일 분석 요청 횟수 초과 시 AnalysisException을 던진다")
-        fun `횟수 초과 시 예외 던짐`() {
-            given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
-            given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
-            given(userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(eq(USER_ID), eq(ISSUE_ID)))
-                .willReturn(null)
-            given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
-                .willReturn(5L)
+            @Test
+            @DisplayName("이슈 캐시 HIT - 다른 사용자의 분석 결과가 있으면 재사용하고 요청 이력을 저장한다")
+            fun `이슈 캐시 HIT시 즉시 반환`() {
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+                given(
+                    userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(
+                        eq(USER_ID),
+                        eq(ISSUE_ID)
+                    )
+                )
+                    .willReturn(null)
+                given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                    .willReturn(0L)
+                given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(mockAnalysisResult)
 
-            assertThrows<AnalysisException> {
-                contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+                val result = contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+
+                assertNotNull(result)
+                assertEquals("TODO: GLM 연동 후 실제 의사 코드 생성", result.pseudoCode)
+                then(gitHubClient).shouldHaveNoInteractions()
+                then(userAnalysisRequestRepository).should().save(any())
+            }
+
+            @Test
+            @DisplayName("이슈가 없으면 AnalysisException을 던진다")
+            fun `이슈 없으면 예외 던짐`() {
+                given(issueRepository.findById(999L)).willReturn(Optional.empty())
+
+                assertThrows<AnalysisException> {
+                    contextAnalyzerService.getPseudoCode(999L, GITHUB_ID)
+                }
+            }
+
+            @Test
+            @DisplayName("사용자가 없으면 AuthException을 던진다")
+            fun `사용자 없으면 예외 던짐`() {
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.empty())
+
+                assertThrows<AuthException> {
+                    contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+                }
+            }
+
+            @Test
+            @DisplayName("일일 분석 요청 횟수 초과 시 AnalysisException을 던진다")
+            fun `횟수 초과 시 예외 던짐`() {
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+                given(
+                    userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(
+                        eq(USER_ID),
+                        eq(ISSUE_ID)
+                    )
+                )
+                    .willReturn(null)
+                given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                    .willReturn(5L)
+
+                assertThrows<AnalysisException> {
+                    contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
+                }
+            }
+
+            @Test
+            @DisplayName("캐시 3일 이내 - GitHub API 호출 없이 기존 캐시 반환한다")
+            fun `캐시 3일 이내 기존 캐시 반환`() {
+                val recentResult = AnalysisResult(
+                    issue = mockIssue,
+                    filePaths = """["src/main/kotlin/com/example/UserService.kt"]""",
+                    guideline = "최신 가이드",
+                    pseudoCode = "최신 코드",
+                    sideEffects = "최신 부작용"
+                )
+                // createdAt 기본값이 현재 시각이라 그대로 두면 3일 이내
+
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+                given(
+                    userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(
+                        eq(USER_ID),
+                        eq(ISSUE_ID)
+                    )
+                )
+                    .willReturn(null)
+                given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                    .willReturn(0L)
+                given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(recentResult)
+                given(userAnalysisRequestRepository.save(any())).willReturn(any())
+
+                val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+
+                assertNotNull(result)
+                // fetchIssue 호출 안 됨
+                then(gitHubClient).shouldHaveNoInteractions()
+            }
+
+            @Test
+            @DisplayName("캐시 3일 초과 + 이슈 수정 안 됨 - 기존 캐시 반환한다")
+            fun `캐시 3일 초과 이슈 수정 안됨 기존 캐시 반환`() {
+                val oldResult = AnalysisResult(
+                    issue = mockIssue,
+                    filePaths = """["src/main/kotlin/com/example/UserService.kt"]""",
+                    guideline = "오래된 가이드",
+                    pseudoCode = "오래된 코드",
+                    sideEffects = "오래된 부작용"
+                )
+                ReflectionTestUtils.setField(oldResult, "createdAt", LocalDateTime.now().minusDays(4))
+
+                val latestIssueInfo = GitHubIssueRes(
+                    number = 42,
+                    title = "Fix NullPointerException",
+                    body = "이슈 본문",
+                    labels = emptyList(),
+                    updatedAt = LocalDateTime.now().minusDays(5)  // createdAt보다 이전
+                )
+
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+                given(
+                    userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(
+                        eq(USER_ID),
+                        eq(ISSUE_ID)
+                    )
+                )
+                    .willReturn(null)
+                given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                    .willReturn(0L)
+                given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(oldResult)
+                given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(latestIssueInfo)
+                given(userAnalysisRequestRepository.save(any())).willReturn(any())
+
+                val result = contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+
+                assertNotNull(result)
+                assertEquals("오래된 가이드", result.guideline)
+                then(analysisResultRepository).shouldHaveNoMoreInteractions()
+            }
+
+            @Test
+            @DisplayName("캐시 3일 초과 + 이슈 수정됨 - 캐시 삭제 후 재생성한다")
+            fun `캐시 3일 초과 이슈 수정됨 재생성`() {
+                val oldResult = AnalysisResult(
+                    issue = mockIssue,
+                    filePaths = """["src/main/kotlin/com/example/UserService.kt"]""",
+                    guideline = "오래된 가이드",
+                    pseudoCode = "오래된 코드",
+                    sideEffects = "오래된 부작용"
+                )
+                ReflectionTestUtils.setField(oldResult, "createdAt", LocalDateTime.now().minusDays(4))
+
+                val latestIssueInfo = GitHubIssueRes(
+                    number = 42,
+                    title = "Fix NullPointerException",
+                    body = "이슈 본문",
+                    labels = emptyList(),
+                    updatedAt = LocalDateTime.now()  // createdAt보다 최신
+                )
+
+                given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
+                given(userRepository.findByGithubIdWithLock(GITHUB_ID)).willReturn(Optional.of(mockUser))
+                given(
+                    userAnalysisRequestRepository.findFirstByUserIdAndAnalysisResultIssueId(
+                        eq(USER_ID),
+                        eq(ISSUE_ID)
+                    )
+                )
+                    .willReturn(null)
+                given(userAnalysisRequestRepository.countByUserIdAndCreatedAtBetween(any(), any(), any()))
+                    .willReturn(0L)
+                given(analysisResultRepository.findByIssueId(ISSUE_ID)).willReturn(oldResult)
+                given(gitHubClient.fetchIssue("spring-projects", "spring-boot", 42)).willReturn(latestIssueInfo)
+                given(gitHubClient.fetchTree("spring-projects", "spring-boot"))
+                    .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
+                given(glmClient.selectFiles(any(), anyOrNull(), any()))
+                    .willReturn(listOf("src/main/kotlin/com/example/UserService.kt"))
+                given(gitHubClient.fetchFileContents(eq("spring-projects"), eq("spring-boot"), any()))
+                    .willReturn(mapOf("src/main/kotlin/com/example/UserService.kt" to "fun userService() { ... }"))
+                given(glmClient.analyze(any(), anyOrNull(), any(), any()))
+                    .willReturn(GlmAnalysisRes(guideline = "새 가이드", pseudoCode = "새 코드", sideEffects = "새 부작용"))
+                given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
+
+                contextAnalyzerService.getGuide(ISSUE_ID, GITHUB_ID)
+
+                // 캐시 삭제 검증
+                then(analysisResultRepository).should().delete(oldResult)
+                then(analysisResultRepository).should().flush()
+                then(analysisResultRepository).should().save(any())
             }
         }
     }


### PR DESCRIPTION
<!--
[#110][FEAT] 이슈 수정 시 분석 결과 캐시 갱신 구현
-->

## 📝 요약
이슈가 수정된 이후에도 기존 분석 결과가 캐시로 남아 갱신되지 않던 문제를 해결했습니다.

캐시된 분석 결과가 3일 이상 경과한 경우 GitHub API로 이슈 수정 여부를 확인하고,
수정이 감지되면 기존 캐시를 무효화하고 재생성합니다.

## 🔗 관련 이슈
- Close #110

## 🛠️ 주요 변경 사항
- [x] `GitHubIssueRes`에 `updatedAt` 필드 추가 (`@JsonProperty("updated_at")`)
- [x] `repoFullName` 파싱을 `resolveOrCreateAnalysis()` 상단으로 이동 (캐시 갱신 체크에 필요)
- [x] 캐시 유효기간(`CACHE_VALIDITY_DAYS` = 3일) 초과 시 GitHub API로 이슈 수정 여부 확인
- [x] 이슈 수정 감지 시 기존 `AnalysisResult` 삭제(`flush`) 후 재생성
- [x] `isIssueModifiedAfterAnalysis()` 시그니처 변경 (`Issue` → `GitHubIssueRes`)
- [x] `CACHE_VALIDITY_DAYS` 상수 추가
- [x] `ContextAnalyzerServiceImplTest` 테스트 수정 및 케이스 추가
  - `repoFullName` 형식 오류 테스트 불필요 stub 제거
  - `fetchFileContent` → `fetchFileContents`(GraphQL) stub 교체
  - GLM 빈 파일 목록/비후보 경로 테스트 → `AnalysisException` 던짐으로 변경
  - 캐시 3일 이내 반환 케이스 추가
  - 캐시 3일 초과 + 이슈 수정 안 됨 케이스 추가
  - 캐시 3일 초과 + 이슈 수정됨 → 캐시 삭제 후 재생성 케이스 추가
  
## 🧪 테스트 결과
<img width="688" height="513" alt="image" src="https://github.com/user-attachments/assets/247710f0-7aea-43a5-ad5d-17dd6f471471" />
`ContextAnalyzerServiceImplTest` 전체 통과

(RecommendServiceTest에서 컴파일 에러가 발생하여 임시 주석 처리 후 진행했습니다.)

## 🧐 리뷰어에게
-  캐시 갱신 주기를 3일(`CACHE_VALIDITY_DAYS`)로 설정했습니다.
이슈 수정이 빈번하지 않고 매 요청마다 GitHub API를 호출하면
Rate Limit(5,000회/시간)에 영향을 줄 수 있어 3일 텀을 두었습니다.
텀 조정이 필요하면 상수만 변경하면 됩니다.

-  `delete()` 후 `flush()`를 명시적으로 호출한 이유는
`analysis_results.issue_id`의 UNIQUE 제약으로 인해
같은 트랜잭션 내에서 삭제 후 즉시 삽입 시 중복 키 에러가 발생하기 때문입니다.

-  기존 코드 파일(.kt, .java, .py 등) 외
설정 파일(.json, .yaml, .yml, .toml, .gradle, .properties)
마크업 파일(.html, .css, .scss, .xml, .md) 추가
