### PR TITLE
[FIX] GitHubIssueRes.updatedAt OffsetDateTime 변경에 따른 테스트 컴파일 오류 수정

### DIFF
--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImplTest.kt
@@ -36,6 +36,7 @@ import org.mockito.kotlin.eq
 import org.springframework.test.context.ActiveProfiles
 import java.util.Optional
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 @ExtendWith(MockitoExtension::class)
 @ActiveProfiles("test")
@@ -389,7 +390,7 @@ class ContextAnalyzerServiceImplTest {
                     title = "Fix NullPointerException",
                     body = "이슈 본문",
                     labels = emptyList(),
-                    updatedAt = LocalDateTime.now().minusDays(5)  // createdAt보다 이전
+                    updatedAt = OffsetDateTime.now().minusDays(5)  // createdAt보다 이전
                 )
 
                 given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
@@ -432,7 +433,7 @@ class ContextAnalyzerServiceImplTest {
                     title = "Fix NullPointerException",
                     body = "이슈 본문",
                     labels = emptyList(),
-                    updatedAt = LocalDateTime.now()  // createdAt보다 최신
+                    updatedAt = OffsetDateTime.now()  // createdAt보다 최신
                 )
 
                 given(issueRepository.findById(ISSUE_ID)).willReturn(Optional.of(mockIssue))
@@ -459,11 +460,10 @@ class ContextAnalyzerServiceImplTest {
                 given(analysisResultRepository.save(any())).willReturn(mockAnalysisResult)
 
                 // 캐시 삭제 검증 전에 stub 추가
-                doNothing().`when`(userAnalysisRequestRepository).deleteAllByAnalysisResultId(any())
                 contextAnalyzerService.getPseudoCode(ISSUE_ID, GITHUB_ID)
 
                 // 캐시 삭제 검증에도 추가
-                then(userAnalysisRequestRepository).should().deleteAllByAnalysisResultId(any())
+                then(userAnalysisRequestRepository).should().updateAnalysisResult(eq(999L), any())
                 then(analysisResultRepository).should().delete(oldResult)
                 then(analysisResultRepository).should().flush()
                 then(analysisResultRepository).should().save(any())


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
GitHubIssueRes.updatedAt LocalDateTime → OffsetDateTime 변경으로 인한
테스트 컴파일 오류 수정 및 stub 교체

## 🔗 관련 이슈
- Close #117

## 🛠️ 주요 변경 사항
- [x] 테스트에서 updatedAt 타입 LocalDateTime → OffsetDateTime으로 변경
- [x] deleteAllByAnalysisResultId stub → updateAnalysisResult stub으로 교체
- [x] deleteAllByAnalysisResultId 검증 → updateAnalysisResult 검증으로 교체
## 🧪 테스트 결과
<img width="640" height="268" alt="image" src="https://github.com/user-attachments/assets/fa922e1c-f051-4f71-83a6-cf08153ab8cc" />
