### PR TITLE
[FEAT] langfuse 기반 analysis 프롬프트 개선

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmClientImpl.kt
@@ -1,11 +1,15 @@
 package com.back.omos.domain.analysis.ai
 
+import com.back.omos.global.ai.LangfuseClient
 import com.back.omos.global.exception.errorCode.AnalysisErrorCode
 import com.back.omos.global.exception.exceptions.AnalysisException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.stereotype.Component
+import org.springframework.ai.chat.prompt.Prompt
+import java.time.Instant
+import java.util.concurrent.Executors
 
 /**
  * Spring AI [ChatModel]을 통해 GLM API를 호출하는 [GlmClient] 구현체입니다.
@@ -13,6 +17,8 @@ import org.springframework.stereotype.Component
  * 이슈 정보와 관련 소스코드를 프롬프트로 구성하여 GLM API에 전달하고,
  * JSON 형태의 응답을 파싱하여 [GlmAnalysisRes]로 반환합니다.
  *
+ * 각 AI 호출의 프롬프트·응답·응답시간은 [LangfuseClient]를 통해 비동기로 기록됩니다.
+ * Langfuse 미설정 시 기록을 건너뛰므로 기능에는 영향을 주지 않습니다.
  * @author Jaewon Ryu
  * @since 2026-04-25
  * @see GlmClient
@@ -20,8 +26,16 @@ import org.springframework.stereotype.Component
 @Component
 class GlmClientImpl(
     private val chatModel: ChatModel,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val langfuseClient: LangfuseClient,
+    private val promptBuilder: GlmPromptBuilder
 ) : GlmClient {
+
+    companion object {
+        private const val GENERATION_SELECT_FILES = "select-files-${GlmPromptBuilder.PROMPT_VERSION_SELECT_FILES}"
+        private const val GENERATION_ANALYZE = "analyze-${GlmPromptBuilder.PROMPT_VERSION_ANALYZE}"
+        private val judgeExecutor = Executors.newFixedThreadPool(2)
+    }
 
     private val log = LoggerFactory.getLogger(GlmClientImpl::class.java)
 
@@ -30,6 +44,7 @@ class GlmClientImpl(
      *
      * 프롬프트를 구성하여 [ChatModel]에 전달하고, JSON 응답을 [GlmAnalysisRes]로 파싱합니다.
      * 응답이 null이거나 JSON 파싱에 실패하면 [AnalysisException]을 던집니다.
+     * 호출 전후로 시각을 측정하여 응답시간·토큰 수를 [LangfuseClient]에 비동기로 기록합니다.
      *
      * @param issueTitle 분석 대상 이슈 제목
      * @param issueBody 분석 대상 이슈 본문 (없으면 null)
@@ -44,17 +59,35 @@ class GlmClientImpl(
         labels: List<String>,
         fileContents: Map<String, String>
     ): GlmAnalysisRes {
-        val prompt = buildPrompt(issueTitle, issueBody, labels, fileContents)
+        val prompt = promptBuilder.buildAnalyzePrompt(issueTitle, issueBody, labels, fileContents)
 
         return try {
-            val response = chatModel.call(prompt)
+            val startTime = Instant.now()
+            val chatResponse = chatModel.call(Prompt(prompt))
+            val endTime = Instant.now()
+
+            val response = chatResponse.result.output.text
                 ?: throw AnalysisException(
                     AnalysisErrorCode.GLM_API_FAIL,
                     "[GlmClientImpl#analyze] GLM 응답이 null입니다.",
                     "코드 분석에 실패했습니다."
                 )
+            val usage = chatResponse.metadata.usage
+            val traceId = langfuseClient.recordGeneration(
+                name = GENERATION_ANALYZE,
+                input = prompt,
+                output = response,
+                startTime = startTime,
+                endTime = endTime,
+                inputTokens = usage?.promptTokens?.toInt(),
+                outputTokens = usage?.completionTokens?.toInt()
+            )
 
-            parseResponse(response)
+            val result = parseResponse(response)
+            if (traceId != null) {
+                evaluateAnalyzeAsync(traceId, prompt, result)
+            }
+            return result
 
         } catch (e: AnalysisException) {
             throw e
@@ -73,6 +106,7 @@ class GlmClientImpl(
      *
      * 이슈 해결에 수정이 필요한 파일을 최대 5개 선별하여 반환합니다.
      * JSON 파싱에 실패하거나 API 호출이 실패하면 [AnalysisException]을 던집니다.
+     * 호출 전후로 시각을 측정하여 응답시간·토큰 수를 [LangfuseClient]에 비동기로 기록합니다.
      *
      * @param issueTitle 분석 대상 이슈 제목
      * @param issueBody 분석 대상 이슈 본문 (없으면 null)
@@ -85,16 +119,37 @@ class GlmClientImpl(
         issueBody: String?,
         filePaths: List<String>
     ): List<String> {
-        val prompt = buildSelectFilesPrompt(issueTitle, issueBody, filePaths)
+        val prompt = promptBuilder.buildSelectFilesPrompt(issueTitle, issueBody, filePaths)
 
         return try {
-            val response = chatModel.call(prompt)
+            val startTime = Instant.now()
+            val chatResponse = chatModel.call(Prompt(prompt))
+            val endTime = Instant.now()
+
+            val response = chatResponse.result.output.text
                 ?: throw AnalysisException(
                     AnalysisErrorCode.GLM_API_FAIL,
                     "[GlmClientImpl#selectFiles] GLM 응답이 null입니다.",
                     "관련 파일 탐색에 실패했습니다."
                 )
-            parseFileList(response)
+            val usage = chatResponse.metadata.usage
+            val traceId = langfuseClient.recordGeneration(
+                name = GENERATION_SELECT_FILES,
+                input = prompt,
+                output = response,
+                startTime = startTime,
+                endTime = endTime,
+                inputTokens = usage?.promptTokens?.toInt(),
+                outputTokens = usage?.completionTokens?.toInt()
+            )
+
+            val result = parseFileList(response)
+
+            if (traceId != null) {
+                evaluateSelectFilesAsync(traceId, issueTitle, issueBody, filePaths, result)
+            }
+
+            return result
         } catch (e: AnalysisException) {
             throw e
         } catch (e: Exception) {
@@ -105,40 +160,6 @@ class GlmClientImpl(
                 "관련 파일 탐색에 실패했습니다."
             )
         }
-    }
-
-    /**
-     * 파일 선별 요청을 위한 프롬프트를 구성합니다.
-     *
-     * GLM이 반드시 `{ "files": [...] }` 형태의 JSON만 반환하도록 지시합니다.
-     *
-     * @param issueTitle 이슈 제목
-     * @param issueBody 이슈 본문 (없으면 null)
-     * @param filePaths 선별 대상 파일 경로 목록
-     * @return GLM API에 전달할 프롬프트 문자열
-     */
-    private fun buildSelectFilesPrompt(
-        issueTitle: String,
-        issueBody: String?,
-        filePaths: List<String>
-    ): String {
-        return """
-    아래 이슈를 해결하기 위해 수정이 필요한 파일을 골라줘.
-    반드시 아래 JSON 형식으로만 응답해. 설명이나 마크다운 없이 JSON만 출력해.
-    최대 5개까지만 선택해.
-    
-    [이슈 내용]
-    제목: $issueTitle
-    본문: ${issueBody ?: "내용 없음"}
-    
-    [파일 목록]
-    ${filePaths.joinToString("\n")}
-    
-    [출력 형식]
-    {
-        "files": ["파일경로1", "파일경로2"]
-    }
-    """.trimIndent()
     }
 
     /**
@@ -177,51 +198,6 @@ class GlmClientImpl(
         }
     }
 
-    /**
-     * 코드 분석 요청을 위한 프롬프트를 구성합니다.
-     *
-     * 이슈 제목·본문·라벨과 관련 소스코드를 포함하며,
-     * GLM이 반드시 `guideline`, `pseudoCode`, `sideEffects` 필드를 가진
-     * JSON만 반환하도록 지시합니다.
-     *
-     * @param issueTitle 이슈 제목
-     * @param issueBody 이슈 본문 (없으면 null)
-     * @param labels 이슈 라벨 목록
-     * @param fileContents 관련 파일 경로와 내용의 맵 (key: 파일 경로, value: 파일 내용)
-     * @return GLM API에 전달할 프롬프트 문자열
-     */
-    private fun buildPrompt(
-        issueTitle: String,
-        issueBody: String?,
-        labels: List<String>,
-        fileContents: Map<String, String>
-    ): String {
-        val filesSection = fileContents.entries.joinToString("\n\n") { (path, content) ->
-            "### $path\n```\n$content\n```"
-        }
-
-        return """
-        이 이슈를 해결하려면 어떤 파일을 수정해야 하는지 알려주고, 수정 방향을 설명해줘.
-        반드시 아래 JSON 형식으로만 응답해줘. 설명이나 마크다운 없이 JSON만 출력해.
-        
-        [이슈 내용]
-        제목: $issueTitle
-        라벨: ${labels.joinToString(", ")}
-        본문: ${issueBody ?: "내용 없음"}
-        
-        [관련 코드]
-        $filesSection
-        
-        [출력 형식]
-        {
-            "guideline": "수정 방향 설명 (한국어)",
-            "pseudoCode": "수정이 필요한 파일과 위치, 변경 방향만 간략히 알려줘. 
-               완전한 코드를 작성하지 말고, 어느 함수/클래스의 어느 부분을 
-               어떤 방향으로 바꿔야 하는지만 설명해줘.",
-            "sideEffects": "수정 시 발생할 수 있는 부작용 (한국어)"
-        }
-        """.trimIndent()
-    }
 
     /**
      * GLM API 응답 JSON을 [GlmAnalysisRes]로 파싱합니다.
@@ -249,5 +225,104 @@ class GlmClientImpl(
                 "코드 분석 결과를 처리하는 데 실패했습니다."
             )
         }
+    }
+
+    private fun evaluateSelectFilesAsync(
+        traceId: String,
+        issueTitle: String,
+        issueBody: String?,
+        candidates: List<String>,
+        selected: List<String>
+    ) {
+        judgeExecutor.submit {
+            try {
+                val judgePrompt = """
+                아래 파일 선별 결과가 이슈 해결에 얼마나 적절한지 평가해줘.
+
+                [이슈 제목]
+                $issueTitle
+
+                [이슈 본문]
+                ${issueBody ?: "내용 없음"}
+
+                [전체 후보 파일 수]
+                ${candidates.size}개
+
+                [선별된 파일]
+                ${selected.joinToString("\n")}
+
+[평가 기준]
+- 선별된 파일이 이슈 제목/본문의 핵심 키워드와 직접 관련 있는가?
+  (모두 관련: 4점, 절반 이상 관련: 2점, 절반 미만 관련: 0점)
+- 이슈 해결에 필요한 핵심 파일이 포함됐는가?
+  (핵심 파일 명확히 포함: 3점, 불확실: 1점, 누락 의심: 0점)
+- 관련 없는 파일이 포함됐는가?
+  (없음: 3점, 1개: 1점, 2개 이상: 0점)
+
+                반드시 아래 JSON 형식으로만 응답해.
+                {"score": 7.5, "reason": "채점 근거 한 줄"}
+            """.trimIndent()
+
+                val judgeResponse = chatModel.call(judgePrompt) ?: return@submit
+                val json = extractJson(judgeResponse) ?: return@submit
+                val node = objectMapper.readTree(json)
+                val score = node.get("score")?.asDouble() ?: return@submit
+                val reason = node.get("reason")?.asText() ?: ""
+
+                langfuseClient.recordScore(traceId, score, reason)
+                log.debug("selectFiles judge 채점 완료: score=$score")
+            } catch (e: Exception) {
+                log.warn("selectFiles judge 채점 실패 (무시됨): ${e.message}")
+            }
+        }
+    }
+
+    private fun evaluateAnalyzeAsync(traceId: String, originalPrompt: String, result: GlmAnalysisRes) {
+        judgeExecutor.submit {
+            try {
+                val judgePrompt = """
+                아래 코드 분석 결과가 이슈와 코드 내용을 얼마나 잘 반영했는지 평가해줘.
+
+                [원본 프롬프트 (이슈 + 코드 포함)]
+                $originalPrompt
+
+                [생성된 분석 결과]
+                guideline: ${result.guideline}
+                pseudoCode: ${result.pseudoCode}
+                sideEffects: ${result.sideEffects}
+
+[평가 기준]
+- guideline이 이슈의 핵심 원인을 정확히 짚는가?
+  (정확히 짚음: 3점, 부분적: 1점, 엉뚱함: 0점)
+- pseudoCode가 구체적인 파일경로와 함수명을 포함하는가?
+  (둘 다 있음: 3점, 하나만: 1점, 없음: 0점)
+- sideEffects가 실제 발생 가능한 내용인가?
+  (현실적: 2점, 모호함: 1점, 없거나 엉뚱함: 0점)
+- 없는 내용을 만들어내지 않았는가?
+  (hallucination 없음: 2점, 있음: 0점)
+
+                반드시 아래 JSON 형식으로만 응답해.
+                {"score": 7.5, "reason": "채점 근거 한 줄"}
+            """.trimIndent()
+
+                val judgeResponse = chatModel.call(judgePrompt) ?: return@submit
+                val json = extractJson(judgeResponse) ?: return@submit
+                val node = objectMapper.readTree(json)
+                val score = node.get("score")?.asDouble() ?: return@submit
+                val reason = node.get("reason")?.asText() ?: ""
+
+                langfuseClient.recordScore(traceId, score, reason)
+                log.debug("analyze judge 채점 완료: score=$score")
+            } catch (e: Exception) {
+                log.warn("analyze judge 채점 실패 (무시됨): ${e.message}")
+            }
+        }
+    }
+
+    private fun extractJson(response: String): String? {
+        val fenceMatch = Regex("""```(?:json)?\s*([\s\S]*?)```""").find(response)
+        if (fenceMatch != null) return fenceMatch.groupValues[1].trim()
+        val candidate = Regex("""\{[\s\S]*\}""").find(response)?.value ?: return null
+        return runCatching { objectMapper.readTree(candidate); candidate }.getOrNull()
     }
 }

--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/ai/GlmPromptBuilder.kt
@@ -1,0 +1,129 @@
+package com.back.omos.domain.analysis.ai
+
+import org.springframework.stereotype.Component
+
+/**
+ * GLM API 호출을 위한 프롬프트를 구성하는 클래스입니다.
+ *
+ * <p>
+ * 이슈 정보와 파일 목록/내용을 기반으로 GLM에 전달할 프롬프트 문자열을 생성합니다.
+ * 프롬프트를 수정할 때 [PROMPT_VERSION_SELECT_FILES] 또는 [PROMPT_VERSION_ANALYZE]를
+ * 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
+ * </p>
+ *
+ * @author Jaewon Ryu
+ * @since 2026-05-06
+ */
+
+@Component
+class GlmPromptBuilder {
+
+    companion object {
+        const val PROMPT_VERSION_SELECT_FILES = "v4"
+        const val PROMPT_VERSION_ANALYZE = "v4"
+    }
+    /**
+     * 이슈 해결에 필요한 파일 선별을 위한 프롬프트를 구성합니다.
+     *
+     * GLM이 반드시 `{ "files": [...] }` 형태의 JSON만 반환하도록 지시합니다.
+     *
+     * @param issueTitle 이슈 제목
+     * @param issueBody 이슈 본문 (없으면 null)
+     * @param filePaths 선별 대상 파일 경로 목록
+     * @return GLM API에 전달할 프롬프트 문자열
+     */
+    fun buildSelectFilesPrompt(
+        issueTitle: String,
+        issueBody: String?,
+        filePaths: List<String>
+    ): String {
+        return """
+    당신은 오픈소스 기여를 돕는 코드 분석 전문가입니다.
+    아래 이슈를 해결하기 위해 수정이 필요한 파일을 선별해주세요.
+
+    [사고 순서]
+    1. 이슈의 핵심 키워드와 변경 범위를 파악하세요.
+    2. 키워드와 관련된 파일을 후보 목록에서 찾으세요.
+    3. 확실히 관련 없는 파일은 제외하세요.
+
+    [예시]
+    이슈: "Button color doesn't change with custom theme"
+    선별 파일: ["src/gui/theme/ThemeManager.java", "src/gui/MainWindow.java"]
+
+    이슈: "NPE when opening entry editor with empty field"
+    선별 파일: ["src/gui/entryeditor/EntryEditor.java", "src/model/entry/BibEntry.java"]
+
+    [규칙]
+    - 반드시 아래 JSON 형식으로만 응답하세요. 설명이나 마크다운 없이 JSON만 출력하세요.
+    - 이슈 해결에 필요한 파일을 빠짐없이 선택하세요.
+    - 최대 10개까지 선택하세요.
+
+    [이슈 내용]
+    제목: $issueTitle
+    본문: ${issueBody ?: "내용 없음"}
+
+    [후보 파일 목록]
+    ${filePaths.joinToString("\n")}
+
+    [출력 형식]
+    {
+        "files": ["파일경로1", "파일경로2"]
+    }
+""".trimIndent()
+    }
+    /**
+     * 이슈와 관련 코드를 기반으로 수정 가이드 생성을 위한 프롬프트를 구성합니다.
+     *
+     * 이슈 제목·본문·라벨과 관련 소스코드를 포함하며,
+     * GLM이 반드시 `guideline`, `pseudoCode`, `sideEffects` 필드를 가진
+     * JSON만 반환하도록 지시합니다.
+     *
+     * @param issueTitle 이슈 제목
+     * @param issueBody 이슈 본문 (없으면 null)
+     * @param labels 이슈 라벨 목록
+     * @param fileContents 관련 파일 경로와 내용의 맵 (key: 파일 경로, value: 파일 내용)
+     * @return GLM API에 전달할 프롬프트 문자열
+     */
+    fun buildAnalyzePrompt(
+        issueTitle: String,
+        issueBody: String?,
+        labels: List<String>,
+        fileContents: Map<String, String>
+    ): String {
+        val filesSection = fileContents.entries.joinToString("\n\n") { (path, content) ->
+            "### $path\n```\n$content\n```"
+        }
+        val labelsSection = if (labels.isEmpty()) "없음" else labels.joinToString(", ")
+        return """
+    당신은 오픈소스 기여를 돕는 코드 분석 전문가입니다.
+    아래 이슈와 관련 코드를 분석하여 수정 가이드를 작성해주세요.
+
+[사고 순서]
+1. 이슈에서 요구하는 변경 유형을 파악하세요 (버그수정/기능추가/리팩토링).
+2. 이슈 본문에 명시된 내용만 근거로 사용하세요. 없는 내용(Priority 3 등)을 임의로 추가하지 마세요.
+3. 제공된 코드에서 관련 부분을 찾으세요. 없더라도 이슈 내용을 기반으로 수정 방향을 추론하세요.
+4. pseudoCode는 파일경로 > 클래스/함수 단위로 구체적으로 서술하세요.
+
+    [규칙]
+    - 반드시 아래 JSON 형식으로만 응답하세요. 설명이나 마크다운 없이 JSON만 출력하세요.
+    - 코드와 파일 경로, 함수명은 원문 그대로 사용하세요 (번역 금지).
+    - guideline, sideEffects는 한국어로 작성하세요.
+    - pseudoCode는 완전한 코드가 아닌 변경 방향 설명이어야 합니다.
+
+    [이슈 내용]
+    제목: $issueTitle
+    라벨: $labelsSection
+    본문: ${issueBody ?: "내용 없음"}
+
+    [관련 코드]
+    $filesSection
+
+    [출력 형식]
+    {
+        "guideline": "이슈의 원인과 전체적인 수정 방향 설명 (한국어, 하나의 문자열로)",
+        "pseudoCode": "수정이 필요한 파일경로 > 클래스/함수명: 변경 방향 설명. 완전한 코드 작성 금지.배열이 아닌 하나의 문자열로 작성",
+        "sideEffects": "이 수정으로 인해 발생할 수 있는 부작용 또는 주의사항 (한국어, 하나의 문자열로)"
+    }
+""".trimIndent()
+    }
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/ai/GlmClientImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/ai/GlmClientImplTest.kt
@@ -1,5 +1,6 @@
 package com.back.omos.domain.analysis.ai
 
+import com.back.omos.global.ai.LangfuseClient
 import com.back.omos.global.exception.exceptions.AnalysisException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -14,6 +15,11 @@ import org.mockito.BDDMockito.given
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.mockito.quality.Strictness
+import org.mockito.junit.jupiter.MockitoSettings
 
 /**
  * GlmClientImpl 단위 테스트
@@ -25,6 +31,7 @@ import org.springframework.ai.chat.model.ChatModel
  * @since 2026-04-29
  */
 @ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("GlmClientImpl 단위 테스트")
 class GlmClientImplTest {
 
@@ -36,9 +43,20 @@ class GlmClientImplTest {
 
     private lateinit var glmClientImpl: GlmClientImpl
 
+    @Mock
+    private lateinit var langfuseClient: LangfuseClient
+
+    private val promptBuilder = GlmPromptBuilder()
+
     @BeforeEach
     fun setUp() {
-        glmClientImpl = GlmClientImpl(chatModel, objectMapper)
+        glmClientImpl = GlmClientImpl(chatModel, objectMapper, langfuseClient, promptBuilder)
+    }
+
+    private fun mockResponse(content: String): ChatResponse {
+        val message = org.springframework.ai.chat.messages.AssistantMessage(content)
+        val generation = Generation(message)
+        return ChatResponse(listOf(generation))
     }
 
     // ──────────────────────────────────────────
@@ -53,8 +71,8 @@ class GlmClientImplTest {
         @DisplayName("정상 JSON 응답을 파일 경로 목록으로 파싱한다")
         fun `정상 JSON 파싱 성공`() {
             // given
-            given(chatModel.call(any<String>()))
-                .willReturn("""{"files": ["src/a.kt", "src/b.kt"]}""")
+            given(chatModel.call(any<Prompt>()))
+                .willReturn(mockResponse("""{"files": ["src/a.kt", "src/b.kt"]}"""))
 
             // when
             val result = glmClientImpl.selectFiles("Fix bug", null, listOf("src/a.kt", "src/b.kt"))
@@ -68,7 +86,7 @@ class GlmClientImplTest {
         fun `마크다운 코드블록 응답 파싱 성공`() {
             // given: ```json ... ``` 래핑된 응답
             val response = "```json\n{\"files\": [\"src/a.kt\"]}\n```"
-            given(chatModel.call(any<String>())).willReturn(response)
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse("```json\n{\"files\": [\"src/a.kt\"]}\n```"))
 
             // when
             val result = glmClientImpl.selectFiles("Fix bug", null, listOf("src/a.kt"))
@@ -81,7 +99,7 @@ class GlmClientImplTest {
         @DisplayName("'files' 키가 없는 JSON 응답이면 AnalysisException을 던진다")
         fun `files 키 없으면 예외`() {
             // given: files 키 없는 올바른 JSON
-            given(chatModel.call(any<String>())).willReturn("""{"other": []}""")
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse("""{"other": []}"""))
 
             // when & then
             assertThrows(AnalysisException::class.java) {
@@ -93,7 +111,7 @@ class GlmClientImplTest {
         @DisplayName("JSON 형식이 깨진 응답이면 AnalysisException을 던진다")
         fun `JSON 형식 오류시 예외`() {
             // given: JSON이 아닌 문자열
-            given(chatModel.call(any<String>())).willReturn("not json at all")
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse("not json at all"))
 
             // when & then
             assertThrows(AnalysisException::class.java) {
@@ -114,7 +132,7 @@ class GlmClientImplTest {
         @DisplayName("chatModel.call()이 null을 반환하면 AnalysisException을 던진다")
         fun `chatModel null 반환시 예외`() {
             // given
-            given(chatModel.call(any<String>())).willReturn(null)
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse(""))
 
             // when & then
             assertThrows(AnalysisException::class.java) {
@@ -126,7 +144,7 @@ class GlmClientImplTest {
         @DisplayName("chatModel.call()이 RuntimeException을 던지면 AnalysisException으로 래핑한다")
         fun `chatModel RuntimeException시 AnalysisException 래핑`() {
             // given: 네트워크 오류 등 런타임 예외 시뮬레이션
-            given(chatModel.call(any<String>())).willThrow(RuntimeException("API connection error"))
+            given(chatModel.call(any<Prompt>())).willThrow(RuntimeException("API connection error"))
 
             // when & then
             assertThrows(AnalysisException::class.java) {
@@ -147,7 +165,7 @@ class GlmClientImplTest {
         @DisplayName("chatModel.call()이 null을 반환하면 AnalysisException을 던진다")
         fun `chatModel null 반환시 예외`() {
             // given
-            given(chatModel.call(any<String>())).willReturn(null)
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse(""))
 
             // when & then
             assertThrows(AnalysisException::class.java) {
@@ -159,7 +177,7 @@ class GlmClientImplTest {
         @DisplayName("chatModel.call()이 RuntimeException을 던지면 AnalysisException으로 래핑한다")
         fun `chatModel RuntimeException시 AnalysisException 래핑`() {
             // given
-            given(chatModel.call(any<String>())).willThrow(RuntimeException("API connection error"))
+            given(chatModel.call(any<Prompt>())).willThrow(RuntimeException("API connection error"))
 
             // when & then
             assertThrows(AnalysisException::class.java) {
@@ -178,7 +196,7 @@ class GlmClientImplTest {
                     "sideEffects": "기존 null 반환에 의존하던 코드 영향 가능"
                 }
             """.trimIndent()
-            given(chatModel.call(any<String>())).willReturn(json)
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse(json))
 
             // when
             val result = glmClientImpl.analyze("Fix NullPointerException", "본문", listOf("bug"), emptyMap())
@@ -193,7 +211,7 @@ class GlmClientImplTest {
         @DisplayName("GlmAnalysisRes로 파싱할 수 없는 JSON 응답이면 AnalysisException을 던진다")
         fun `파싱 불가 JSON 응답시 예외`() {
             // given: 필수 필드가 누락된 JSON (GlmAnalysisRes 역직렬화 실패)
-            given(chatModel.call(any<String>())).willReturn("broken json")
+            given(chatModel.call(any<Prompt>())).willReturn(mockResponse("broken json"))
 
             // when & then
             assertThrows(AnalysisException::class.java) {

--- a/omos/src/test/kotlin/com/back/omos/domain/analysis/ai/GlmPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/analysis/ai/GlmPromptEvalTest.kt
@@ -1,0 +1,200 @@
+package com.back.omos.domain.analysis.ai
+
+import com.back.omos.domain.analysis.github.GitHubClient
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.io.File
+
+/**
+ * 프롬프트 버전별 성능을 비교하기 위한 평가 테스트입니다.
+ *
+ * 고정된 이슈 샘플 5종으로 selectFiles → analyze 파이프라인을 실행하고
+ * 결과를 Langfuse에 자동 기록합니다.
+ * 프롬프트를 수정할 때마다 이 테스트를 실행하여 버전 간 score/latency를 비교하세요.
+ *
+ * 실행 후 localhost:3001 → Traces에서 결과를 확인합니다.
+ *
+ * @author Jaewon Ryu
+ * @since 2026-05-06
+ */
+@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
+@SpringBootTest
+@ActiveProfiles("test")
+class GlmPromptEvalTest {
+
+    @Autowired
+    private lateinit var glmClient: GlmClient
+
+    @Autowired
+    @Qualifier("analysisGitHubClientImpl")
+    private lateinit var gitHubClient: GitHubClient
+
+    companion object {
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun loadDotEnv(registry: DynamicPropertyRegistry) {
+            val envFile = File(".env").takeIf { it.exists() }
+                ?: File("../.env").takeIf { it.exists() }
+                ?: return
+
+            envFile.readLines().forEach { line ->
+                val trimmed = line.trim()
+                if (trimmed.isNotEmpty() && !trimmed.startsWith('#')) {
+                    val idx = trimmed.indexOf('=')
+                    if (idx > 0) {
+                        val key = trimmed.substring(0, idx).trim()
+                        val value = trimmed.substring(idx + 1).trim()
+                        registry.add(key) { value }
+                    }
+                }
+            }
+        }
+
+        data class EvalSample(
+            val description: String,
+            val owner: String,
+            val repo: String,
+            val issueNumber: Int,
+            val issueTitle: String,
+            val issueBody: String?,
+            val labels: List<String>
+        )
+
+        val EVAL_SAMPLES = listOf(
+            EvalSample(
+                description = "JabRef - setStyle CSS 교체 리팩토링",
+                owner = "JabRef",
+                repo = "jabref",
+                issueNumber = 15686,
+                issueTitle = "Replace setStyle(..) calls with CSS styleClass",
+                issueBody = "There are about 35 calls to setStyle(...) in the codebase. This should be replaced by proper CSS styleClass usage.",
+                labels = listOf("component: css", "component: ui", "good first issue")
+            ),
+            EvalSample(
+                description = "JabRef - PDF 인덱싱 오류 로깅 개선",
+                owner = "JabRef",
+                repo = "jabref",
+                issueNumber = 15680,
+                issueTitle = "Log file name or citation key when PDF indexing fails",
+                issueBody = "When an error occurs during PDF full-text indexing, the log does not include which file caused the error. The file name or citation key should be included in the error log.",
+                labels = listOf("component: external-files", "good first issue")
+            ),
+            EvalSample(
+                description = "Tadreeb - Dashboard Reset 버튼 버그",
+                owner = "Tadreeb-LMS",
+                repo = "tadreeblms",
+                issueNumber = 546,
+                issueTitle = "Reset Button Not Clearing Filter Fields on Dashboard",
+                issueBody = "The Reset button in the Dashboard filter section is not functioning as expected. After entering values in the filter fields and clicking the Reset button, the input fields remain populated instead of being cleared.",
+                labels = listOf("bug", "good first issue")
+            ),
+            EvalSample(
+                description = "Camunda - RocksDB 메트릭 추가",
+                owner = "camunda",
+                repo = "camunda",
+                issueNumber = 52365,
+                issueTitle = "Expose more RocksDB metrics",
+                issueBody = "RocksDbMetricsDoc defines which RocksDB properties we expose as metrics. Some useful ones such as rocksdb.num-immutable-mem-table-flushed are missing though.",
+                labels = listOf("area/observability", "good first issue")
+            ),
+            EvalSample(
+                description = "super-productivity - 텍스트 필드 리사이즈 버그",
+                owner = "super-productivity",
+                repo = "super-productivity",
+                issueNumber = 7482,
+                issueTitle = "text field in the task editing view not resizing properly",
+                issueBody = "Especially when entering longer words, the text field of the task editing view is not resizing properly, which results in the disability to see and edit the entire text body.",
+                labels = listOf("good first issue", "bug")
+            )
+        )
+    }
+
+    @Test
+    fun `고정 샘플 5종으로 프롬프트 평가`() {
+        EVAL_SAMPLES.forEachIndexed { index, sample ->
+            println("\n===== 샘플 ${index + 1}: ${sample.description} =====")
+
+            try {
+                // 1단계: GitHub Tree API로 파일 목록 가져오기
+                val allFilePaths = gitHubClient.fetchTree(sample.owner, sample.repo)
+                    .filter { path ->
+                        path.endsWith(".ts") || path.endsWith(".js") ||
+                        path.endsWith(".kt") || path.endsWith(".java") ||
+                        path.endsWith(".py") || path.endsWith(".go") ||
+                        path.endsWith(".rs") || path.endsWith(".cpp") ||
+                        path.endsWith(".json") || path.endsWith(".yaml") ||
+                        path.endsWith(".yml") || path.endsWith(".md") ||
+                        path.endsWith(".html") || path.endsWith(".css") ||
+                        path.endsWith(".scss") || path.endsWith(".xml") ||
+                        path.endsWith(".toml") || path.endsWith(".gradle") ||
+                        path.endsWith(".properties")
+                    }
+                println("필터링 후 파일 수: ${allFilePaths.size}")
+
+// 2단계: GLM selectFiles 호출 (동적 배치)
+                val batchSizes = listOf(3000, 2000, 1000, 700, 300, 100)
+                var selectedPaths: List<String> = emptyList()
+                for (size in batchSizes) {
+                    try {
+                        selectedPaths = glmClient.selectFiles(
+                            issueTitle = sample.issueTitle,
+                            issueBody = sample.issueBody,
+                            filePaths = allFilePaths.take(size)
+                        )
+                        println("selectFiles 성공: 배치=$size, 선별=${selectedPaths.size}개")
+                        break
+                    } catch (e: Exception) {
+                        println("배치 $size 실패, 축소: ${e.message?.take(50)}")
+                    }
+                }
+
+                if (selectedPaths.isEmpty()) {
+                    println("샘플 ${index + 1} selectFiles 전체 실패, 건너뜀")
+                    return@forEachIndexed
+                }
+                println("선별된 파일: $selectedPaths")
+
+                // 3단계: 선별된 파일 내용 fetch
+                val fileContents = gitHubClient.fetchFileContents(
+                    sample.owner, sample.repo, selectedPaths
+                ).mapValues { (_, content) ->
+                    content.lines()
+                        .filter { it.isNotBlank() }
+                        .filter { line ->
+                            val t = line.trimStart()
+                            !t.startsWith("//") && !t.startsWith("*") &&
+                            !t.startsWith("/*") && !t.startsWith("#")
+                        }
+                        .joinToString("\n")
+                        .take(3000)
+                }
+
+                // 4단계: GLM analyze 호출
+                val result = glmClient.analyze(
+                    issueTitle = sample.issueTitle,
+                    issueBody = sample.issueBody,
+                    labels = sample.labels,
+                    fileContents = fileContents
+                )
+                println("guideline: ${result.guideline}")
+                println("pseudoCode: ${result.pseudoCode.take(100)}...")
+
+            } catch (e: Exception) {
+                println("샘플 ${index + 1} 실패 (건너뜀): ${e.message}")
+            }
+
+            // rate limit 방지
+            if (index < EVAL_SAMPLES.lastIndex) Thread.sleep(15_000)
+        }
+
+        // Langfuse fire-and-forget + judge 채점 완료 대기
+        Thread.sleep(120_000)
+    }
+}


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
GLM API 호출에 Langfuse 모니터링을 연동하고, LLM-as-judge 자동 채점 파이프라인을 구축했습니다.
5종 고정 샘플 eval 테스트를 통해 프롬프트를 v1에서 v4까지 단계적으로 개선했습니다.

## 🔗 관련 이슈
- Close #113

## 🛠️ 주요 변경 사항
- [x] 1. Langfuse 연동 (GlmClientImpl)
-  chatModel.call(String) → chatModel.call(Prompt(...)) 변경으로 토큰 수 추출 가능
-  selectFiles, analyze 각 호출마다 recordGeneration 으로 프롬프트/응답/응답시간/토큰 수 비동기 기록
-  Langfuse 미설정 환경에서는 기록을 건너뛰므로 메인 로직에 영향 없음

- [x] 2. LLM-as-judge 채점 파이프라인 (GlmClientImpl)
-  evaluateSelectFilesAsync, evaluateAnalyzeAsync — GLM이 직접 결과물을 채점
-  judgeExecutor (스레드풀 2개) 로 비동기 처리, 응답 시간에 영향 없음
-  채점 결과는 recordScore로 Langfuse trace에 연결

- [x] 3. 프롬프트 빌더 분리 (GlmPromptBuilder)
-  GlmClientImpl에서 프롬프트 구성 로직을 GlmPromptBuilder로 분리
-  PROMPT_VERSION_SELECT_FILES, PROMPT_VERSION_ANALYZE 상수로 버전 관리
-  버전 상수 기반으로 GENERATION_NAME 자동 생성 → Langfuse에서 버전별 비교 가능

- [x] 4. 프롬프트 v1 → v4 개선 (GlmPromptBuilder)

| 버전 | 주요 변경 | select 점수 | analyze 점수 | select latency | analyze latency | analyze input 토큰 |
|------|-----------|:-----------:|:------------:|:--------------:|:---------------:|:-----------------:|
| v1 | Zero-shot | 5.5점 | 8.0점 | 54초 | 55초 | 2,727 |
| v2 | 역할 부여, 파일 수 10개 확대, 번역 금지 | 7.6점 | 8.1점 | 51초 | 72초 | 4,719 |
| v3 | CoT 추가 | 6.9점 | 7.1점 | 172초 | 59초 | 4,283 |
| v4 | Few-shot + hallucination 방지 | 9.0점 | 8.3점 | 68초 | 62초 | 4,213 |
> v3에서 CoT 단독 적용 시 hallucination이 증가하는 부작용 확인.
v4에서 Few-shot + "이슈 본문에 없는 내용 추가 금지" 지시로 해결.
v3의 latency는 timeout으로 한번의 시도에서 7분을 소모해 평균치가 올라감.

## 🧪 테스트 결과
전체 단위 테스트 통과 확인
<img width="674" height="350" alt="image" src="https://github.com/user-attachments/assets/f37a41e7-4c22-4188-8af8-f1ce0a9e70e7" />
Langfuse Traces 기록 확인
<img width="618" height="1090" alt="image" src="https://github.com/user-attachments/assets/89a51284-da12-4a97-83b3-1fc98ffcf5d2" />

## 🧐 리뷰어에게

-  프롬프트 개선으로 품질은 향상됐지만 latency와 토큰 비용은 증가했습니다.
(select-files latency: v1 평균 42초 → v4 평균 75초)
파일 선별 수 확대 (5개 → 10개) 와 Few-shot 추가에 의해 토큰이 증가했습니다.


-  judge도 결국 GLM이라서 실제 코드를 직접 보고 채점하는 게 아니라,
파일 이름이랑 이슈 내용만 보고 판단하기에 score가 들쭉날쭉한 느낌이 있습니다.
그렇기에 완벽한 지표라기보다는 v1보다 v4가 나아졌다 정도의 방향성 확인 용도로 보면 될 것 같습니다.
