### PR TITLE
[#114][FEAT] langfuse기반 Issue 추천 프롬포트 개선

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.Instant
 
 /**
@@ -44,7 +45,7 @@ class IssueGlmClientImpl(
 
     companion object {
         // 프롬프트를 수정할 때마다 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        private const val GENERATION_NAME = "issue-recommendation-GLM-4.5-v1"
+        private const val GENERATION_NAME = "issue-recommendation-GLM-4.5-v5"
     }
 
     override fun generateRecommendationReasons(
@@ -53,50 +54,123 @@ class IssueGlmClientImpl(
     ): List<AIRecommendationResult> {
         val promptText = buildRecommendPrompt(userProfile, candidateIssues)
 
-        // 측정 시작
+        // 측정 시작 (전체 프로세스 시작)
         val startTime = Instant.now()
 
-        // 2. ChatResponse 형태로 호출 (토큰 정보 추출을 위해)
+        // 1. 추천 로직 실행
         val chatResponse = try {
             chatModel.call(Prompt(promptText))
         } catch (e: Exception) {
-            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED);
+            throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED)
         }
 
-        // 3. 시간 측정 종료 및 메타데이터 추출
-        val endTime = Instant.now()
-        val responseContent = chatResponse.result.output.text ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY);
+        val recEndTime = Instant.now()
+        val recDuration = Duration.between(startTime, recEndTime).toMillis() / 1000.0
+
+        val responseContent = chatResponse.result.output.text ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY)
         val usage = chatResponse.metadata.usage
 
-        // 4. Langfuse 기록 (토큰 수 포함) 및 traceId 획득
-        val traceId = langfuseClient.recordGeneration(
-            name = GENERATION_NAME,
-            input = promptText,
-            output = responseContent,
-            startTime = startTime,
-            endTime = endTime,
-            inputTokens = usage?.promptTokens?.toInt(),
-            outputTokens = usage?.completionTokens?.toInt()
-        )
-
         return try {
-            val result =
+            val results =
                 objectMapper.readValue(responseContent, object : TypeReference<List<AIRecommendationResult>>() {})
 
-            // 5. 성공 시 품질 점수 기록 (예: 파싱 성공 시 10점)
+            // 2. 평가 로직 실행 (평가 결과와 걸린 시간을 리스트로 받아옴)
+            val evalStartTime = Instant.now()
+            val evaluationResults = evaluateAllRecommendations(userProfile, results) // 일괄 평가 호출
+            val totalEndTime = Instant.now()
+            val evalDuration = Duration.between(evalStartTime, totalEndTime).toMillis() / 1000.0
+
+            // 3. Langfuse Generation 기록 (전체 시간을 포함)
+            val traceId = langfuseClient.recordGeneration(
+                name = GENERATION_NAME,
+                input = promptText,
+                output = responseContent,
+                startTime = startTime,
+                endTime = totalEndTime,
+                inputTokens = usage?.promptTokens?.toInt(),
+                outputTokens = usage?.completionTokens?.toInt()
+            )
+
+            // 4. 생성된 traceId에 개별 점수 매칭 기록
             if (traceId != null) {
-                langfuseClient.recordScore(traceId, 10.0, "JSON Parsing Success")
+                evaluationResults.forEachIndexed { index, eval ->
+                    // 일괄 평가이므로 evalDuration은 전체 호출에 걸린 시간입니다.
+                    val timeInfo = "[Time - 추천:${recDuration}s / 평가(Batch):${evalDuration}s]"
+
+                    langfuseClient.recordScore(
+                        traceId = traceId,
+                        score = eval.score,
+                        reason = "$timeInfo ${eval.fullReason}"
+                    )
+                }
             }
 
-            result
+            results
         } catch (e: Exception) {
-            // 6. 실패 시 품질 점수 기록 (예: 파싱 실패 시 0점)
+            // 실패 시에도 일단 현재까지의 시간으로 기록
+            val errorEndTime = Instant.now()
+            val traceId = langfuseClient.recordGeneration(
+                name = GENERATION_NAME,
+                input = promptText,
+                output = responseContent,
+                startTime = startTime,
+                endTime = errorEndTime
+            )
             if (traceId != null) {
                 langfuseClient.recordScore(traceId, 0.0, "JSON Parsing Failed: ${e.message}")
             }
             throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
     }
+
+    /**
+     * 개별 추천 결과를 평가하고 결과 객체를 반환합니다.
+     */
+    private fun evaluateAllRecommendations(
+        userProfile: String,
+        results: List<AIRecommendationResult>
+    ): List<EvalResult> {
+        val recommendationsJson = results.mapIndexed { index, res ->
+            mapOf("id" to index, "title" to res.title, "reason" to res.reason)
+        }.let { objectMapper.writeValueAsString(it) }
+
+        val batchEvalPrompt = """
+        너는 깐깐한 시니어 개발자다. 아래 [추천 리스트]의 적절성을 [사용자 프로필] 기준으로 한 번에 평가하라.
+        
+        [사용자 프로필]: $userProfile
+        [추천 리스트]: $recommendationsJson
+
+        [채점 기준 (총 10점)]
+        1. 스택(3점): 기술 스택 일치 여부
+        2. 도메인(4점): 관심 분야 매칭
+        3. 성장(3점): 사유의 구체성 및 학습 가치
+        
+        [규칙]
+        - 관대함 금지. 평범하면 5점, 스택 불일치 시 해당 항목 0점.
+        - 응답은 반드시 아래 JSON 배열 형식만 허용 (설명 생략):
+        [{"id": 0, "score": 8.0, "stack": 3, "domain": 3, "growth": 2, "reason": "한 문장 근거"}, ...]
+    """.trimIndent()
+
+        return try {
+            val response = chatModel.call(batchEvalPrompt) ?: return emptyList()
+            val cleanJson = response.replace("```json", "").replace("```", "").trim()
+            val nodes = objectMapper.readTree(cleanJson)
+
+            nodes.map { node ->
+                val score = node.get("score").asDouble()
+                val stack = node.get("stack").asInt()
+                val domain = node.get("domain").asInt()
+                val growth = node.get("growth").asInt()
+                val reason = node.get("reason").asText()
+                EvalResult(score, "[스택:$stack/도메인:$domain/성장:$growth] $reason")
+            }
+        } catch (e: Exception) {
+            results.map { EvalResult(0.0, "일괄 평가 실패: ${e.message}") }
+        }
+    }
+
+    // 평가 결과를 임시 저장하기 위한 내부 클래스
+    private data class EvalResult(val score: Double, val fullReason: String)
 
     /**
      * 유저의 기술 스택과 후보 이슈 데이터를 하나로 묶는 프롬프트 엔지니어링
@@ -126,9 +200,9 @@ class IssueGlmClientImpl(
             1. **프로필 기반 키워드 추출**: 프로필에서 개발자의 주력 기술과 관심 도메인을 스스로 파악하세요.
             2. **기술적 매칭**: 파악한 키워드와 연관성이 높은 이슈를 3개 선정합니다.
             3. **언어 및 내용 제약 (CRITICAL)**: 
-               - **반드시 모든 추천 사유('reason' 필드)는 한국어로만 작성하세요.**
-               - 후보 이슈의 제목이나 요약이 영어로 되어 있더라도, 이를 분석하여 **한국어로 번역 및 설명**해야 합니다.
-               - 전문 용어(예: Spring Boot, JWT, Redis)는 그대로 사용하되, 문장은 자연스러운 한국어로 구성하세요.
+               - **모든 추천 사유('reason' 필드)는 한국어로 작성하세요.**
+               - **[핵심] 추천 사유는 2~3문장 내외로 매우 간결하게 작성하세요.** (장황한 설명은 지양하고 매칭된 기술 스택과 이유만 명확히 제시)
+               - 영어 이슈도 한국어로 요약하되, 전문 용어(예: Spring Boot, JWT)는 원문을 유지하세요.
             4. **형식 준수**: 아래 JSON 배열 형식으로만 응답하며, 마크다운 코드 블록(```json)이나 다른 인사말은 절대 포함하지 마세요.
             
             ### [출력 형식]
@@ -136,7 +210,7 @@ class IssueGlmClientImpl(
               {
                 "title": "이슈 제목",
                 "repoName": "레포지토리 풀네임",
-                "reason": "반드시 한국어로 작성된 맞춤형 추천 사유 및 성장 포인트"
+                "reason": "핵심 기술 매칭과 성장 포인트 중심의 간결한 한국어 사유"
               }
             ]
         """.trimIndent()

--- a/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientImpl.kt
@@ -2,12 +2,15 @@ package com.back.omos.domain.issue.ai
 
 import com.back.omos.domain.issue.dto.AIRecommendationResult
 import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.global.ai.LangfuseClient
 import com.back.omos.global.exception.errorCode.AiErrorCode
 import com.back.omos.global.exception.exceptions.AiException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.core.type.TypeReference
 import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 /**
  * Generative AI 모델과 통신하여 실제 추천 로직을 수행하는 클라이언트 구현체입니다.
@@ -35,9 +38,14 @@ import org.springframework.stereotype.Component
 @Component
 class IssueGlmClientImpl(
     private val chatModel: ChatModel,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val langfuseClient: LangfuseClient // 추가
 ) : IssueGlmClient {
 
+    companion object {
+        // 프롬프트를 수정할 때마다 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
+        private const val GENERATION_NAME = "issue-recommendation-GLM-4.5-v1"
+    }
 
     override fun generateRecommendationReasons(
         userProfile: String,
@@ -45,15 +53,47 @@ class IssueGlmClientImpl(
     ): List<AIRecommendationResult> {
         val promptText = buildRecommendPrompt(userProfile, candidateIssues)
 
-        val responseContent = try {
-            chatModel.call(promptText) ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY);
+        // 측정 시작
+        val startTime = Instant.now()
+
+        // 2. ChatResponse 형태로 호출 (토큰 정보 추출을 위해)
+        val chatResponse = try {
+            chatModel.call(Prompt(promptText))
         } catch (e: Exception) {
             throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
 
+        // 3. 시간 측정 종료 및 메타데이터 추출
+        val endTime = Instant.now()
+        val responseContent = chatResponse.result.output.text ?: throw AiException(AiErrorCode.AI_RESPONSE_EMPTY);
+        val usage = chatResponse.metadata.usage
+
+        // 4. Langfuse 기록 (토큰 수 포함) 및 traceId 획득
+        val traceId = langfuseClient.recordGeneration(
+            name = GENERATION_NAME,
+            input = promptText,
+            output = responseContent,
+            startTime = startTime,
+            endTime = endTime,
+            inputTokens = usage?.promptTokens?.toInt(),
+            outputTokens = usage?.completionTokens?.toInt()
+        )
+
         return try {
-            objectMapper.readValue(responseContent, object : TypeReference<List<AIRecommendationResult>>() {})
+            val result =
+                objectMapper.readValue(responseContent, object : TypeReference<List<AIRecommendationResult>>() {})
+
+            // 5. 성공 시 품질 점수 기록 (예: 파싱 성공 시 10점)
+            if (traceId != null) {
+                langfuseClient.recordScore(traceId, 10.0, "JSON Parsing Success")
+            }
+
+            result
         } catch (e: Exception) {
+            // 6. 실패 시 품질 점수 기록 (예: 파싱 실패 시 0점)
+            if (traceId != null) {
+                langfuseClient.recordScore(traceId, 0.0, "JSON Parsing Failed: ${e.message}")
+            }
             throw AiException(AiErrorCode.AI_RESPONSE_PARSE_FAILED);
         }
     }

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssueGlmClientTest.kt
@@ -1,6 +1,7 @@
 package com.back.omos.domain.issue.ai
 
 import com.back.omos.domain.issue.entity.Issue
+import com.back.omos.global.ai.LangfuseClient
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.mockito.kotlin.whenever
@@ -11,7 +12,15 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.mockito.Mockito.mock
 import org.mockito.kotlin.*
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.metadata.ChatResponseMetadata
+import org.springframework.ai.chat.metadata.Usage
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.chat.prompt.Prompt
+import kotlin.jvm.java
 
 /**
  * AI 모델(GLM)을 이용한 이슈 추천 로직의 단위 테스트 클래스입니다.
@@ -33,25 +42,42 @@ import org.mockito.kotlin.*
 class IssueGlmClientTest {
     private val chatModel: ChatModel = mock()
     private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
-    private val client = IssueGlmClientImpl(chatModel, objectMapper)
+    private val langfuseClient: LangfuseClient = mock()
+    private val client = IssueGlmClientImpl(chatModel, objectMapper, langfuseClient)
 
     @Test
     fun `AI가 준 JSON 응답이 객체 리스트로 정확히 변환되는지 테스트`() {
+        // 1. Given: 가짜 JSON 응답 준비
         val fakeJsonResponse = """
-            [
-              { "title": "이슈1", "repoName": "owner/repo1", "reason": "이유1" },
-              { "title": "이슈2", "repoName": "owner/repo2", "reason": "이유2" }
-            ]
-        """.trimIndent()
+        [
+          { "title": "이슈1", "repoName": "owner/repo1", "reason": "이유1" },
+          { "title": "이슈2", "repoName": "owner/repo2", "reason": "이유2" }
+        ]
+    """.trimIndent()
 
-        whenever(chatModel.call(any<String>())).thenReturn(fakeJsonResponse)
+        // [수정 포인트] ChatResponse 구조를 한 번에 모킹합니다.
+        val mockResponse = mock(ChatResponse::class.java)
+        val mockGeneration = mock(Generation::class.java)
+        val mockMetadata = mock(ChatResponseMetadata::class.java)
+        val mockUsage = mock(Usage::class.java)
+        val mockAssistantMessage = AssistantMessage(fakeJsonResponse)
 
-        // when: 클라이언트 호출
+        // 계층 구조 연결 (NPE 방지 세트)
+        whenever(mockResponse.result).thenReturn(mockGeneration)
+        whenever(mockGeneration.output).thenReturn(mockAssistantMessage)
+        whenever(mockResponse.metadata).thenReturn(mockMetadata)
+        whenever(mockMetadata.usage).thenReturn(mockUsage)
+
+        // [수정 포인트] any<String>() 대신 any<Prompt>() 사용
+        whenever(chatModel.call(any<Prompt>())).thenReturn(mockResponse)
+
+        // 2. When: 클라이언트 호출
         val results = client.generateRecommendationReasons("Kotlin 스택", emptyList())
 
-        // then: 파싱 결과 확인
+        // 3. Then: 파싱 결과 확인
         assertEquals(2, results.size)
         assertEquals("이슈1", results[0].title)
+        assertEquals("owner/repo1", results[0].repoName) // 인덱스 및 필드명 확인
         assertEquals("owner/repo2", results[1].repoName)
     }
 
@@ -86,22 +112,44 @@ class IssueGlmClientTest {
             ]
         """.trimIndent()
 
-        whenever(chatModel.call(any<String>())).thenReturn(fakeJsonResponse)
+        // 1. 필요한 추가 Mock 객체들
+        val mockResponse = mock(ChatResponse::class.java)
+        val mockGeneration = mock(Generation::class.java)
+        val mockMetadata = mock(ChatResponseMetadata::class.java) // 메타데이터 추가
+        val mockUsage = mock(Usage::class.java) // 토큰 사용량 추가
 
-        // 2. When: 호출
+        // 2. 가짜 응답 본문 설정
+        val mockAssistantMessage = AssistantMessage(fakeJsonResponse)
+        whenever(mockGeneration.output).thenReturn(mockAssistantMessage)
+        whenever(mockResponse.result).thenReturn(mockGeneration)
+
+        // 3. [핵심] 메타데이터와 Usage 연결 (NPE 방지)
+        whenever(mockResponse.metadata).thenReturn(mockMetadata)
+        whenever(mockMetadata.usage).thenReturn(mockUsage)
+
+        // (선택사항) 만약 코드에서 토큰 숫자를 직접 읽는다면 아래도 추가
+        whenever(mockUsage.promptTokens).thenReturn(100L.toInt())
+        whenever(mockUsage.completionTokens).thenReturn(100L.toInt())
+
+        // 4. Mocking 완료
+        whenever(chatModel.call(any<Prompt>())).thenReturn(mockResponse)
+
+        // 2. When
         val results = client.generateRecommendationReasons("Java/Kotlin Backend", candidateIssues)
 
-        // 3. Then: 결과 검증 및 내부 프롬프트 생성 로직 실행 확인
+        // 3. Then
         assertEquals(2, results.size)
 
-        val promptCaptor = argumentCaptor<String>()
+        // [핵심 수정] ArgumentCaptor도 Prompt 타입을 캡처하도록 변경
+        val promptCaptor = argumentCaptor<Prompt>()
         verify(chatModel).call(promptCaptor.capture())
-        val generatedPrompt = promptCaptor.firstValue
+
+        // 캡처된 Prompt 객체 내부의 텍스트 내용을 가져옴
+        // instructions[0]을 거치지 않고 바로 뽑기
+        val generatedPrompt = promptCaptor.firstValue.contents
 
         assertTrue(generatedPrompt.contains("google/guava"))
         assertTrue(generatedPrompt.contains("bug, p0"))
-        assertTrue(generatedPrompt.contains("없음"))
-        assertTrue(generatedPrompt.contains("내용 없음"))
-        assertEquals(400, candidateIssues[0].content?.take(400)?.length)
+        assertTrue(generatedPrompt.contains("데이터 미비 이슈")) // "없음" 대신 구체적인 제목 확인 추천
     }
 }

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssuePromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssuePromptEvalTest.kt
@@ -64,11 +64,59 @@ class IssuePromptEvalTest {
         }
     }
 
+
+    @Test
+    fun `기술 스택이 모호한 관심사 기반 프로필 추천 성능 평가`() {
+        val candidatePool = createFixedCandidateIssues()
+
+        val ambiguousCases = listOf(
+            EvalCase("Data-Oriented", "데이터의 무결성을 유지하면서 수만 건의 쿼리를 최적화하는 데 집착합니다."),
+            EvalCase("Low-Level", "하드웨어 리소스를 직접 제어하거나 메모리 할당 효율을 높이는 저수준 최적화에 관심이 많습니다."),
+            EvalCase("UI-UX-Flow", "사용자에게 부드러운 화면 전환을 제공하고 상태 관리를 선언적으로 처리하는 것을 선호합니다."),
+            EvalCase("Infrastructure", "서버의 확장성을 고민하며, 동시성 처리를 통해 처리량을 극대화하는 설계를 좋아합니다."),
+            EvalCase("Middleware", "클라이언트와 서버 사이에서 요청을 가로채거나 비동기적으로 메시지를 처리하는 구조를 설계하고 싶습니다.")
+        )
+
+        ambiguousCases.forEach { case ->
+            println("=== [Evaluating Ambiguous] Focus: ${case.language} ===")
+            try {
+                val results = issueGlmClient.generateRecommendationReasons(case.profile, candidatePool)
+                results.forEach { println(" - [${case.language}] -> ${it.title}") }
+            } catch (e: Exception) {
+                println(" ! Error: ${e.message}")
+            }
+        }
+    }
+
+    @Test
+    fun `후보 풀에 없는 기술 스택 프로필 추천 성능 평가`() {
+        val candidatePool = createFixedCandidateIssues()
+
+        val unmatchedCases = listOf(
+            EvalCase("Rust", "Rust 언어의 소유권 개념을 사랑하며, Rocket 프레임워크로 웹 서버를 구축합니다."),
+            EvalCase("Swift", "iOS 환경에서 Swift를 사용해 고성능 애니메이션과 Combine을 활용한 비동기 처리를 구현합니다."),
+            EvalCase("Ruby", "Ruby on Rails의 생산성을 즐기며, 가독성 높은 코드를 작성하는 데 자부심이 있습니다."),
+            EvalCase("Flutter", "Dart 언어를 기반으로 하나의 코드베이스에서 멀티 플랫폼 UI를 구현하는 데 특화되어 있습니다."),
+            EvalCase("PHP", "Laravel 프레임워크를 활용해 대규모 커머스 시스템의 백엔드를 구축해온 시니어 개발자입니다.")
+        )
+
+        unmatchedCases.forEach { case ->
+            println("=== [Evaluating Unmatched] Tech: ${case.language} ===")
+            try {
+                val results = issueGlmClient.generateRecommendationReasons(case.profile, candidatePool)
+                results.forEach { println(" - [${case.language}] -> ${it.title}") }
+            } catch (e: Exception) {
+                println(" ! Error: ${e.message}")
+            }
+        }
+    }
+
+
     private fun createFixedCandidateIssues(): List<Issue> {
         return listOf(
             Issue(
                 repoFullName = "spring-projects/spring-data-jpa",
-                issueNumber = 101L, // Long 타입의 이슈 번호 추가
+                issueNumber = 101L,
                 title = "Fix N+1 query in Spring Data JPA",
                 labels = listOf("java", "bug")
             ),

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssuePromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssuePromptEvalTest.kt
@@ -1,0 +1,103 @@
+package com.back.omos.domain.issue.ai
+
+import com.back.omos.domain.issue.entity.Issue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * 이슈 추천 프롬프트 버전별 성능을 비교하기 위한 평가 테스트입니다.
+ *
+ * <p>
+ * 언어별(Java, C++, Kotlin, Python, Go) 고정 프로필 샘플로 AI를 호출하고,
+ * 결과를 Langfuse에 자동 기록하여 매칭 정확도와 품질을 비교합니다.
+ *
+ * <p><b>테스트 구성:</b><br>
+ * - 샘플 1: Java (백엔드/Spring Boot 중심)<br>
+ * - 샘플 2: C++ (시스템 프로그래밍/최적화 중심)<br>
+ * - 샘플 3: Kotlin (안드로이드/비동기 중심)<br>
+ * - 샘플 4: Python (데이터 사이언스/API 중심)<br>
+ * - 샘플 5: Go (MSA/인프라 중심)<br>
+ *
+ * <p><b>실행 방법:</b><br>
+ * IntelliJ에서 실행하며, 실행 후 Langfuse 대시보드에서 버전별 Latency와 파싱 성공률을 확인합니다.
+ * 프롬프트 수정 시 [IssueGlmClientImpl.GENERATION_NAME]의 버전을 갱신해야 합니다.
+ *
+ * @author 유재원
+ * @since 2026-05-06
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+class IssuePromptEvalTest {
+
+    @Autowired
+    lateinit var issueGlmClient: IssueGlmClient
+
+    @Test
+    fun `언어별 고정 프로필 기반 추천 성능 평가 실행`() {
+        // 1. 공통 후보 이슈 풀 (AI가 이 중에서 각 언어에 맞는 것을 골라야 함)
+        val candidatePool = createFixedCandidateIssues()
+
+        // 2. 5가지 언어별 테스트 케이스 정의
+        val testCases = listOf(
+            EvalCase("Java", "Java 17, Spring Boot, JPA 숙련자. 대용량 트래픽 처리와 DB 성능 최적화에 관심이 많음."),
+            EvalCase("C++", "C++20 표준 선호. 임베디드 시스템, 그래픽스 엔진 개발 및 메모리 관리 최적화 경험 보유."),
+            EvalCase("Kotlin", "Kotlin 코루틴과 Flow 활용 능숙. 안드로이드 클린 아키텍처 및 Jetpack Compose 개발자."),
+            EvalCase("Python", "FastAPI를 활용한 백엔드 개발 및 Pandas 기반 데이터 전처리, Scikit-learn 모델 서빙 관심."),
+            EvalCase("Go", "Goroutine 기반 고성능 서버 개발 및 Kubernetes 커스텀 리소스, MSA 환경 구축 선호.")
+        )
+
+        // 3. 테스트 실행
+        testCases.forEach { case ->
+            println("=== [Evaluating] Language: ${case.language} ===")
+            try {
+                val results = issueGlmClient.generateRecommendationReasons(case.profile, candidatePool)
+
+                // 결과 요약 출력
+                results.forEach {
+                    println(" - Recommended: ${it.title} (Reason: ${it.reason.take(30)}...)")
+                }
+            } catch (e: Exception) {
+                println(" ! Error during ${case.language} evaluation: ${e.message}")
+            }
+        }
+    }
+
+    private fun createFixedCandidateIssues(): List<Issue> {
+        return listOf(
+            Issue(
+                repoFullName = "spring-projects/spring-data-jpa",
+                issueNumber = 101L, // Long 타입의 이슈 번호 추가
+                title = "Fix N+1 query in Spring Data JPA",
+                labels = listOf("java", "bug")
+            ),
+            Issue(
+                repoFullName = "khronos/vulkan",
+                issueNumber = 202L,
+                title = "Optimize memory allocation in Vulkan renderer",
+                labels = listOf("cpp", "performance")
+            ),
+            Issue(
+                repoFullName = "google/android-samples",
+                issueNumber = 303L,
+                title = "Migrate LiveData to StateFlow in Main Screen",
+                labels = listOf("kotlin", "refactor")
+            ),
+            Issue(
+                repoFullName = "tiangolo/fastapi",
+                issueNumber = 404L,
+                title = "Add async support for FastAPI middleware",
+                labels = listOf("python", "feature")
+            ),
+            Issue(
+                repoFullName = "golang/go",
+                issueNumber = 505L,
+                title = "Implement worker pool using channels",
+                labels = listOf("go", "improvement")
+            )
+        )
+    }
+
+    data class EvalCase(val language: String, val profile: String)
+}

--- a/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssuePromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/issue/ai/IssuePromptEvalTest.kt
@@ -48,6 +48,8 @@ class IssuePromptEvalTest {
             EvalCase("Go", "Goroutine 기반 고성능 서버 개발 및 Kubernetes 커스텀 리소스, MSA 환경 구축 선호.")
         )
 
+        val failures = mutableListOf<String>()
+
         // 3. 테스트 실행
         testCases.forEach { case ->
             println("=== [Evaluating] Language: ${case.language} ===")
@@ -59,8 +61,16 @@ class IssuePromptEvalTest {
                     println(" - Recommended: ${it.title} (Reason: ${it.reason.take(30)}...)")
                 }
             } catch (e: Exception) {
-                println(" ! Error during ${case.language} evaluation: ${e.message}")
+                val errorMessage = " ! Error during ${case.language} evaluation: ${e.message}"
+                println(errorMessage)
+                failures.add(errorMessage) // 실패 내용 기록
             }
+        }
+
+        // 4. 최종 검증: 실패가 하나라도 있으면 테스트를 실패 처리
+        if (failures.isNotEmpty()) {
+            val failureSummary = failures.joinToString(separator = "\n")
+            org.junit.jupiter.api.Assertions.fail<Unit>("추천 성능 평가 중 다음 케이스에서 예외가 발생했습니다:\n$failureSummary")
         }
     }
 


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
프롬프트에 issue 추천받은거 평가하여 점수 측정 추가
이슈 추천시 시간이 오래걸리는거를 고침

## 🔗 관련 이슈
- Close #114 

## 🛠️ 주요 변경 사항
- [ ] 추천받은 Issue에 대해 적절히 추천되었는지 기준에 따른 평가 프롬포트 추가후 개선
- [ ] Issue 추천 프롬포트 개선
- [ ] `IssuePromptEvalTest` 이슈 추천 프롬프트 버전별 성능을 비교하기 위한 평가 테스트를 위한 테스트 코드 추가

## 🧪 테스트 결과
| version | 평균 시간 | 평균 출력 토큰 | 평균 총 토큰 | 평균 점수 | 특징 |
|---|---|---|---|---|---|
| v1 | 1m 30s | 2,571 | 3,364 |  | 점수를 도입하기전 프롬포트라 점수가 없습니다. |
| v2 | 1m 32s | 1,982 | 2,774 | 7.86 / 10.0 | 추천받은 Issue에 대해 평가하여 점수를 받은 프롬포트를 추가 |
| v3 | 4m 23s | 3,379 | 4,172 | 4.13 / 10.0 | 같은모델이라 평가가 너무 후하게 주는 경향이 있어서 엄격한 페르소나 도입후 세분화된 평가항목 도입 그래서 평균시간이 증가 그리고 점수가 하락|
| v4 | 1m 52s | 1,921 | 2,713 | 4.66 / 10.0 | 평가하는데 시간이 너무 오래 걸려서 성능 개선 |
| v5 | 1m 13s | 1,709 | 2,514 | 5.13 / 10.0 | 이슈 추천의 프롬포트도 개선 후 시간, 점수 개선 |


## 🧐 리뷰어에게
실제로 GLM-4-Flash, GLM-5 TURBO를 다 사용해 봤으나 Flash는 시간이 너무 오래걸리는 단점이 있고 TURBO는 크게 성능개선이 안되고 오히려 토큰이 더 많이 쓰이는 단점이 있어서 GLM-4.5 현 버전을 계속 사용하도록 했습니다.
