### PR TITLE
[BUG] .tsx 등 일부 확장자 필터링 누락으로 화이트리스트 추가

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/analysis/service/ContextAnalyzerServiceImpl.kt
@@ -214,8 +214,9 @@ class ContextAnalyzerServiceImpl(
         // 1단계: 확장자 필터링
         val allFilePaths = gitHubClient.fetchTree(owner, repoName)
             .filter { path ->
-                path.endsWith(".ts") || path.endsWith(".js") ||
-                        path.endsWith(".kt") || path.endsWith(".java") ||
+                path.endsWith(".ts") || path.endsWith(".tsx") || path.endsWith(".js") ||
+                        path.endsWith(".jsx") || path.endsWith(".kt") ||
+                        path.endsWith(".kts") || path.endsWith(".java") ||
                         path.endsWith(".py") || path.endsWith(".go") ||
                         path.endsWith(".rs") || path.endsWith(".cpp") ||
                         path.endsWith(".json") || path.endsWith(".yaml") ||
@@ -223,7 +224,9 @@ class ContextAnalyzerServiceImpl(
                         path.endsWith(".html") || path.endsWith(".css") ||
                         path.endsWith(".scss") || path.endsWith(".xml") ||
                         path.endsWith(".toml") || path.endsWith(".gradle") ||
-                        path.endsWith(".properties")
+                        path.endsWith(".properties") || path.endsWith(".vue") ||
+                        path.endsWith(".svelte") || path.endsWith(".c") ||
+                        path.endsWith(".h")
             }
         log.info("[generateAnalysis] 확장자 필터링 후 파일 수: ${allFilePaths.size}")
 // 2단계: 동적 배치로 GLM 1차 호출 (최대한 많은 파일 경로 전달)


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
파일 확장자 화이트리스트에 누락된 확장자들을 추가했습니다.
기존에 .tsx, .jsx 등이 빠져있어 TypeScript/React 기반 레포에서
파일 선별이 실패하는 문제를 수정했습니다.

## 🔗 관련 이슈
- Close #129

## 🛠️ 주요 변경 사항
- [x] .tsx, .jsx 추가 (React/TypeScript 컴포넌트)
- [x] .kts 추가 (Kotlin 스크립트, build.gradle.kts 등)
- [x] .vue, .svelte 추가 (프론트엔드 프레임워크)
- [x] .c, .h 추가 (C/C++ 헤더)

## 🧐 리뷰어에게
이후에는 장기적으로는 이진 파일만 제외하는 블랙리스트 방식으로
리팩토링하는 것도 고려해볼 수 있습니다.
