### PR TITLE
[TASK] pr에 close issueNumber 추가 및 PR 템플릿 반영 추가, extractJson 코드블록 파싱 실패 해결

### DIFF
--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -329,8 +329,12 @@ class SpringAiClient(
      * @return 추출된 JSON 문자열, 찾지 못한 경우 null
      */
     private fun extractJson(response: String): String? {
-        val fenceMatch = Regex("""```(?:json)?\s*([\s\S]*?)```""").find(response)
-        if (fenceMatch != null) return fenceMatch.groupValues[1].trim()
+        // 코드 펜스 안 내용이 유효한 JSON일 때만 반환 — body 안에 ```javascript 같은 코드 블록이 있으면 오매칭 방지
+        Regex("""```(?:json)?\s*([\s\S]*?)```""").findAll(response).forEach { match ->
+            val candidate = match.groupValues[1].trim()
+            val parsed = runCatching { objectMapper.readTree(candidate); candidate }.getOrNull()
+            if (parsed != null) return parsed
+        }
         // non-greedy 정규식은 JSON 값 안의 '}'(예: {postId}, judge reason의 코드 스니펫)에서 잘리므로,
         // 첫 번째 '{'와 마지막 '}'로 범위를 잡아 최외각 JSON 객체를 추출한다.
         val start = response.indexOf('{')

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -46,7 +46,7 @@ class SpringAiClient(
 
     companion object {
         // 프롬프트 내용을 변경할 때 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        private const val GENERATION_PR_DRAFT = "pr-draft-v7.1"
+        private const val GENERATION_PR_DRAFT = "pr-draft-v7.2"
         private const val GENERATION_TRANSLATE = "pr-translate-v2.2"
 
         // LLM judge 채점 전용 풀 — 동시 채점 수를 제한해 스레드 고갈 방지

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -46,7 +46,7 @@ class SpringAiClient(
 
     companion object {
         // 프롬프트 내용을 변경할 때 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        private const val GENERATION_PR_DRAFT = "pr-draft-v7.0"
+        private const val GENERATION_PR_DRAFT = "pr-draft-v7.1"
         private const val GENERATION_TRANSLATE = "pr-translate-v2.2"
 
         // LLM judge 채점 전용 풀 — 동시 채점 수를 제한해 스레드 고갈 방지

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/ai/SpringAiClient.kt
@@ -46,7 +46,7 @@ class SpringAiClient(
 
     companion object {
         // 프롬프트 내용을 변경할 때 버전을 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        private const val GENERATION_PR_DRAFT = "pr-draft-v7.2"
+        private const val GENERATION_PR_DRAFT = "pr-draft-v7.3"
         private const val GENERATION_TRANSLATE = "pr-translate-v2.2"
 
         // LLM judge 채점 전용 풀 — 동시 채점 수를 제한해 스레드 고갈 방지

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClient.kt
@@ -39,6 +39,18 @@ interface GitHubClient {
     fun fetchMergedPrs(fullName: String): List<GitHubPrRes>
 
     /**
+     * 레포지토리의 PR 템플릿 내용을 가져옵니다.
+     *
+     * <p>
+     * .github/pull_request_template.md 등 일반적인 위치를 순서대로 탐색합니다.
+     * 파일이 없으면 null을 반환합니다.
+     *
+     * @param fullName owner/repo 형식의 레포지토리 이름
+     * @return PR 템플릿 내용, 없으면 null
+     */
+    fun fetchPrTemplate(fullName: String): String?
+
+    /**
      * GitHub Compare API로 두 브랜치 간의 diff를 가져옵니다.
      *
      * @param upstreamRepo owner/repo 형식의 upstream 레포지토리

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -126,6 +126,10 @@ class GitHubClientImpl(
      *   <li>.github/pull_request_template.md</li>
      *   <li>.github/PULL_REQUEST_TEMPLATE.md</li>
      *   <li>pull_request_template.md</li>
+     *   <li>docs/pull_request_template.md</li>
+     *   <li>.github/PULL_REQUEST_TEMPLATE/pull_request_template.md</li>
+     *   <li>PULL_REQUEST_TEMPLATE/pull_request_template.md</li>
+     *   <li>docs/PULL_REQUEST_TEMPLATE/pull_request_template.md</li>
      * </ol>
      *
      * @param fullName owner/repo 형식의 레포지토리 이름
@@ -135,7 +139,11 @@ class GitHubClientImpl(
         val paths = listOf(
             ".github/pull_request_template.md",
             ".github/PULL_REQUEST_TEMPLATE.md",
-            "pull_request_template.md"
+            "pull_request_template.md",
+            "docs/pull_request_template.md",
+            ".github/PULL_REQUEST_TEMPLATE/pull_request_template.md",
+            "PULL_REQUEST_TEMPLATE/pull_request_template.md",
+            "docs/PULL_REQUEST_TEMPLATE/pull_request_template.md"
         )
         for (path in paths) {
             val result = fetchFile(fullName, path)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/github/GitHubClientImpl.kt
@@ -118,6 +118,33 @@ class GitHubClientImpl(
     }
 
     /**
+     * PR 템플릿 파일 내용을 가져옵니다.
+     *
+     * <p>
+     * 일반적인 PR 템플릿 경로를 순서대로 탐색하며 가장 먼저 발견된 파일을 반환합니다.
+     * <ol>
+     *   <li>.github/pull_request_template.md</li>
+     *   <li>.github/PULL_REQUEST_TEMPLATE.md</li>
+     *   <li>pull_request_template.md</li>
+     * </ol>
+     *
+     * @param fullName owner/repo 형식의 레포지토리 이름
+     * @return PR 템플릿 내용, 없으면 null
+     */
+    override fun fetchPrTemplate(fullName: String): String? {
+        val paths = listOf(
+            ".github/pull_request_template.md",
+            ".github/PULL_REQUEST_TEMPLATE.md",
+            "pull_request_template.md"
+        )
+        for (path in paths) {
+            val result = fetchFile(fullName, path)
+            if (result != null) return result
+        }
+        return null
+    }
+
+    /**
      * GitHub Compare API로 두 브랜치 간의 diff를 가져옵니다.
      *
      * <p>

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -43,7 +43,7 @@ class PrDraftPromptBuilder {
 
     companion object {
         // 프롬프트 내용을 변경할 때 이 버전도 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        const val PROMPT_VERSION = "v7.2"
+        const val PROMPT_VERSION = "v7.3"
         const val PROMPT_VERSION_TRANSLATE = "v2.2"
     }
 
@@ -127,7 +127,7 @@ class PrDraftPromptBuilder {
                ## 테스트 방법
                <!-- 직접 작성 필요 -->
             6. 분석 가이드라인은 변경 맥락 파악을 위한 참고용입니다. PR은 실제 diff에 반영된 변경 사항만 기술하고, 가이드라인에만 언급된 내용은 포함하지 마세요.
-            ${if (issueNumber != null) "7. CONTRIBUTING.md나 기존 PR 예시에 이슈를 close하는 방식이 명시되어 있으면 그 방식을 따르고, 없으면 본문 마지막에 `Closes #$issueNumber`를 추가하세요." else ""}
+            ${if (issueNumber != null) "7. 본문에 이미 close 항목이 있으면 `Closes #$issueNumber`로 채우고 중복 추가하지 마세요. 없으면 본문 마지막에 추가하세요." else ""}
 
             반드시 아래 JSON 형식으로만 응답하세요.
             {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -43,7 +43,7 @@ class PrDraftPromptBuilder {
 
     companion object {
         // 프롬프트 내용을 변경할 때 이 버전도 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        const val PROMPT_VERSION = "v7.1"
+        const val PROMPT_VERSION = "v7.2"
         const val PROMPT_VERSION_TRANSLATE = "v2.2"
     }
 
@@ -56,6 +56,7 @@ class PrDraftPromptBuilder {
      * @param prs 참고용 기존 병합 PR 목록
      * @param issueTitle 연결된 이슈 제목 (없으면 null)
      * @param issueContent 연결된 이슈 본문 (없으면 null)
+     * @param prTemplate 레포지토리의 PR 템플릿 내용 (없으면 null)
      * @return AI에 전달할 프롬프트 문자열
      */
     fun build(
@@ -65,9 +66,14 @@ class PrDraftPromptBuilder {
         issueTitle: String? = null,
         issueContent: String? = null,
         issueGuideline: String? = null,
-        issueNumber: Long? = null
+        issueNumber: Long? = null,
+        prTemplate: String? = null
     ): String {
         val contextSection = when {
+            prTemplate != null -> {
+                val contributingPart = if (contributing != null) "\n[CONTRIBUTING.md]\n$contributing\n" else ""
+                "$contributingPart\n[PR 템플릿]\n$prTemplate\n"
+            }
             contributing != null -> {
                 "\n[CONTRIBUTING.md]\n$contributing\n\n[기본 템플릿]\n$defaultTemplate\n"
             }
@@ -79,6 +85,8 @@ class PrDraftPromptBuilder {
         }
 
         val structureInstruction = when {
+            prTemplate != null ->
+                "[PR 템플릿]의 섹션 구조와 체크박스(- [ ])를 그대로 유지하세요. HTML 주석(<!-- -->)은 모두 삭제하세요. 변경 이유는 이슈 내용을 우선 참고하고, 이슈에도 없으면 '(작성 필요)'로 남겨두세요."
             contributing != null ->
                 "CONTRIBUTING.md의 PR 본문 형식을 따르세요. PR 형식이 없거나 모호한 경우 '변경 이유(Why)', '수정 내용(What)'의 2단 구조로 작성하세요. 변경 이유는 이슈 내용을 우선 참고하고, 이슈에도 없으면 '(작성 필요)'로 남겨두세요."
             prs.isNotEmpty() ->

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -43,7 +43,7 @@ class PrDraftPromptBuilder {
 
     companion object {
         // 프롬프트 내용을 변경할 때 이 버전도 함께 올려야 Langfuse에서 버전별 성능 비교가 가능합니다.
-        const val PROMPT_VERSION = "v7.0"
+        const val PROMPT_VERSION = "v7.1"
         const val PROMPT_VERSION_TRANSLATE = "v2.2"
     }
 
@@ -64,7 +64,8 @@ class PrDraftPromptBuilder {
         prs: List<GitHubPrRes>,
         issueTitle: String? = null,
         issueContent: String? = null,
-        issueGuideline: String? = null
+        issueGuideline: String? = null,
+        issueNumber: Long? = null
     ): String {
         val contextSection = when {
             contributing != null -> {
@@ -87,7 +88,8 @@ class PrDraftPromptBuilder {
         }
 
         val issueSection = if (issueTitle != null) {
-            "\n[이슈]\n제목: $issueTitle\n내용: ${issueContent ?: "(본문 없음)"}\n"
+            val numberLine = if (issueNumber != null) "번호: #$issueNumber\n" else ""
+            "\n[이슈]\n${numberLine}제목: $issueTitle\n내용: ${issueContent ?: "(본문 없음)"}\n"
         } else ""
 
         val guidelineSection = issueGuideline
@@ -116,7 +118,7 @@ class PrDraftPromptBuilder {
             5. 테스트 방법 섹션은 개발자가 직접 작성할 수 있도록 아래와 같이 placeholder로 남겨두세요.
                ## 테스트 방법
                <!-- 직접 작성 필요 -->
-            6. 분석 가이드라인은 변경 맥락 파악을 위한 참고용입니다. PR은 실제 diff에 반영된 변경 사항만 기술하고, 가이드라인에만 언급된 내용은 포함하지 마세요.
+            6. 분석 가이드라인은 변경 맥락 파악을 위한 참고용입니다. PR은 실제 diff에 반영된 변경 사항만 기술하고, 가이드라인에만 언급된 내용은 포함하지 마세요.${if (issueNumber != null) "\n            7. CONTRIBUTING.md나 기존 PR 예시에 이슈를 close하는 방식이 명시되어 있으면 그 방식을 따르고, 없으면 본문 마지막에 `Closes #$issueNumber`를 추가하세요." else ""}
 
             반드시 아래 JSON 형식으로만 응답하세요.
             {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftPromptBuilder.kt
@@ -126,7 +126,8 @@ class PrDraftPromptBuilder {
             5. 테스트 방법 섹션은 개발자가 직접 작성할 수 있도록 아래와 같이 placeholder로 남겨두세요.
                ## 테스트 방법
                <!-- 직접 작성 필요 -->
-            6. 분석 가이드라인은 변경 맥락 파악을 위한 참고용입니다. PR은 실제 diff에 반영된 변경 사항만 기술하고, 가이드라인에만 언급된 내용은 포함하지 마세요.${if (issueNumber != null) "\n            7. CONTRIBUTING.md나 기존 PR 예시에 이슈를 close하는 방식이 명시되어 있으면 그 방식을 따르고, 없으면 본문 마지막에 `Closes #$issueNumber`를 추가하세요." else ""}
+            6. 분석 가이드라인은 변경 맥락 파악을 위한 참고용입니다. PR은 실제 diff에 반영된 변경 사항만 기술하고, 가이드라인에만 언급된 내용은 포함하지 마세요.
+            ${if (issueNumber != null) "7. CONTRIBUTING.md나 기존 PR 예시에 이슈를 close하는 방식이 명시되어 있으면 그 방식을 따르고, 없으면 본문 마지막에 `Closes #$issueNumber`를 추가하세요." else ""}
 
             반드시 아래 JSON 형식으로만 응답하세요.
             {

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -84,7 +84,7 @@ class PrDraftServiceImpl(
         val guideline = issue?.id?.let { analysisResultRepository.findByIssueId(it)?.guideline }
 
         // prompt 작성
-        val prompt = prDraftPromptBuilder.build(diffContent, contributing, prs, issue?.title, issue?.content, guideline)
+        val prompt = prDraftPromptBuilder.build(diffContent, contributing, prs, issue?.title, issue?.content, guideline, issue?.issueNumber)
 
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)

--- a/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
+++ b/omos/src/main/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImpl.kt
@@ -78,13 +78,14 @@ class PrDraftServiceImpl(
 
         // prompt에게 줄 pr 형식 정보
         val contributing = gitHubClient.fetchContributing(request.upstreamRepo)
-        val prs = if (contributing == null) gitHubClient.fetchMergedPrs(request.upstreamRepo) else emptyList()
+        val prTemplate = gitHubClient.fetchPrTemplate(request.upstreamRepo)
+        val prs = if (contributing == null && prTemplate == null) gitHubClient.fetchMergedPrs(request.upstreamRepo) else emptyList()
 
         // 이슈에 대한 분석 가이드라인 조회 (없으면 null)
         val guideline = issue?.id?.let { analysisResultRepository.findByIssueId(it)?.guideline }
 
         // prompt 작성
-        val prompt = prDraftPromptBuilder.build(diffContent, contributing, prs, issue?.title, issue?.content, guideline, issue?.issueNumber)
+        val prompt = prDraftPromptBuilder.build(diffContent, contributing, prs, issue?.title, issue?.content, guideline, issue?.issueNumber, prTemplate)
 
         // AI 호출
         val aiResult = aiClient.generatePrDraft(prompt)

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -237,6 +237,52 @@ class PrDraftPromptEvalTest {
     }
 
     /**
+     * PR 템플릿이 프롬프트에 올바르게 포함되는지 확인합니다.
+     * AI 호출 없이 프롬프트 문자열만 검증하므로 빠르게 실행됩니다.
+     */
+    @Test
+    fun `PR 템플릿이 프롬프트에 포함되는지 확인`() {
+        val prompt = promptBuilder.build(
+            diffContent = "--- a/Test.kt\n+++ b/Test.kt\n@@ -1 +1 @@\n-old\n+new",
+            contributing = null,
+            prs = emptyList(),
+            prTemplate = SAMPLE_PR_TEMPLATE
+        )
+        println(prompt)
+        assert(prompt.contains("[PR 템플릿]")) { "[PR 템플릿] 섹션이 프롬프트에 없습니다" }
+        assert(prompt.contains("- [ ]")) { "체크박스가 프롬프트에 없습니다" }
+        assert(!prompt.contains("[기본 템플릿]")) { "prTemplate이 있는데 [기본 템플릿]이 포함되었습니다" }
+        println("프롬프트 검증 통과")
+    }
+
+    /**
+     * PR 템플릿 컨텍스트로 샘플 1을 평가합니다.
+     * prTemplate이 있을 때 AI가 해당 구조를 따르는지 확인합니다.
+     */
+    @Test
+    fun `PR 템플릿 컨텍스트로 프롬프트 평가`() {
+        val sample = EVAL_SAMPLES[0]
+        try {
+            val prompt = promptBuilder.build(
+                diffContent = sample.diff,
+                contributing = null,
+                prs = emptyList(),
+                issueTitle = sample.issueTitle,
+                issueContent = sample.issueContent,
+                issueGuideline = sample.issueGuideline,
+                issueNumber = sample.issueNumber,
+                prTemplate = SAMPLE_PR_TEMPLATE
+            )
+            val result = aiClient.generatePrDraft(prompt)
+            println("제목: ${result.title}")
+            println("본문 미리보기: ${result.body.take(200)}...")
+        } catch (e: Exception) {
+            println("PR 템플릿 테스트 실패 (건너뜀): ${e.message}")
+        }
+        Thread.sleep(60_000)
+    }
+
+    /**
      * 기존 PR 예시 컨텍스트로 프롬프트를 평가합니다.
      */
     @Test
@@ -284,6 +330,24 @@ class PrDraftPromptEvalTest {
                 }
             }
         }
+
+        val SAMPLE_PR_TEMPLATE = """
+            - [ ] I have read and followed the Contributing docs.
+            - [ ] This PR has content that I did not fully write myself.
+              - [ ] I used AI and I have read and followed the Generative AI Contribution Policy.
+            - [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
+
+            ---
+
+            ## Summary
+
+            ## Changes
+
+            ## How to Test
+
+            ## Related Issues
+            close #
+        """.trimIndent()
 
         val SAMPLE_CONTRIBUTING = """
             # Contributing Guide

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -37,7 +37,7 @@ import java.io.File
  * @author 5h6vm
  * @since 2026-04-30
  */
-@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
+//@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
 @SpringBootTest
 @ActiveProfiles("test")
 class PrDraftPromptEvalTest {

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -64,7 +64,8 @@ class PrDraftPromptEvalTest {
                     prs = emptyList(),
                     issueTitle = sample.issueTitle,
                     issueContent = sample.issueContent,
-                    issueGuideline = sample.issueGuideline
+                    issueGuideline = sample.issueGuideline,
+                    issueNumber = sample.issueNumber
                 )
                 val result = aiClient.generatePrDraft(prompt)
                 println("제목: ${result.title}")
@@ -95,7 +96,8 @@ class PrDraftPromptEvalTest {
                     prs = emptyList(),
                     issueTitle = sample.issueTitle,
                     issueContent = sample.issueContent,
-                    issueGuideline = sample.issueGuideline
+                    issueGuideline = sample.issueGuideline,
+                    issueNumber = sample.issueNumber
                 )
 
                 val result = aiClient.generatePrDraft(prompt)
@@ -131,7 +133,8 @@ class PrDraftPromptEvalTest {
                     prs = emptyList(),
                     issueTitle = sample.issueTitle,
                     issueContent = sample.issueContent,
-                    issueGuideline = sample.issueGuideline
+                    issueGuideline = sample.issueGuideline,
+                    issueNumber = sample.issueNumber
                 )
                 val result = aiClient.generatePrDraft(prompt)
                 println("제목: ${result.title}")
@@ -162,7 +165,8 @@ class PrDraftPromptEvalTest {
                     prs = emptyList(),
                     issueTitle = sample.issueTitle,
                     issueContent = sample.issueContent,
-                    issueGuideline = sample.issueGuideline
+                    issueGuideline = sample.issueGuideline,
+                    issueNumber = sample.issueNumber
                 )
                 val result = aiClient.generatePrDraft(prompt)
                 println("제목: ${result.title}")
@@ -217,7 +221,8 @@ class PrDraftPromptEvalTest {
                     prs = emptyList(),
                     issueTitle = sample.issueTitle,
                     issueContent = sample.issueContent,
-                    issueGuideline = sample.issueGuideline
+                    issueGuideline = sample.issueGuideline,
+                    issueNumber = sample.issueNumber
                 )
                 val result = aiClient.generatePrDraft(prompt)
                 println("제목: ${result.title}")
@@ -409,7 +414,8 @@ class PrDraftPromptEvalTest {
             val diff: String,
             val issueTitle: String? = null,
             val issueContent: String? = null,
-            val issueGuideline: String? = null
+            val issueGuideline: String? = null,
+            val issueNumber: Long? = null
         )
 
         val EVAL_SAMPLES = listOf(
@@ -422,6 +428,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "getUserProfile() 호출 시 NullPointerException 발생",
                 issueContent = "name 또는 email이 null인 사용자 조회 시 UserProfileRes 생성 단계에서 NPE 발생. null 안전 처리 및 예외 메시지 개선 필요.",
                 issueGuideline = "UserService.getUserProfile()에서 User.name·User.email이 nullable임에도 직접 접근해 UserProfileRes 생성 시 NPE가 발생함. orElseThrow 예외를 RuntimeException 대신 도메인 예외(UserNotFoundException)로 교체하고, 반환 시 엘비스 연산자(?:)로 null 기본값을 처리할 것. UserProfileRes 생성자 파라미터 타입 변경 여부도 함께 확인 필요.",
+                issueNumber = 42L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/UserService.kt b/src/main/kotlin/com/example/service/UserService.kt
                     index a1b2c3d..e4f5g6h 100644
@@ -448,6 +455,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "게시글 목록 API 데이터 증가 시 응답 속도 저하",
                 issueContent = "게시글 수가 늘어나면서 /api/posts 응답 시간이 점점 길어지고 있음. page, size 파라미터를 받아 페이지 단위로 반환하도록 수정 요청.",
                 issueGuideline = "PostController.getPosts()가 전체 목록을 List로 반환해 데이터 증가 시 메모리 과부하가 발생할 수 있음. 컨트롤러에 @RequestParam으로 page·size를 받아 PageRequest를 생성하고, PostService와 PostRepository의 반환 타입을 Page<PostRes>로 변경해야 함. 응답 타입 변경으로 API 클라이언트의 totalElements 처리 로직도 함께 수정 필요.",
+                issueNumber = 87L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/controller/PostController.kt b/src/main/kotlin/com/example/controller/PostController.kt
                     index b2c3d4e..f5g6h7i 100644
@@ -481,6 +489,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "OrderService 주문 조회 + 권한 검증 코드 중복",
                 issueContent = "cancelOrder, getOrderDetail 두 메서드에서 동일한 주문 조회 및 소유자 확인 로직이 반복됨. 공통 private 메서드로 추출하여 중복 제거 필요.",
                 issueGuideline = "OrderService.cancelOrder()와 getOrderDetail()에서 주문 조회(findById + orElseThrow) 및 소유권 검증(order.userId != userId) 로직이 중복됨. 해당 공통 로직을 private 메서드로 추출하고 두 메서드에서 호출하도록 변경할 것. 추출된 메서드는 검증 실패 시 ForbiddenException을 던지고 Order를 반환하는 형태로 작성.",
+                issueNumber = 156L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/OrderService.kt b/src/main/kotlin/com/example/service/OrderService.kt
                     index c3d4e5f..g6h7i8j 100644
@@ -520,6 +529,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "레포지토리 정보 반복 조회 시 DB 부하",
                 issueContent = "대시보드 렌더링 시 동일한 레포지토리 정보를 여러 번 조회하는데 매번 DB 쿼리가 발생함. 캐싱 레이어 적용으로 부하 감소 필요.",
                 issueGuideline = "RepoService.getRepoInfo()가 매 호출마다 DB를 조회하고 있음. @Cacheable(value=[\"repoInfo\"], key=\"#repoId\")를 적용해 첫 조회 결과를 캐시하고, 레포 정보 변경 시 @CacheEvict로 무효화하는 메서드를 추가할 것. 설정 클래스에 @EnableCaching이 없으면 함께 추가 필요.",
+                issueNumber = 203L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/RepoService.kt b/src/main/kotlin/com/example/service/RepoService.kt
                     index d4e5f6g..h7i8j9k 100644
@@ -552,6 +562,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "댓글 생성 API 입력값 검증 없음",
                 issueContent = "현재 댓글 내용에 빈 문자열이나 500자를 초과하는 텍스트도 저장 가능함. Jakarta Validation(@NotBlank, @Size)을 적용하고 컨트롤러에 @Valid 추가 필요.",
                 issueGuideline = "CreateCommentReq의 content 필드에 @field:NotBlank와 @field:Size(max=500), postId에 @field:Positive를 추가하고 CommentController.createComment()의 @RequestBody 앞에 @Valid를 붙여야 함. 유효성 검증 실패 시 400 응답을 반환하는 GlobalExceptionHandler의 MethodArgumentNotValidException 핸들러가 있는지도 확인 필요.",
+                issueNumber = 78L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/dto/CreateCommentReq.kt b/src/main/kotlin/com/example/dto/CreateCommentReq.kt
                     index e5f6g7h..i8j9k0l 100644
@@ -590,6 +601,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "사용자 미존재 에러 메시지 영문으로 노출됨",
                 issueContent = "USER_NOT_FOUND 에러 발생 시 클라이언트에 'User not found' 영문 메시지가 그대로 노출됨. 한국어로 변경 요청.",
                 issueGuideline = "ErrorCode enum의 USER_NOT_FOUND 값에 설정된 message 파라미터 'User not found'를 한국어로 변경하면 됨. 다른 영문 메시지 항목도 함께 확인하여 일관성을 맞출 것.",
+                issueNumber = 34L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/exception/ErrorCode.kt b/src/main/kotlin/com/example/exception/ErrorCode.kt
                     index a1b2c3d..e4f5g6h 100644
@@ -610,6 +622,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "액세스 토큰 만료 시간이 짧아 사용 중 자동 로그아웃 발생",
                 issueContent = "현재 액세스 토큰 TTL이 1시간으로 설정되어 있어 장시간 사용 중 세션이 끊기는 불편이 있음. 24시간으로 연장 요청.",
                 issueGuideline = "JwtProperties의 accessExpirationMs 기본값 3_600_000(1시간)을 86_400_000(24시간)으로 변경하면 됨. 보안 정책상 만료 시간 연장의 적절성을 검토하고, 필요 시 리프레시 토큰 로직과의 균형도 확인할 것.",
+                issueNumber = 112L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/config/JwtProperties.kt b/src/main/kotlin/com/example/config/JwtProperties.kt
                     index b2c3d4e..f5g6h7i 100644
@@ -634,6 +647,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "알림 기능 구현 — 읽지 않은 알림 조회 및 읽음 처리",
                 issueContent = "사용자에게 읽지 않은 알림 목록 조회(GET /notifications/unread), 전체 읽음 처리(PATCH /notifications/read-all), 단건 읽음 처리(PATCH /notifications/{id}/read) API가 필요함. Notification entity, service, controller 신규 구현.",
                 issueGuideline = "Notification entity는 User와 ManyToOne(LAZY), type은 Enum(STRING), isRead 기본값 false로 설계할 것. NotificationService에 읽지 않은 알림 조회(@Transactional(readOnly=true)), 전체 읽음 벌크 처리, 단건 읽음(소유권 검증 후 markAsRead 호출) 메서드를 구현. NotificationController에서 @AuthenticationPrincipal로 userId를 추출해 서비스에 위임하는 방식으로 작성.",
+                issueNumber = 245L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/domain/notification/Notification.kt b/src/main/kotlin/com/example/domain/notification/Notification.kt
                     new file mode 100644
@@ -737,6 +751,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "게시글 댓글 CRUD 기능 구현",
                 issueContent = "게시글에 댓글 작성(POST /comments), 게시글별 댓글 목록 조회(GET /comments/post/{postId}) 기능 필요. Comment entity, DTO, Repository, Service, Controller 전체 신규 구현.",
                 issueGuideline = "Comment entity는 Post·User와 각각 ManyToOne(LAZY), content는 @Column(TEXT)로 설계. CommentService에 댓글 생성(Post·User 조회 후 Comment 저장)과 게시글별 목록 조회(createdAt 내림차순) 메서드를 구현. CommentController는 @AuthenticationPrincipal로 작성자 userId를 받아 서비스에 전달하고, 조회 엔드포인트는 /post/{postId} 하위로 구성.",
+                issueNumber = 389L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/domain/comment/Comment.kt b/src/main/kotlin/com/example/domain/comment/Comment.kt
                     new file mode 100644
@@ -852,6 +867,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "이슈 목록을 최근 활동 순으로 정렬 변경 요청",
                 issueContent = "현재 이슈 목록이 생성일(createdAt) 기준으로 정렬되는데, 최근에 댓글이 달리거나 수정된 이슈가 위에 보여야 한다는 피드백이 있음. updatedAt 기준으로 변경 요청.",
                 issueGuideline = "IssueService.getIssues()의 PageRequest 생성 시 Sort.by(\"createdAt\")를 Sort.by(\"updatedAt\")으로 변경하면 됨. issues 테이블의 updated_at 컬럼에 인덱스가 존재하는지 확인하고, 없으면 마이그레이션으로 추가하는 것을 권장.",
+                issueNumber = 67L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/IssueService.kt b/src/main/kotlin/com/example/service/IssueService.kt
                     index a1b2c3d..e4f5g6h 100644
@@ -873,6 +889,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "결제 실패 시 감사 로그도 함께 롤백되어 감사 추적 불가",
                 issueContent = "결제 처리 트랜잭션이 롤백될 때 같은 트랜잭션에 묶인 감사 로그도 삭제됨. 감사 로그는 결제 성공/실패 여부와 무관하게 항상 커밋되어야 함. REQUIRES_NEW 전파 전략 적용 필요.",
                 issueGuideline = "PaymentService.recordAuditLog()의 @Transactional을 @Transactional(propagation = Propagation.REQUIRES_NEW)로 변경해 독립 트랜잭션에서 항상 커밋되도록 할 것. REQUIRES_NEW는 새 커넥션을 사용하므로 커넥션 풀 크기가 충분한지 확인하고, 부모 트랜잭션이 락을 보유한 경우 데드락 가능성도 검토 필요.",
+                issueNumber = 134L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/PaymentService.kt b/src/main/kotlin/com/example/service/PaymentService.kt
                     index b2c3d4e..f5g6h7i 100644
@@ -896,6 +913,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "파일 업로드 5MB 제한으로 고화질 이미지 업로드 불가",
                 issueContent = "현재 파일 업로드 최대 크기가 5MB로 제한되어 있어 고화질 이미지(보통 5~10MB)를 업로드할 수 없음. 서비스 제한, Spring multipart 설정, DTO 응답 필드를 함께 10MB로 상향 요청.",
                 issueGuideline = "세 곳을 일관되게 수정해야 함. FileService.upload()의 하드코딩된 5MB 체크를 10MB로 변경하고, application.yml에 spring.servlet.multipart.max-file-size=10MB·max-request-size=20MB를 추가. 클라이언트가 업로드 파일 크기를 확인할 수 있도록 FileUploadRes DTO에 sizeBytes(Long) 필드도 추가할 것.",
+                issueNumber = 178L,
                 diff = """
                     diff --git a/src/main/resources/application.yml b/src/main/resources/application.yml
                     index a1b2c3d..e4f5g6h 100644
@@ -941,6 +959,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "UserService 단위 테스트 누락",
                 issueContent = "getUserProfile 메서드에 대한 단위 테스트가 없음. 정상 조회 케이스와 미존재 사용자 케이스에 대한 테스트 클래스 추가 필요.",
                 issueGuideline = "MockK로 UserRepository를 mock하고 UserServiceTest 클래스를 신규 작성. 정상 조회(존재하는 userId → UserProfileRes 반환 검증)와 예외 케이스(존재하지 않는 userId → UserNotFoundException 발생 검증) 두 시나리오를 @Nested 클래스 구조로 작성할 것.",
+                issueNumber = 91L,
                 diff = """
                     diff --git a/src/test/kotlin/com/example/service/UserServiceTest.kt b/src/test/kotlin/com/example/service/UserServiceTest.kt
                     new file mode 100644
@@ -993,6 +1012,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "Prometheus/Grafana 연동을 위한 메트릭 수집 설정 필요",
                 issueContent = "운영 모니터링 대시보드 구축을 위해 Spring Actuator와 Micrometer Prometheus 의존성 추가 필요. build.gradle.kts에 의존성만 추가하면 됨.",
                 issueGuideline = "build.gradle.kts의 dependencies 블록에 spring-boot-starter-actuator와 micrometer-registry-prometheus를 추가할 것. Prometheus 스크래핑 엔드포인트 노출을 위해 application.yml에 management.endpoints.web.exposure.include=prometheus 설정도 함께 추가 필요.",
+                issueNumber = 223L,
                 diff = """
                     diff --git a/build.gradle.kts b/build.gradle.kts
                     index a1b2c3d..e4f5g6h 100644
@@ -1016,6 +1036,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "v2 전환 완료 후 레거시 /legacy 엔드포인트 제거",
                 issueContent = "v2 API 전환이 완료되었고 /api/users/legacy/* 엔드포인트를 사용하는 클라이언트가 없음을 확인. @Deprecated 엔드포인트 및 관련 서비스 메서드 제거 요청.",
                 issueGuideline = "UserController의 getLegacyProfile(), getLegacyAvatar() 엔드포인트와 UserService의 getLegacyProfile(), getLegacyAvatarUrl() 메서드를 제거하면 됨. 관련 LegacyUserProfileRes DTO 클래스도 사용처가 없으면 함께 삭제하고, 해당 엔드포인트를 사용하는 클라이언트가 없음을 최종 확인 후 진행할 것.",
+                issueNumber = 301L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/controller/UserController.kt b/src/main/kotlin/com/example/controller/UserController.kt
                     index b2c3d4e..f5g6h7i 100644
@@ -1056,6 +1077,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "PostService ktlint 포맷팅 위반 수정",
                 issueContent = "CI ktlint 검사에서 PostService 파일에 공백 및 포맷팅 위반이 감지됨. 로직 변경 없이 Kotlin 코딩 컨벤션에 맞게 포맷팅만 정리.",
                 issueGuideline = "PostService의 함수 선언부 콜론 앞뒤 공백, 중괄호 앞 공백, 람다 중괄호 내부 공백을 Kotlin 코딩 컨벤션에 맞게 수정할 것. 로직 변경 없이 포맷팅만 정리하며, ./gradlew ktlintFormat 명령으로 자동 교정 후 변경 내역을 확인하는 것을 권장.",
+                issueNumber = 45L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/PostService.kt b/src/main/kotlin/com/example/service/PostService.kt
                     index a1b2c3d..e4f5g6h 100644
@@ -1089,6 +1111,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "User 테이블에 프로필 이미지 URL 컬럼 추가",
                 issueContent = "프로필 이미지 기능 구현을 위해 users 테이블에 profile_image_url, profile_image_updated_at 컬럼이 필요함. Flyway 마이그레이션 스크립트로 컬럼 추가 및 조회 성능을 위한 인덱스 생성.",
                 issueGuideline = "Flyway 마이그레이션 파일(V5__...)을 신규 작성해 users 테이블에 profile_image_url(VARCHAR 500, NULL 허용)·profile_image_updated_at(DATETIME, NULL 허용) 컬럼을 ALTER TABLE로 추가할 것. profile_image_updated_at 기준 조회 성능을 위해 CREATE INDEX도 같은 파일에 포함. 기존 User entity에 해당 필드도 함께 추가 필요.",
+                issueNumber = 267L,
                 diff = """
                     diff --git a/src/main/resources/db/migration/V5__add_profile_image_to_user.sql b/src/main/resources/db/migration/V5__add_profile_image_to_user.sql
                     new file mode 100644
@@ -1109,6 +1132,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "로그인·사용자 삭제 이벤트 로그 부재로 운영 중 디버깅 어려움",
                 issueContent = "운영 환경에서 비정상 로그인 시도나 사용자 삭제 이슈 발생 시 추적이 불가능함. AuthService와 UserService 주요 메서드에 구조화 로그(SLF4J) 추가 필요.",
                 issueGuideline = "AuthService와 UserService에 LoggerFactory.getLogger(javaClass)로 SLF4J 로거를 추가하고, 주요 이벤트(로그인 시도·성공, 사용자 삭제 요청·완료)에 구조화 로그를 남길 것. 로그 레벨은 시도/요청은 info, 삭제처럼 위험도 높은 작업은 warn으로 구분하고, 비밀번호·토큰 등 민감 정보가 로그에 포함되지 않도록 주의.",
+                issueNumber = 334L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/AuthService.kt b/src/main/kotlin/com/example/service/AuthService.kt
                     index a1b2c3d..e4f5g6h 100644
@@ -1155,6 +1179,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "RuntimeException 직접 사용으로 에러 핸들러에서 도메인 예외 구분 불가",
                 issueContent = "현재 서비스 전반에서 RuntimeException을 직접 throw하고 있어 GlobalExceptionHandler에서 도메인별 에러를 분기할 수 없음. UserNotFoundException, PostNotFoundException, ForbiddenException 등 커스텀 예외 클래스 도입 요청.",
                 issueGuideline = "exception 패키지에 UserNotFoundException(id: Long), PostNotFoundException(id: Long), ForbiddenException 커스텀 예외 클래스를 신규 생성할 것. 이후 서비스 코드에서 RuntimeException을 직접 throw하는 부분을 해당 도메인 예외로 교체하고, GlobalExceptionHandler에 각 예외 타입별 @ExceptionHandler 메서드도 추가 필요.",
+                issueNumber = 119L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/exception/CustomExceptions.kt b/src/main/kotlin/com/example/exception/CustomExceptions.kt
                     new file mode 100644
@@ -1193,6 +1218,7 @@ class PrDraftPromptEvalTest {
                 issueTitle = "NotificationService가 MailService 구현체에 직접 의존해 테스트 및 교체 어려움",
                 issueContent = "NotificationService가 MailService 구현체를 직접 주입받아 단위 테스트 시 mock 처리가 번거롭고 구현체 교체 시 서비스 코드를 수정해야 함. MailSender 인터페이스를 분리하고 SmtpMailSender 구현체를 추가하는 방식으로 의존성 역전 적용 요청.",
                 issueGuideline = "MailSender 인터페이스를 신규 생성하고 send(to, subject, body) 메서드를 정의할 것. SmtpMailSender가 MailSender를 구현하도록 작성하고 JavaMailSender를 주입받아 MIME 메시지를 생성·발송. NotificationService의 생성자 파라미터를 MailService → MailSender로 교체하고 sendMail() 호출을 send()로 변경. JavaMailSender 스프링 빈 설정이 존재하는지 확인 필요.",
+                issueNumber = 289L,
                 diff = """
                     diff --git a/src/main/kotlin/com/example/service/MailSender.kt b/src/main/kotlin/com/example/service/MailSender.kt
                     new file mode 100644

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/ai/PrDraftPromptEvalTest.kt
@@ -37,7 +37,7 @@ import java.io.File
  * @author 5h6vm
  * @since 2026-04-30
  */
-//@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
+@Disabled("수동 프롬프트 평가 전용 — 실행 시 @Disabled 제거")
 @SpringBootTest
 @ActiveProfiles("test")
 class PrDraftPromptEvalTest {

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -68,7 +68,7 @@ class PrDraftServiceImplTest {
             given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
             given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn("contributing content")
-            given(prDraftPromptBuilder.build(diffContent, "contributing content", emptyList(), "test issue", null, null)).willReturn("prompt")
+            given(prDraftPromptBuilder.build(diffContent, "contributing content", emptyList(), "test issue", null, null, 1L)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("feat: title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft
@@ -92,7 +92,7 @@ class PrDraftServiceImplTest {
             given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn(null)
             given(gitHubClient.fetchMergedPrs("owner/repo")).willReturn(prs)
-            given(prDraftPromptBuilder.build(diffContent, null, prs, "test issue", null, null)).willReturn("prompt")
+            given(prDraftPromptBuilder.build(diffContent, null, prs, "test issue", null, null, 1L)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft

--- a/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
+++ b/omos/src/test/kotlin/com/back/omos/domain/prdraft/service/PrDraftServiceImplTest.kt
@@ -68,7 +68,8 @@ class PrDraftServiceImplTest {
             given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
             given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn("contributing content")
-            given(prDraftPromptBuilder.build(diffContent, "contributing content", emptyList(), "test issue", null, null, 1L)).willReturn("prompt")
+            given(gitHubClient.fetchPrTemplate("owner/repo")).willReturn(null)
+            given(prDraftPromptBuilder.build(diffContent, "contributing content", emptyList(), "test issue", null, null, 1L, null)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("feat: title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft
@@ -85,14 +86,35 @@ class PrDraftServiceImplTest {
         }
 
         @Test
+        fun `prTemplate 있을 때 merged PR 목록을 가져오지 않고 AI 호출 후 결과를 저장한다`() {
+            given(userRepository.findByGithubId(githubId)).willReturn(Optional.of(user))
+            given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
+            given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
+            given(gitHubClient.fetchContributing("owner/repo")).willReturn(null)
+            given(gitHubClient.fetchPrTemplate("owner/repo")).willReturn("## Summary\n- [ ] checkbox")
+            given(prDraftPromptBuilder.build(diffContent, null, emptyList(), "test issue", null, null, 1L, "## Summary\n- [ ] checkbox")).willReturn("prompt")
+            given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("feat: title", "body"))
+            given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
+                val prDraft = it.arguments[0] as PrDraft
+                ReflectionTestUtils.setField(prDraft, "id", 1L)
+                prDraft
+            }
+
+            service.create(githubId, req)
+
+            verify(gitHubClient, org.mockito.BDDMockito.never()).fetchMergedPrs(any())
+        }
+
+        @Test
         fun `contributing 없을 때 기존 PR 목록을 가져와 프롬프트를 빌드한다`() {
             val prs = listOf(GitHubPrRes("pr title", "pr body", "2026-01-01"))
             given(userRepository.findByGithubId(githubId)).willReturn(Optional.of(user))
             given(issueRepository.findByRepoFullNameAndIssueNumber("owner/repo", 1L)).willReturn(issue)
             given(gitHubClient.fetchDiff("owner/repo", "main", githubId, "fix/issue-123")).willReturn(diffContent)
             given(gitHubClient.fetchContributing("owner/repo")).willReturn(null)
+            given(gitHubClient.fetchPrTemplate("owner/repo")).willReturn(null)
             given(gitHubClient.fetchMergedPrs("owner/repo")).willReturn(prs)
-            given(prDraftPromptBuilder.build(diffContent, null, prs, "test issue", null, null, 1L)).willReturn("prompt")
+            given(prDraftPromptBuilder.build(diffContent, null, prs, "test issue", null, null, 1L, null)).willReturn("prompt")
             given(aiClient.generatePrDraft("prompt")).willReturn(AiPrResult("title", "body"))
             given(prDraftRepository.save(any(PrDraft::class.java))).willAnswer {
                 val prDraft = it.arguments[0] as PrDraft


### PR DESCRIPTION
<!--
[#ISSUE_NUMBER][ISSUE_TYPE] ISSUE_TITLE
-->

## 📝 요약
PR 초안이 대상 레포지토리의 양식을 따르지 않고, 이슈 close 링크도 누락되는 문제 개선

## 🔗 관련 이슈
- Close #이슈번호

## 🛠️ 주요 변경 사항
- [ ] `GitHubClient`에 `fetchPrTemplate()` 추가: `.github/pull_request_template.md` 등을 탐색해 PR 템플릿을 가져옴
- [ ] PR 템플릿이 있으면 해당 구조(체크박스 포함)를 따르도록 프롬프트 수정
- [ ] 이슈 번호(`issueNumber`)를 프롬프트에 전달해 본문 마지막에 `Closes #번호` 자동 추가
- [ ] `extractJson()` 버그 수정: body 안에 코드 블록(` ```javascript `)이 있을 때 JSON 파싱 실패하던 문제 해결
- [ ] 프롬프트 버전 v7.2로 업데이트

## 🧪 테스트 결과
실제 동작 확인

## 🧐 리뷰어에게
특별히 확인을 요청하거나 고민되는 지점이 있다면 적어주세요.
